### PR TITLE
Add usage tracking to evaluation API

### DIFF
--- a/apps/web/src/app/api/evaluate/route.ts
+++ b/apps/web/src/app/api/evaluate/route.ts
@@ -10,6 +10,7 @@ import {
 } from "@/evaluation/evaluation-service";
 import { tierToValue } from "@/evaluation/tier-utils";
 import { getRunHistoryContext } from "@/evaluation/run-history-context";
+import { logUsage } from "@/lib/usage-logger";
 import { getCharacterStrategy } from "@/evaluation/strategy/character-strategies";
 
 const anthropic = new Anthropic();
@@ -121,6 +122,15 @@ export async function POST(request: Request) {
         system: SYSTEM_PROMPT,
         messages: [{ role: "user", content: mapPromptFull }],
       });
+
+      // Log usage
+      logUsage(supabase, {
+        userId: body.userId ?? null,
+        evalType: "map",
+        model: "claude-haiku-4-5-20251001",
+        inputTokens: message.usage.input_tokens,
+        outputTokens: message.usage.output_tokens,
+      }).catch(console.error);
 
       const textBlock = message.content.find((b) => b.type === "text");
       if (!textBlock || textBlock.type !== "text") {
@@ -262,6 +272,15 @@ ${responseFormat}`;
       messages: [{ role: "user", content: userPrompt }],
     });
 
+    // Log usage
+    logUsage(supabase, {
+      userId: body.userId ?? null,
+      evalType: type,
+      model: "claude-haiku-4-5-20251001",
+      inputTokens: message.usage.input_tokens,
+      outputTokens: message.usage.output_tokens,
+    }).catch(console.error);
+
     const textBlock = message.content.find((b) => b.type === "text");
     if (!textBlock || textBlock.type !== "text") {
       return NextResponse.json(
@@ -343,6 +362,15 @@ Respond as JSON with ONLY the rankings array for these items:
           system: SYSTEM_PROMPT,
           messages: [{ role: "user", content: retryPrompt }],
         });
+
+        // Log retry usage
+        logUsage(supabase, {
+          userId: body.userId ?? null,
+          evalType: `${type}_retry`,
+          model: "claude-haiku-4-5-20251001",
+          inputTokens: retryMsg.usage.input_tokens,
+          outputTokens: retryMsg.usage.output_tokens,
+        }).catch(console.error);
 
         const retryText = retryMsg.content.find((b) => b.type === "text");
         if (retryText && retryText.type === "text") {

--- a/apps/web/src/lib/types/database.types.ts
+++ b/apps/web/src/lib/types/database.types.ts
@@ -528,6 +528,39 @@ export type Database = {
         }
         Relationships: []
       }
+      usage_logs: {
+        Row: {
+          cost_estimate: number | null
+          created_at: string | null
+          eval_type: string
+          id: string
+          input_tokens: number | null
+          model: string
+          output_tokens: number | null
+          user_id: string | null
+        }
+        Insert: {
+          cost_estimate?: number | null
+          created_at?: string | null
+          eval_type: string
+          id?: string
+          input_tokens?: number | null
+          model: string
+          output_tokens?: number | null
+          user_id?: string | null
+        }
+        Update: {
+          cost_estimate?: number | null
+          created_at?: string | null
+          eval_type?: string
+          id?: string
+          input_tokens?: number | null
+          model?: string
+          output_tokens?: number | null
+          user_id?: string | null
+        }
+        Relationships: []
+      }
     }
     Views: {
       evaluation_stats: {

--- a/apps/web/src/lib/usage-logger.ts
+++ b/apps/web/src/lib/usage-logger.ts
@@ -1,0 +1,33 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@/lib/types/database.types";
+
+// Haiku pricing per 1M tokens (as of March 2026)
+const MODEL_PRICING: Record<string, { input: number; output: number }> = {
+  "claude-haiku-4-5-20251001": { input: 0.80, output: 4.00 },
+  "claude-sonnet-4-20250514": { input: 3.00, output: 15.00 },
+};
+
+export async function logUsage(
+  supabase: SupabaseClient<Database>,
+  params: {
+    userId: string | null;
+    evalType: string;
+    model: string;
+    inputTokens: number;
+    outputTokens: number;
+  }
+): Promise<void> {
+  const pricing = MODEL_PRICING[params.model] ?? MODEL_PRICING["claude-haiku-4-5-20251001"];
+  const costEstimate =
+    (params.inputTokens / 1_000_000) * pricing.input +
+    (params.outputTokens / 1_000_000) * pricing.output;
+
+  await supabase.from("usage_logs").insert({
+    user_id: params.userId ?? null,
+    eval_type: params.evalType,
+    model: params.model,
+    input_tokens: params.inputTokens,
+    output_tokens: params.outputTokens,
+    cost_estimate: costEstimate,
+  });
+}

--- a/supabase/migrations/010_usage_logs.sql
+++ b/supabase/migrations/010_usage_logs.sql
@@ -1,0 +1,18 @@
+create table usage_logs (
+  id uuid primary key default gen_random_uuid(),
+  created_at timestamptz default now(),
+  user_id uuid references auth.users(id),
+  eval_type text not null,
+  model text not null,
+  input_tokens int,
+  output_tokens int,
+  cost_estimate float
+);
+
+create index idx_usage_user_date on usage_logs (user_id, created_at);
+create index idx_usage_type on usage_logs (eval_type);
+
+-- Public read for aggregate stats, authenticated write
+alter table usage_logs enable row level security;
+create policy "Public read usage" on usage_logs for select using (true);
+create policy "Authenticated insert usage" on usage_logs for insert with check (auth.uid() = user_id);


### PR DESCRIPTION
## Summary
- Tracks token usage and estimated cost for every Claude API call
- New `usage_logs` table in Supabase with RLS (public read, authenticated write)
- `logUsage()` helper calculates cost from model pricing (Haiku: $0.80/$4.00 per 1M tokens)
- All 3 Claude calls in `/api/evaluate` log usage: map eval, card/shop eval, retry eval

## Test plan
- [ ] Deploy to Vercel, make an evaluation, check `usage_logs` table in Supabase
- [ ] Verify cost_estimate is reasonable (~$0.001 per Haiku call)
- [ ] Verify user_id is populated when authenticated

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)