### PR TITLE
Switch to structured output (tool_use) for evaluations

### DIFF
--- a/apps/web/src/app/api/evaluate/route.ts
+++ b/apps/web/src/app/api/evaluate/route.ts
@@ -7,6 +7,7 @@ import {
   getStatisticalEvaluation,
   logEvaluation,
   parseClaudeCardRewardResponse,
+  parseToolUseInput,
 } from "@/evaluation/evaluation-service";
 import { tierToValue } from "@/evaluation/tier-utils";
 import { getRunHistoryContext } from "@/evaluation/run-history-context";
@@ -291,7 +292,7 @@ Evaluate ALL ${items.length} items. Return EXACTLY ${items.length} rankings in t
       );
     }
 
-    const parsed = toolUse.input as unknown as Parameters<typeof parseClaudeCardRewardResponse>[0];
+    const parsed = parseToolUseInput(toolUse.input);
     const evaluation = parseClaudeCardRewardResponse(parsed);
 
     // Match Claude's returned IDs back to our original items
@@ -363,7 +364,7 @@ Evaluate ALL ${items.length} items. Return EXACTLY ${items.length} rankings in t
 
         const retryToolUse = retryMsg.content.find((b) => b.type === "tool_use");
         if (retryToolUse && retryToolUse.type === "tool_use") {
-          const retryParsed = parseClaudeCardRewardResponse(retryToolUse.input as unknown as Parameters<typeof parseClaudeCardRewardResponse>[0]);
+          const retryParsed = parseClaudeCardRewardResponse(parseToolUseInput(retryToolUse.input));
 
           for (const ranking of retryParsed.rankings) {
             const matchIdx = items.findIndex(

--- a/apps/web/src/evaluation/evaluation-service.ts
+++ b/apps/web/src/evaluation/evaluation-service.ts
@@ -26,6 +26,49 @@ interface ClaudeCardRewardResponse {
   spending_plan?: string | null;
 }
 
+const VALID_TIERS = new Set(["S", "A", "B", "C", "D", "F"]);
+const VALID_RECS = new Set(["strong_pick", "good_pick", "situational", "skip"]);
+
+/**
+ * Safely parse an unknown tool_use input into a ClaudeCardRewardResponse.
+ * Validates structure at runtime instead of casting through unknown.
+ */
+export function parseToolUseInput(input: unknown): ClaudeCardRewardResponse {
+  if (!input || typeof input !== "object") {
+    throw new Error("Tool use input is not an object");
+  }
+
+  const obj = input as Record<string, unknown>;
+  const rawRankings = Array.isArray(obj.rankings) ? obj.rankings : [];
+
+  const rankings: ClaudeCardEvaluation[] = rawRankings.map((r: unknown) => {
+    if (!r || typeof r !== "object") {
+      throw new Error("Ranking entry is not an object");
+    }
+    const entry = r as Record<string, unknown>;
+
+    const tier = String(entry.tier ?? "C");
+    const rec = String(entry.recommendation ?? "situational");
+
+    return {
+      item_id: String(entry.item_id ?? ""),
+      rank: Number(entry.rank ?? 0),
+      tier: (VALID_TIERS.has(tier) ? tier : "C") as TierLetter,
+      synergy_score: Number(entry.synergy_score ?? 50),
+      confidence: Number(entry.confidence ?? 50),
+      recommendation: (VALID_RECS.has(rec) ? rec : "situational") as ClaudeCardEvaluation["recommendation"],
+      reasoning: String(entry.reasoning ?? ""),
+    };
+  });
+
+  return {
+    rankings,
+    skip_recommended: Boolean(obj.skip_recommended ?? false),
+    skip_reasoning: obj.skip_reasoning ? String(obj.skip_reasoning) : null,
+    spending_plan: obj.spending_plan ? String(obj.spending_plan) : null,
+  };
+}
+
 /**
  * Attempt to get a statistical evaluation for an item from the database.
  * Uses tiered lookup: exact → broad → broadest.


### PR DESCRIPTION
## Summary
Replaces freeform JSON text parsing with Anthropic `tool_use` for card and shop evaluations. The tool schema guarantees valid, well-structured JSON — no more parsing failures.

## What this fixes
- Code fence wrapping (`\`\`\`json...\`\`\``)
- Trailing text after JSON objects
- Malformed JSON from token truncation
- Missing required fields (tier, recommendation, etc.)

## How it works
- Defined a `submit_evaluation` tool with a strict JSON schema
- `tool_choice: { type: "tool", name: "submit_evaluation" }` forces Claude to use it
- Response is in `message.content[].input` — already parsed, no `JSON.parse` needed
- Schema enforces: tier enum (S-F), recommendation enum, integer scores
- Retry for missing items also uses tool_use

## Test plan
- [ ] Preview deploy builds
- [ ] Card reward evaluation returns structured data
- [ ] Shop evaluation (14+ items) returns all items
- [ ] No more JSON parse errors in production

Partial fix for #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)