### PR TITLE
User-friendly error handling with retry

### DIFF
--- a/apps/web/src/app/api/evaluate/route.ts
+++ b/apps/web/src/app/api/evaluate/route.ts
@@ -395,11 +395,18 @@ Evaluate ALL ${items.length} items. Return EXACTLY ${items.length} rankings in t
     return NextResponse.json(evaluation);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    const stack = error instanceof Error ? error.stack : undefined;
-    console.error("Evaluation failed:", message, stack);
+    console.error("Evaluation failed:", message);
+
+    // Detect rate limiting from Anthropic
+    const isRateLimit = message.includes("rate") || message.includes("429");
+    const status = isRateLimit ? 429 : 500;
+    const detail = isRateLimit
+      ? "Rate limited — please wait a moment"
+      : "Evaluation service error";
+
     return NextResponse.json(
-      { error: "Evaluation failed", detail: message },
-      { status: 500 }
+      { error: "Evaluation failed", detail },
+      { status }
     );
   }
 }

--- a/apps/web/src/components/eval-error.tsx
+++ b/apps/web/src/components/eval-error.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { cn } from "@/lib/cn";
+
+interface EvalErrorProps {
+  error: string;
+  onRetry?: () => void;
+  className?: string;
+}
+
+const USER_FRIENDLY_MESSAGES: Record<string, string> = {
+  "Evaluation failed: 429": "Rate limited — please wait a moment and try again",
+  "Evaluation failed: 500": "Evaluation service error — retrying may help",
+  "Evaluation failed: 502": "Evaluation service temporarily unavailable",
+  "Evaluation failed: 503": "Evaluation service temporarily unavailable",
+  "Could not build evaluation context": "Not enough game data yet — play through a combat first",
+  "Failed to fetch": "Network error — check your internet connection",
+};
+
+function friendlyMessage(error: string): string {
+  for (const [pattern, message] of Object.entries(USER_FRIENDLY_MESSAGES)) {
+    if (error.includes(pattern)) return message;
+  }
+  return "Evaluation unavailable";
+}
+
+export function EvalError({ error, onRetry, className }: EvalErrorProps) {
+  return (
+    <div
+      className={cn(
+        "rounded-lg border border-zinc-800 bg-zinc-900/50 px-4 py-3 flex items-center justify-between",
+        className
+      )}
+    >
+      <p className="text-sm text-zinc-400">{friendlyMessage(error)}</p>
+      {onRetry && (
+        <button
+          onClick={onRetry}
+          className="shrink-0 rounded bg-zinc-800 px-3 py-1 text-xs text-zinc-300 hover:bg-zinc-700 transition-colors"
+        >
+          Retry
+        </button>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/features/card-pick/card-pick-view.tsx
+++ b/apps/web/src/features/card-pick/card-pick-view.tsx
@@ -6,6 +6,7 @@ import { useCardEvaluation } from "./use-card-evaluation";
 import { CardRating } from "./card-rating";
 import { CardSkeleton } from "@/components/loading-skeleton";
 import { RefineInput } from "@/components/refine-input";
+import { EvalError } from "@/components/eval-error";
 
 interface CardPickViewProps {
   state: CardRewardState;
@@ -16,7 +17,7 @@ interface CardPickViewProps {
 }
 
 export function CardPickView({ state, deckCards, player, runId, exclusive = true }: CardPickViewProps) {
-  const { evaluation, isLoading, error } = useCardEvaluation(state, deckCards, player, runId, exclusive);
+  const { evaluation, isLoading, error, retry } = useCardEvaluation(state, deckCards, player, runId, exclusive);
   const cards = state.card_reward.cards;
 
   return (
@@ -79,9 +80,7 @@ export function CardPickView({ state, deckCards, player, runId, exclusive = true
         )}
       </div>
 
-      {error && (
-        <p className="text-sm text-red-400">{error}</p>
-      )}
+      {error && <EvalError error={error} onRetry={retry} />}
 
       {evaluation && !isLoading && (
         <RefineInput

--- a/apps/web/src/features/card-pick/use-card-evaluation.ts
+++ b/apps/web/src/features/card-pick/use-card-evaluation.ts
@@ -40,6 +40,7 @@ interface UseCardEvaluationResult {
   evaluation: CardRewardEvaluation | null;
   isLoading: boolean;
   error: string | null;
+  retry: () => void;
 }
 
 /**
@@ -120,7 +121,8 @@ export function useCardEvaluation(
       });
 
       if (!res.ok) {
-        throw new Error(`Evaluation failed: ${res.status}`);
+        const body = await res.json().catch(() => null);
+        throw new Error(body?.detail ?? `Evaluation failed: ${res.status}`);
       }
 
       const data: CardRewardEvaluation = await res.json();
@@ -133,10 +135,16 @@ export function useCardEvaluation(
     }
   }, [state, deckCards, player, cards, cardKey, runId, exclusive]);
 
+  const retry = () => {
+    evaluatedKey.current = "";
+    setError(null);
+    setEvaluation(null);
+  };
+
   // Trigger evaluation (not in useEffect — runs during render check)
   if (cardKey !== evaluatedKey.current && !isLoading) {
     evaluate();
   }
 
-  return { evaluation, isLoading, error };
+  return { evaluation, isLoading, error, retry };
 }

--- a/apps/web/src/features/event/event-view.tsx
+++ b/apps/web/src/features/event/event-view.tsx
@@ -9,6 +9,7 @@ import type { TierLetter } from "@/evaluation/tier-utils";
 import { useEventEvaluation } from "./use-event-evaluation";
 import { CardSkeleton } from "@/components/loading-skeleton";
 import { RefineInput } from "@/components/refine-input";
+import { EvalError } from "@/components/eval-error";
 
 const RECOMMENDATION_BORDER: Record<string, string> = {
   strong_pick: "border-emerald-500/40",
@@ -39,7 +40,7 @@ interface EventViewProps {
 }
 
 export function EventView({ state, deckCards, player, runId }: EventViewProps) {
-  const { evaluation, isLoading, error } = useEventEvaluation(
+  const { evaluation, isLoading, error, retry } = useEventEvaluation(
     state,
     deckCards,
     player,
@@ -69,9 +70,7 @@ export function EventView({ state, deckCards, player, runId }: EventViewProps) {
         </p>
       )}
 
-      {error && (
-        <p className="text-sm text-red-400">{error}</p>
-      )}
+      {error && <EvalError error={error} onRetry={retry} />}
 
       {options.length === 0 && (
         <p className="text-sm text-zinc-500">Waiting for selection...</p>

--- a/apps/web/src/features/event/use-event-evaluation.ts
+++ b/apps/web/src/features/event/use-event-evaluation.ts
@@ -36,6 +36,7 @@ interface UseEventEvaluationResult {
   evaluation: CardRewardEvaluation | null;
   isLoading: boolean;
   error: string | null;
+  retry: () => void;
 }
 
 export function useEventEvaluation(
@@ -48,7 +49,7 @@ export function useEventEvaluation(
 
   // Don't evaluate if only one option or no real choices
   if (options.length <= 1) {
-    return { evaluation: null, isLoading: false, error: null };
+    return { evaluation: null, isLoading: false, error: null, retry: () => {} };
   }
 
   const eventKey = `${state.event.event_id}:${options.map((o) => o.index).join(",")}`;
@@ -133,7 +134,8 @@ Use item_id format EVENT_0, EVENT_1, EVENT_2 matching the option numbers (0-inde
       });
 
       if (!res.ok) {
-        throw new Error(`Evaluation failed: ${res.status}`);
+        const body = await res.json().catch(() => null);
+        throw new Error(body?.detail ?? `Evaluation failed: ${res.status}`);
       }
 
       const data = await res.json();
@@ -174,9 +176,15 @@ Use item_id format EVENT_0, EVENT_1, EVENT_2 matching the option numbers (0-inde
     }
   }, [state, deckCards, player, options, eventKey, runId]);
 
+  const retry = () => {
+    evaluatedKey.current = "";
+    setError(null);
+    setEvaluation(null);
+  };
+
   if (eventKey !== evaluatedKey.current && !isLoading) {
     evaluate();
   }
 
-  return { evaluation, isLoading, error };
+  return { evaluation, isLoading, error, retry };
 }

--- a/apps/web/src/features/map/map-view.tsx
+++ b/apps/web/src/features/map/map-view.tsx
@@ -10,6 +10,7 @@ import { useMapEvaluation } from "./use-map-evaluation";
 import { TierBadge } from "@/components/tier-badge";
 import { ConfidenceIndicator } from "@/components/confidence-indicator";
 import { RefineInput } from "@/components/refine-input";
+import { EvalError } from "@/components/eval-error";
 import type { TierLetter } from "@/evaluation/tier-utils";
 
 interface MapViewProps {
@@ -51,7 +52,7 @@ const RECOMMENDATION_BORDER: Record<string, string> = {
 
 export function MapView({ state, player, deckCards }: MapViewProps) {
   const { nodes, current_position, visited, next_options, boss } = state.map;
-  const { evaluation, isLoading, error } = useMapEvaluation(state, deckCards, player);
+  const { evaluation, isLoading, error, retry } = useMapEvaluation(state, deckCards, player);
 
   const maxRow = useMemo(
     () => Math.max(...nodes.map((n) => n.row), boss.row),
@@ -109,9 +110,7 @@ export function MapView({ state, player, deckCards }: MapViewProps) {
         </div>
       )}
 
-      {error && (
-        <p className="text-sm text-red-400">Evaluation error: {error}</p>
-      )}
+      {error && <EvalError error={error} onRetry={retry} />}
 
       {/* Path recommendations */}
       <div className="grid grid-cols-3 gap-3">

--- a/apps/web/src/features/map/use-map-evaluation.ts
+++ b/apps/web/src/features/map/use-map-evaluation.ts
@@ -50,6 +50,7 @@ interface UseMapEvaluationResult {
   evaluation: MapPathEvaluation | null;
   isLoading: boolean;
   error: string | null;
+  retry: () => void;
 }
 
 export function useMapEvaluation(
@@ -224,7 +225,8 @@ Respond as JSON:
       });
 
       if (!res.ok) {
-        throw new Error(`Evaluation failed: ${res.status}`);
+        const body = await res.json().catch(() => null);
+        throw new Error(body?.detail ?? `Evaluation failed: ${res.status}`);
       }
 
       const data = await res.json();
@@ -249,9 +251,15 @@ Respond as JSON:
     }
   }, [state, deckCards, player, options, mapKey]);
 
+  const retry = () => {
+    evaluatedKey.current = "";
+    setError(null);
+    setEvaluation(null);
+  };
+
   if (mapKey !== evaluatedKey.current && !isLoading) {
     evaluate();
   }
 
-  return { evaluation, isLoading, error };
+  return { evaluation, isLoading, error, retry };
 }

--- a/apps/web/src/features/rest-site/rest-site-view.tsx
+++ b/apps/web/src/features/rest-site/rest-site-view.tsx
@@ -10,6 +10,7 @@ import type { TierLetter } from "@/evaluation/tier-utils";
 import { useRestEvaluation } from "./use-rest-evaluation";
 import { CardSkeleton } from "@/components/loading-skeleton";
 import { RefineInput } from "@/components/refine-input";
+import { EvalError } from "@/components/eval-error";
 
 const RECOMMENDATION_BORDER: Record<string, string> = {
   strong_pick: "border-emerald-500/40",
@@ -49,7 +50,7 @@ interface RestSiteViewProps {
 }
 
 export function RestSiteView({ state, deckCards, player, runId }: RestSiteViewProps) {
-  const { evaluation, isLoading, error } = useRestEvaluation(
+  const { evaluation, isLoading, error, retry } = useRestEvaluation(
     state,
     deckCards,
     player,
@@ -87,9 +88,7 @@ export function RestSiteView({ state, deckCards, player, runId }: RestSiteViewPr
         </span>
       </div>
 
-      {error && (
-        <p className="text-sm text-red-400">{error}</p>
-      )}
+      {error && <EvalError error={error} onRetry={retry} />}
 
       {/* Options */}
       <div className="grid grid-cols-2 gap-4">

--- a/apps/web/src/features/rest-site/use-rest-evaluation.ts
+++ b/apps/web/src/features/rest-site/use-rest-evaluation.ts
@@ -36,6 +36,7 @@ interface UseRestEvaluationResult {
   evaluation: CardRewardEvaluation | null;
   isLoading: boolean;
   error: string | null;
+  retry: () => void;
 }
 
 export function useRestEvaluation(
@@ -47,7 +48,7 @@ export function useRestEvaluation(
   const options = state.rest_site.options.filter((o) => o.is_enabled);
 
   if (options.length <= 1) {
-    return { evaluation: null, isLoading: false, error: null };
+    return { evaluation: null, isLoading: false, error: null, retry: () => {} };
   }
 
   const restKey = `rest:${state.run.floor}:${options.map((o) => o.id).join(",")}`;
@@ -144,7 +145,8 @@ The #1 ranked option should be "strong_pick". The other option(s) should be "sit
       });
 
       if (!res.ok) {
-        throw new Error(`Evaluation failed: ${res.status}`);
+        const body = await res.json().catch(() => null);
+        throw new Error(body?.detail ?? `Evaluation failed: ${res.status}`);
       }
 
       const data = await res.json();
@@ -196,9 +198,15 @@ The #1 ranked option should be "strong_pick". The other option(s) should be "sit
     }
   }, [state, deckCards, player, options, restKey, runId]);
 
+  const retry = () => {
+    evaluatedKey.current = "";
+    setError(null);
+    setEvaluation(null);
+  };
+
   if (restKey !== evaluatedKey.current && !isLoading) {
     evaluate();
   }
 
-  return { evaluation, isLoading, error };
+  return { evaluation, isLoading, error, retry };
 }

--- a/apps/web/src/features/shop/shop-view.tsx
+++ b/apps/web/src/features/shop/shop-view.tsx
@@ -11,6 +11,7 @@ import {
 import { ShopItemCard } from "./shop-item-card";
 import { CardSkeleton } from "@/components/loading-skeleton";
 import { RefineInput } from "@/components/refine-input";
+import { EvalError } from "@/components/eval-error";
 
 interface ShopViewProps {
   state: ShopState;
@@ -20,7 +21,7 @@ interface ShopViewProps {
 }
 
 export function ShopView({ state, deckCards, player, runId }: ShopViewProps) {
-  const { evaluation, isLoading, error } = useShopEvaluation(
+  const { evaluation, isLoading, error, retry } = useShopEvaluation(
     state,
     deckCards,
     player,
@@ -73,9 +74,7 @@ export function ShopView({ state, deckCards, player, runId }: ShopViewProps) {
         </div>
       )}
 
-      {error && (
-        <p className="text-sm text-red-400">Evaluation error: {error}</p>
-      )}
+      {error && <EvalError error={error} onRetry={retry} />}
 
       {isLoading && !evaluation ? (
         <div className="grid grid-cols-3 gap-3">

--- a/apps/web/src/features/shop/use-shop-evaluation.ts
+++ b/apps/web/src/features/shop/use-shop-evaluation.ts
@@ -64,6 +64,7 @@ interface UseShopEvaluationResult {
   evaluation: CardRewardEvaluation | null;
   isLoading: boolean;
   error: string | null;
+  retry: () => void;
 }
 
 export function useShopEvaluation(
@@ -135,7 +136,8 @@ export function useShopEvaluation(
       });
 
       if (!res.ok) {
-        throw new Error(`Evaluation failed: ${res.status}`);
+        const body = await res.json().catch(() => null);
+        throw new Error(body?.detail ?? `Evaluation failed: ${res.status}`);
       }
 
       const data: CardRewardEvaluation = await res.json();
@@ -148,11 +150,17 @@ export function useShopEvaluation(
     }
   }, [state, deckCards, player, shopItems, shopKey, runId]);
 
+  const retry = () => {
+    evaluatedKey.current = "";
+    setError(null);
+    setEvaluation(null);
+  };
+
   if (shopKey !== evaluatedKey.current && !isLoading) {
     evaluate();
   }
 
-  return { evaluation, isLoading, error };
+  return { evaluation, isLoading, error, retry };
 }
 
 export { getItemId, getItemName, getItemDescription };


### PR DESCRIPTION
## Summary
- `EvalError` component translates raw errors into user-friendly messages with retry button
- All 5 evaluation hooks expose `retry()` to clear cache and re-trigger
- API route detects Anthropic rate limits, returns proper 429 status
- Error responses include parsed `detail` for better context

## Error message mapping
| Raw error | User sees |
|---|---|
| `Evaluation failed: 429` | Rate limited — please wait a moment and try again |
| `Evaluation failed: 500` | Evaluation service error — retrying may help |
| `Could not build evaluation context` | Not enough game data yet — play through a combat first |
| `Failed to fetch` | Network error — check your internet connection |
| Anything else | Evaluation unavailable |

## Test plan
- [ ] Preview build passes
- [ ] Trigger an eval error (e.g., invalid API key) → shows friendly message + retry
- [ ] Click retry → clears error, re-triggers evaluation

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)