### PR TITLE
fix(eval): drop .int() from eval schemas so Anthropic accepts them

### DIFF
--- a/packages/shared/evaluation/eval-schemas.test.ts
+++ b/packages/shared/evaluation/eval-schemas.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { z } from "zod";
 import {
   bossBriefingSchema,
   buildMapEvalSchema,
@@ -193,6 +194,68 @@ describe("eval-schemas", () => {
           rankings: [validRanking(1), validRanking(2), validRanking(3)],
         }),
       ).toThrow();
+    });
+  });
+
+  // Regression: #48 — `z.number().int()` and `z.int()` both bake
+  // `minimum: -Number.MAX_SAFE_INTEGER, maximum: Number.MAX_SAFE_INTEGER`
+  // into the emitted JSON Schema, and Anthropic's structured-output
+  // endpoint rejects integer types that carry minimum/maximum
+  // ("For 'integer' type, properties maximum, minimum are not supported").
+  // The Phase 4.5 smoke test (route.test.ts) used MockLanguageModelV3 and
+  // never round-tripped through Anthropic's schema validator, so this
+  // class of bug ships silently. Catch it at the schema-definition layer.
+  describe("Anthropic JSON Schema compatibility (regression #48)", () => {
+    function* walk(node: unknown, path: string[] = []): Generator<{ path: string[]; node: Record<string, unknown> }> {
+      if (!node || typeof node !== "object") return;
+      const obj = node as Record<string, unknown>;
+      yield { path, node: obj };
+      for (const [k, v] of Object.entries(obj)) {
+        if (v && typeof v === "object") {
+          yield* walk(v, [...path, k]);
+        }
+      }
+    }
+
+    function assertNoIntegerBounds(jsonSchema: unknown, schemaName: string) {
+      for (const { path, node } of walk(jsonSchema)) {
+        if (node.type === "integer" && ("minimum" in node || "maximum" in node)) {
+          throw new Error(
+            `[${schemaName}] integer schema at ${path.join(".") || "<root>"} carries minimum/maximum, which Anthropic structured-output rejects. ` +
+              `Use plain z.number() instead of z.number().int() or z.int(). Node: ${JSON.stringify(node)}`,
+          );
+        }
+      }
+    }
+
+    const cases: Array<[string, unknown]> = [
+      ["bossBriefingSchema", bossBriefingSchema],
+      ["buildMapEvalSchema(3)", buildMapEvalSchema(3)],
+      ["mapEvalResponseSchema", mapEvalResponseSchema],
+      ["genericEvalSchema", genericEvalSchema],
+      ["simpleEvalSchema", simpleEvalSchema],
+      ["buildCardRewardSchema(items=3, shop=false)", buildCardRewardSchema(
+        [{ name: "Strike" }, { name: "Defend" }, { name: "Bash" }],
+        false,
+      )],
+      ["buildCardRewardSchema(items=3, shop=true)", buildCardRewardSchema(
+        [{ name: "Strike" }, { name: "Defend" }, { name: "Bash" }],
+        true,
+      )],
+    ];
+
+    it.each(cases)("%s emits no integer min/max", (name, schema) => {
+      const json = z.toJSONSchema(schema as z.ZodType);
+      assertNoIntegerBounds(json, name);
+    });
+
+    // Sanity check: the helper actually catches the bad pattern. If this
+    // ever stops failing, the regression assertion above is silently broken.
+    it("helper detects the bug pattern when present (sanity check)", () => {
+      const bad = z.object({ confidence: z.number().int() });
+      expect(() =>
+        assertNoIntegerBounds(z.toJSONSchema(bad), "bad-fixture"),
+      ).toThrow(/integer schema at .* carries minimum\/maximum/);
     });
   });
 });

--- a/packages/shared/evaluation/eval-schemas.ts
+++ b/packages/shared/evaluation/eval-schemas.ts
@@ -10,9 +10,16 @@ import { z } from "zod";
  * Notes:
  * - Field names are snake_case to match what Claude outputs today (zero
  *   behavior change at the wire). camelCase conversion stays in adapters.
- * - `confidence` is `z.number().int()` only — no `.min/max` clamps. Haiku
- *   occasionally returns out-of-range values and the existing code coerces
- *   silently; tightening here would introduce parse failures with no benefit.
+ * - Numeric fields use plain `z.number()` — NOT `z.number().int()` or
+ *   `z.int()`. Both add `minimum: -Number.MAX_SAFE_INTEGER, maximum:
+ *   Number.MAX_SAFE_INTEGER` to the emitted JSON Schema, and Anthropic's
+ *   structured-output endpoint rejects integer types that carry
+ *   minimum/maximum ("For 'integer' type, properties maximum, minimum are
+ *   not supported"). This caused #48. Downstream consumers assign into
+ *   TypeScript `number` (float) anyway, and the comment about Haiku
+ *   returning out-of-range values that the consumer coerces silently
+ *   already implied no real safety from the int constraint. The regression
+ *   guard lives in `eval-schemas.test.ts`.
  * - The `tier` enum mirrors `TierLetter` from `./tier-utils`. Kept inline as
  *   a zod enum (rather than imported) so this module has zero runtime deps
  *   beyond zod.
@@ -48,10 +55,10 @@ export const nodePreferencesSchema = z.object({
 export type NodePreferencesRaw = z.infer<typeof nodePreferencesSchema>;
 
 export const mapEvalRankingSchema = z.object({
-  option_index: z.number().int(),
+  option_index: z.number(),
   node_type: z.string().optional(),
   tier: tierEnum,
-  confidence: z.number().int(),
+  confidence: z.number(),
   recommendation: recommendationEnum.optional(),
   reasoning: z.string(),
 });
@@ -90,10 +97,10 @@ export const mapEvalResponseSchema = z.object({
 
 export const genericEvalRankingSchema = z.object({
   item_id: z.string(),
-  rank: z.number().int().optional(),
+  rank: z.number().optional(),
   tier: tierEnum,
-  synergy_score: z.number().int().optional(),
-  confidence: z.number().int(),
+  synergy_score: z.number().optional(),
+  confidence: z.number(),
   recommendation: recommendationEnum.optional(),
   reasoning: z.string(),
 });
@@ -119,9 +126,9 @@ export type SimpleEvalRaw = z.infer<typeof simpleEvalSchema>;
 // ─── Card reward / shop eval ───
 
 export const cardRewardRankingSchema = z.object({
-  position: z.number().int(),
+  position: z.number(),
   tier: tierEnum,
-  confidence: z.number().int(),
+  confidence: z.number(),
   reasoning: z.string(),
 });
 export type CardRewardRankingRaw = z.infer<typeof cardRewardRankingSchema>;


### PR DESCRIPTION
## Summary
- Root cause: zod v4's `z.number().int()` (and `z.int()`) bakes `minimum: -Number.MAX_SAFE_INTEGER, maximum: Number.MAX_SAFE_INTEGER` into the emitted JSON Schema. Anthropic's structured-output endpoint rejects integer types that carry `minimum`/`maximum` → every eval whose schema had an integer field 500'd at `generateText` after the Phase 3/4 AI-SDK migration.
- Fix: drop `.int()` — replace each `z.number().int()` with `z.number()` in `mapEvalRankingSchema`, `genericEvalRankingSchema`, and `cardRewardRankingSchema`. Downstream consumers assign into TypeScript `number` (float) anyway, so the int constraint added no real runtime safety.
- Regression guard: new test walks `z.toJSONSchema()` output for every exported eval schema and fails if any integer-typed node carries `minimum`/`maximum`, plus a sanity fixture that confirms the helper catches the bad pattern. Phase 4.5's smoke test used `MockLanguageModelV3` and never round-tripped through Anthropic's schema validator, which is why this shipped silently — this regression test closes that gap at the schema-definition layer without needing a live API call.

Closes #48

## Test plan
- [x] Capture a real `event_api_request` body from the desktop dev-logger; POST to the pre-fix local dev server → 500 `"output_config.format.schema: For 'integer' type, properties maximum, minimum are not supported"`.
- [x] Apply fix; POST same body → 200 with a valid `rankings` array + `pick_summary` + `overall_advice`.
- [x] `npm test -w @sts2/web` — 127/127 passing (includes 8 new regression cases via the shared-package include path).
- [x] `npm test -w @sts2/desktop` — 204/204 passing.
- [x] Sanity-check the regression test actually catches the bug: temporarily reverted `eval-schemas.ts` to origin/main, re-ran → 5 regression cases failed with the expected `integer schema at ... carries minimum/maximum` message. Restored fix → all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)