### PR TITLE
feat(desktop): dev mode points at local Next.js dev server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ yarn-error.log*
 .env*
 !.env.example
 !.env.production
+!.env.development
 
 # vercel
 .vercel

--- a/apps/desktop/.env.development
+++ b/apps/desktop/.env.development
@@ -1,0 +1,12 @@
+# Loaded by Vite only when running in dev mode (`npm run tauri dev`).
+# Overrides values in `.env` so dev builds always hit the local Next.js
+# route handlers in `apps/web`. Run `npm run dev -w @sts2/web` in another
+# terminal before launching the desktop app.
+#
+# To point dev at a non-local API (e.g. a Vercel preview), create
+# `.env.development.local` — Vite loads it last and it stays gitignored.
+
+VITE_API_BASE_URL=http://localhost:3000
+VITE_SUPABASE_URL=https://ptitcfnivcofrxjnckdd.supabase.co
+VITE_SUPABASE_ANON_KEY=sb_publishable_cexAfiwLz0lIw_8jWGp5og_cJ991wCV
+VITE_SENTRY_DSN=https://12f87c41bf7be1e26757c68d4089ac8b@o4511051123064832.ingest.us.sentry.io/4511142195953664

--- a/apps/desktop/.env.example
+++ b/apps/desktop/.env.example
@@ -1,3 +1,17 @@
+# Desktop app env vars. Vite loads these with standard mode precedence:
+#   .env.[mode].local  >  .env.[mode]  >  .env.local  >  .env
+#
+# Mode-specific files are committed:
+#   .env.development — points VITE_API_BASE_URL at http://localhost:3000
+#                      so `npm run tauri dev` hits the local Next.js
+#                      route handlers in apps/web. Start the web dev
+#                      server first: `npm run dev -w @sts2/web`.
+#   .env.production  — points at https://sts2-helper.vercel.app
+#
+# For personal overrides (e.g. hitting a Vercel preview from a dev
+# build, pointing at a staging Supabase), create
+# .env.[mode].local — those stay gitignored.
+
 VITE_API_BASE_URL=https://sts2-helper.vercel.app
 VITE_SUPABASE_URL=https://your-project.supabase.co
 VITE_SUPABASE_ANON_KEY=your_anon_key

--- a/apps/desktop/src-tauri/capabilities/default.json
+++ b/apps/desktop/src-tauri/capabilities/default.json
@@ -22,7 +22,8 @@
         { "url": "https://sts2replay.com/**" },
         { "url": "https://api.sts2replay.com/**" },
         { "url": "https://*.supabase.co/**" },
-        { "url": "wss://*.supabase.co/**" }
+        { "url": "wss://*.supabase.co/**" },
+        { "url": "http://localhost:3000/**" }
       ]
     }
   ]

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -24,7 +24,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self' ipc: http://localhost:15526 http://127.0.0.1:15526 https://*.supabase.co wss://*.supabase.co https://sts2-helper.vercel.app https://sts2replay.com https://api.sts2replay.com https://*.ingest.us.sentry.io; img-src 'self' https://*.supabase.co data: blob:; font-src 'self' data:; worker-src 'self' blob:"
+      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self' ipc: http://localhost:3000 http://localhost:15526 http://127.0.0.1:15526 https://*.supabase.co wss://*.supabase.co https://sts2-helper.vercel.app https://sts2replay.com https://api.sts2replay.com https://*.ingest.us.sentry.io; img-src 'self' https://*.supabase.co data: blob:; font-src 'self' data:; worker-src 'self' blob:"
     }
   },
   "plugins": {

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -37,8 +37,14 @@ if (import.meta.env.DEV) {
   });
 }
 
-// Configure shared package for desktop environment
-const API_BASE = import.meta.env.VITE_API_BASE_URL ?? "https://sts2-helper.vercel.app";
+// Configure shared package for desktop environment.
+// Dev mode defaults to the local Next.js dev server so API edits don't
+// require a Vercel deploy — #50. Shipped prod builds fall back to the
+// Vercel URL. Committed `.env.development` / `.env.production` override
+// either default; `.env.[mode].local` beats both for per-machine tweaks.
+const API_BASE =
+  import.meta.env.VITE_API_BASE_URL ??
+  (import.meta.env.DEV ? "http://localhost:3000" : "https://sts2-helper.vercel.app");
 const AUTH_REDIRECT_ORIGIN = "sts2replay://";
 const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL ?? "";
 const SUPABASE_ANON_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY ?? "";


### PR DESCRIPTION
## Summary
- Commit `apps/desktop/.env.development` with `VITE_API_BASE_URL=http://localhost:3000` so `npm run tauri dev` hits the local Next.js route handlers in `apps/web` instead of production. Add the `!.env.development` gitignore exception so the file is tracked (matching the existing `.env.production` convention).
- Harden `apps/desktop/src/main.tsx:41` so the fallback when no env var is set defaults to localhost in DEV and the Vercel URL in prod — keeps the flow working even if the committed env file is deleted.
- Whitelist `http://localhost:3000` in the Tauri HTTP plugin ACL (`capabilities/default.json`) and CSP `connect-src` (`tauri.conf.json`) so `tauriFetch` + any ad-hoc webview fetch can reach the dev origin.
- Update `.env.example` to document the dev/prod split and the `.env.[mode].local` override path for personal tweaks (previews, staging).

Motivates #50 itself: #48 shipped silently because the Phase 4.5 smoke test mocked the AI SDK, and there was no live-API path in dev that would have caught the Anthropic schema rejection. Routing dev → localhost closes that gap — run `npm run dev -w @sts2/web` in one terminal, `npm run tauri dev` in another, and every API edit is exercised before it touches prod.

Closes #50

## Test plan
- [x] `npm test -w @sts2/desktop` — 204/204 passing.
- [x] `tsc --noEmit` in `apps/desktop` — clean.
- [x] Both edited JSON files (`tauri.conf.json`, `capabilities/default.json`) parse cleanly.
- [ ] **Manual smoke** (after merge / local): run `npm run dev -w @sts2/web` → `npm run tauri dev` in another terminal → desktop app issues `POST http://localhost:3000/api/evaluate` (verify via dev-logger network trace or web dev-server terminal output), fire an event eval → 200 with a rankings response from the local route handler.
- [ ] **Prod build sanity** (optional): `npm run build -w @sts2/desktop` → confirm the bundled `main.tsx` still resolves `API_BASE` to the Vercel URL (inspect `dist/assets/*.js` for the literal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)