### PR TITLE
fix(eval): drop .length() from map/card_reward array schemas

### DIFF
--- a/packages/shared/evaluation/eval-schemas.test.ts
+++ b/packages/shared/evaluation/eval-schemas.test.ts
@@ -197,18 +197,32 @@ describe("eval-schemas", () => {
     });
   });
 
-  // Regression: #48 — `z.number().int()` and `z.int()` both bake
-  // `minimum: -Number.MAX_SAFE_INTEGER, maximum: Number.MAX_SAFE_INTEGER`
-  // into the emitted JSON Schema, and Anthropic's structured-output
-  // endpoint rejects integer types that carry minimum/maximum
-  // ("For 'integer' type, properties maximum, minimum are not supported").
-  // The Phase 4.5 smoke test (route.test.ts) used MockLanguageModelV3 and
-  // never round-tripped through Anthropic's schema validator, so this
-  // class of bug ships silently. Catch it at the schema-definition layer.
-  describe("Anthropic JSON Schema compatibility (regression #48)", () => {
-    function* walk(node: unknown, path: string[] = []): Generator<{ path: string[]; node: Record<string, unknown> }> {
+  // Regression: Anthropic's structured-output endpoint rejects several JSON
+  // Schema constraints that zod v4 bakes in by default. Every time we've hit
+  // this it's been a "zod feature I reached for → Anthropic 500 → full
+  // debugging cycle" loop. The walk-and-assert below catches every known
+  // rejection at the schema-definition layer so future schemas trip CI before
+  // touching the real API.
+  //
+  // Known-rejected constraints (expand as new ones are discovered):
+  //   • #48  integer type with `minimum` or `maximum`
+  //           zod: `z.number().int()` / `z.int()`
+  //           Anthropic: "For 'integer' type, properties maximum, minimum
+  //                       are not supported"
+  //   • #52  array type with `minItems` > 1 or `maxItems` > 1
+  //           zod: `z.array(...).length(N)` / `.min(N)` / `.max(N)` where N ≥ 2
+  //           Anthropic: "For 'array' type, 'minItems' values other than 0
+  //                       or 1 are not supported"
+  //           (minItems of 0 or 1 is fine — same for maxItems.)
+  //
+  // The Phase 4.5 smoke test (route.test.ts) uses MockLanguageModelV3 so it
+  // never round-trips through Anthropic's validator. This guard closes that
+  // gap without needing a live API call.
+  describe("Anthropic JSON Schema compatibility (regression #48, #52)", () => {
+    type JsonNode = Record<string, unknown>;
+    function* walk(node: unknown, path: string[] = []): Generator<{ path: string[]; node: JsonNode }> {
       if (!node || typeof node !== "object") return;
-      const obj = node as Record<string, unknown>;
+      const obj = node as JsonNode;
       yield { path, node: obj };
       for (const [k, v] of Object.entries(obj)) {
         if (v && typeof v === "object") {
@@ -217,13 +231,28 @@ describe("eval-schemas", () => {
       }
     }
 
-    function assertNoIntegerBounds(jsonSchema: unknown, schemaName: string) {
+    function assertAnthropicCompatible(jsonSchema: unknown, schemaName: string) {
       for (const { path, node } of walk(jsonSchema)) {
+        const where = path.join(".") || "<root>";
+
+        // #48 — integer min/max
         if (node.type === "integer" && ("minimum" in node || "maximum" in node)) {
           throw new Error(
-            `[${schemaName}] integer schema at ${path.join(".") || "<root>"} carries minimum/maximum, which Anthropic structured-output rejects. ` +
+            `[${schemaName}] integer schema at ${where} carries minimum/maximum, which Anthropic structured-output rejects (#48). ` +
               `Use plain z.number() instead of z.number().int() or z.int(). Node: ${JSON.stringify(node)}`,
           );
+        }
+
+        // #52 — array minItems/maxItems > 1
+        if (node.type === "array") {
+          const minItems = typeof node.minItems === "number" ? node.minItems : undefined;
+          const maxItems = typeof node.maxItems === "number" ? node.maxItems : undefined;
+          if ((minItems !== undefined && minItems > 1) || (maxItems !== undefined && maxItems > 1)) {
+            throw new Error(
+              `[${schemaName}] array schema at ${where} carries minItems/maxItems > 1, which Anthropic structured-output rejects (#52). ` +
+                `Use .refine((arr) => arr.length === N) instead of .length(N)/.min(N)/.max(N). Node: ${JSON.stringify(node)}`,
+            );
+          }
         }
       }
     }
@@ -231,6 +260,7 @@ describe("eval-schemas", () => {
     const cases: Array<[string, unknown]> = [
       ["bossBriefingSchema", bossBriefingSchema],
       ["buildMapEvalSchema(3)", buildMapEvalSchema(3)],
+      ["buildMapEvalSchema(5)", buildMapEvalSchema(5)], // worst case for minItems rejection
       ["mapEvalResponseSchema", mapEvalResponseSchema],
       ["genericEvalSchema", genericEvalSchema],
       ["simpleEvalSchema", simpleEvalSchema],
@@ -244,18 +274,49 @@ describe("eval-schemas", () => {
       )],
     ];
 
-    it.each(cases)("%s emits no integer min/max", (name, schema) => {
+    it.each(cases)("%s is Anthropic-compatible", (name, schema) => {
       const json = z.toJSONSchema(schema as z.ZodType);
-      assertNoIntegerBounds(json, name);
+      assertAnthropicCompatible(json, name);
     });
 
-    // Sanity check: the helper actually catches the bad pattern. If this
-    // ever stops failing, the regression assertion above is silently broken.
-    it("helper detects the bug pattern when present (sanity check)", () => {
-      const bad = z.object({ confidence: z.number().int() });
-      expect(() =>
-        assertNoIntegerBounds(z.toJSONSchema(bad), "bad-fixture"),
-      ).toThrow(/integer schema at .* carries minimum\/maximum/);
+    // Sanity: the helper actually catches each bug class when present. If any
+    // of these ever stops failing, the regression assertion has silently
+    // drifted out of sync with what Anthropic rejects.
+    describe("helper sanity checks", () => {
+      it("catches integer min/max (#48)", () => {
+        const bad = z.object({ confidence: z.number().int() });
+        expect(() =>
+          assertAnthropicCompatible(z.toJSONSchema(bad), "bad-int"),
+        ).toThrow(/integer schema at .* carries minimum\/maximum/);
+      });
+
+      it("catches array .length(N) where N > 1 (#52)", () => {
+        const bad = z.object({ rankings: z.array(z.string()).length(3) });
+        expect(() =>
+          assertAnthropicCompatible(z.toJSONSchema(bad), "bad-length"),
+        ).toThrow(/array schema at .* carries minItems\/maxItems > 1/);
+      });
+
+      it("catches array .min(N) where N > 1 (#52)", () => {
+        const bad = z.object({ rankings: z.array(z.string()).min(2) });
+        expect(() =>
+          assertAnthropicCompatible(z.toJSONSchema(bad), "bad-min"),
+        ).toThrow(/array schema at .* carries minItems\/maxItems > 1/);
+      });
+
+      it("catches array .max(N) where N > 1 (#52)", () => {
+        const bad = z.object({ rankings: z.array(z.string()).max(5) });
+        expect(() =>
+          assertAnthropicCompatible(z.toJSONSchema(bad), "bad-max"),
+        ).toThrow(/array schema at .* carries minItems\/maxItems > 1/);
+      });
+
+      it("allows array .min(1) (minItems=1 is Anthropic-compatible)", () => {
+        const ok = z.object({ rankings: z.array(z.string()).min(1) });
+        expect(() =>
+          assertAnthropicCompatible(z.toJSONSchema(ok), "ok-min-1"),
+        ).not.toThrow();
+      });
     });
   });
 });

--- a/packages/shared/evaluation/eval-schemas.ts
+++ b/packages/shared/evaluation/eval-schemas.ts
@@ -10,16 +10,17 @@ import { z } from "zod";
  * Notes:
  * - Field names are snake_case to match what Claude outputs today (zero
  *   behavior change at the wire). camelCase conversion stays in adapters.
- * - Numeric fields use plain `z.number()` — NOT `z.number().int()` or
- *   `z.int()`. Both add `minimum: -Number.MAX_SAFE_INTEGER, maximum:
- *   Number.MAX_SAFE_INTEGER` to the emitted JSON Schema, and Anthropic's
- *   structured-output endpoint rejects integer types that carry
- *   minimum/maximum ("For 'integer' type, properties maximum, minimum are
- *   not supported"). This caused #48. Downstream consumers assign into
- *   TypeScript `number` (float) anyway, and the comment about Haiku
- *   returning out-of-range values that the consumer coerces silently
- *   already implied no real safety from the int constraint. The regression
- *   guard lives in `eval-schemas.test.ts`.
+ * - ⚠️ Avoid zod constraints that leak into the emitted JSON Schema.
+ *   Anthropic's structured-output endpoint rejects several JSON Schema
+ *   constraints that zod v4 bakes in by default. Known-rejected:
+ *     • `z.number().int()` / `z.int()` → `minimum: -MAX_SAFE_INTEGER,
+ *       maximum: MAX_SAFE_INTEGER` on integer type (#48). Use `z.number()`.
+ *     • `z.array(...).length(N)` / `.min(N)` / `.max(N)` → `minItems: N,
+ *       maxItems: N` (#52). Use `.refine()` to enforce count at parse time.
+ *   When in doubt, run the schema through `z.toJSONSchema()` and eyeball
+ *   the output before wiring it to `generateText`. The regression test in
+ *   `eval-schemas.test.ts` walks every exported schema and fails on the
+ *   known-rejected patterns above, so new instances trip CI.
  * - The `tier` enum mirrors `TierLetter` from `./tier-utils`. Kept inline as
  *   a zod enum (rather than imported) so this module has zero runtime deps
  *   beyond zod.
@@ -67,14 +68,24 @@ export type MapEvalRankingRaw = z.infer<typeof mapEvalRankingSchema>;
 /**
  * Server-side schema for map evals. Embeds the dynamic option count in the
  * `rankings` array description so Haiku is told exactly how many entries to
- * return. Also enforces `.length(optionCount)` so missing entries fail zod
- * validation → 502 (per the strict-fail decision).
+ * return. Enforces the exact count via `.refine()` so missing entries fail
+ * zod validation → 502 (per the strict-fail decision).
+ *
+ * `.refine()` rather than `.length(optionCount)` because zod v4 emits
+ * `.length(N)` as `minItems: N, maxItems: N` in the JSON Schema and
+ * Anthropic's structured-output endpoint rejects any minItems/maxItems
+ * value other than 0 or 1 ("For 'array' type, 'minItems' values other
+ * than 0 or 1 are not supported"). `.refine()` runs only at parse time
+ * and produces no JSON Schema constraints. This caused #52; regression
+ * guard lives in `eval-schemas.test.ts`.
  */
 export function buildMapEvalSchema(optionCount: number) {
   return z.object({
     rankings: z
       .array(mapEvalRankingSchema)
-      .length(optionCount)
+      .refine((arr) => arr.length === optionCount, {
+        message: `Expected exactly ${optionCount} rankings, one per path option`,
+      })
       .describe(`Exactly ${optionCount} entries, one per path option in order.`),
     overall_advice: z.string(),
     node_preferences: nodePreferencesSchema,
@@ -140,15 +151,20 @@ interface CardRewardItem {
 /**
  * Per-call schema for card_reward and shop evals. Embeds exact item position
  * labels in the `rankings` description (mirroring the inline tool schema at
- * `route.ts:479-507`) and enforces `.length(items.length)` so Haiku returning
- * fewer entries than items becomes a zod parse error → 502 (per the
+ * `route.ts:479-507`) and enforces the exact item count via `.refine()` so
+ * Haiku returning fewer entries becomes a zod parse error → 502 (per the
  * strict-fail decision; replaces the silent fallback fill at route.ts:573-592).
+ *
+ * See `buildMapEvalSchema` for why `.refine()` rather than `.length()` —
+ * same Anthropic minItems/maxItems rejection (#52).
  */
 export function buildCardRewardSchema(items: CardRewardItem[], includeShopPlan: boolean) {
   const baseShape = {
     rankings: z
       .array(cardRewardRankingSchema)
-      .length(items.length)
+      .refine((arr) => arr.length === items.length, {
+        message: `Expected exactly ${items.length} rankings, one per offered item`,
+      })
       .describe(
         `Exactly ${items.length} entries in this EXACT order: ${items
           .map((it, i) => `${i + 1}=${it.name}`)


### PR DESCRIPTION
## Summary
- Second instance of the #48 pattern. `z.array(...).length(N)` emits `{ minItems: N, maxItems: N }` in the JSON Schema; Anthropic's structured-output endpoint rejects any `minItems`/`maxItems` value other than 0 or 1, so `map` / `card_reward` / `shop` evals all 500 with `"For 'array' type, 'minItems' values other than 0 or 1 are not supported"`.
- Swap `.length(N)` for `.refine((arr) => arr.length === N)` in `buildMapEvalSchema` and `buildCardRewardSchema`. Refines run only at parse time, produce no JSON Schema constraints, and still surface count mismatches as `NoObjectGeneratedError` → 502 (so the strict-fail behavior Phase 3 introduced stays intact).
- Generalize the regression guard from #49 to catch **any** known-rejected constraint, not just integer min/max. Helper renamed `assertNoIntegerBounds` → `assertAnthropicCompatible`. Added sanity-check fixtures for every bad pattern (integer min/max, array `.length`, `.min`, `.max`) plus a positive fixture confirming `.min(1)` still passes. Also added `buildMapEvalSchema(5)` as a worst-case case since 5 was the upper bound in the observed error.
- Updated the header comment in `eval-schemas.ts` to list all known-rejected zod patterns at the call site, so the next person reaching for an array length constraint reads the warning before writing the code.

Closes #52

## Test plan
- [x] Replay a captured `map_api_request` body (2 path options) against local dev server → pre-fix: 500 with the Anthropic error. Post-fix: 200 with a full `{ rankings, overall_advice, node_preferences }` response.
- [x] `npm test -w @sts2/web` — 132/132 passing (127 + 5 new regression cases).
- [x] `npm test -w @sts2/desktop` — 204/204 passing.
- [x] Sanity-check the generalized test actually catches the bug: reverted `eval-schemas.ts` to origin/main, re-ran eval-schemas.test → 4 regression cases failed with the expected `array schema at ... carries minItems/maxItems > 1` message. Restored fix → 28/28 green.
- [ ] **Manual smoke after merge** (once prod redeploys): fire a map eval from the desktop app against prod → 200 instead of 500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)