### PR TITLE
fix(eval): sanitize ranking drift in route handler instead of zod refine

### DIFF
--- a/apps/web/src/app/api/evaluate/route.test.ts
+++ b/apps/web/src/app/api/evaluate/route.test.ts
@@ -13,11 +13,17 @@
  *     → toCardRewardEvaluation adapter
  *     → canonical CardRewardEvaluation shape
  *
- * and the strict-fail side:
+ * and the strict-fail side for schema-level constraints:
  *
- *   malformed mock output → NoObjectGeneratedError
- *   partial rankings (2 of 3) → NoObjectGeneratedError (locks in the
- *     deletion of the old route.ts:573-592 fallback fill)
+ *   malformed mock output (wrong types, missing required fields)
+ *     → NoObjectGeneratedError
+ *
+ * Ranking COUNT enforcement moved out of the schema in #54 (the
+ * schema-level `.refine()` rejected Claude's drift-added summary/placeholder
+ * entries as hard 502s even when the real rankings were all present).
+ * Count enforcement now lives in the route handler via `sanitizeRankings`,
+ * which has its own unit test at
+ * `packages/shared/evaluation/sanitize-rankings.test.ts`.
  */
 import { describe, it, expect } from "vitest";
 import { generateText, NoObjectGeneratedError, Output } from "ai";
@@ -90,27 +96,29 @@ describe("AI SDK + zod integration (Phase 4.5 smoke)", () => {
       expect(evaluation.skipRecommended).toBe(false);
     });
 
-    it("throws NoObjectGeneratedError when the mock returns 2 of 3 rankings (locks in strict-fail)", async () => {
+    it("accepts 2 of 3 rankings at the schema layer (count enforcement lives in the route handler post-#54)", async () => {
+      // Pre-#54 the schema's `.refine()` rejected this. Post-#54 the schema
+      // accepts any length (required so Claude's drift-added summary and
+      // placeholder entries don't hard-502 the real rankings), and
+      // `sanitizeRankings` in the route handler enforces the count after
+      // filtering bogus entries. Unit coverage of that enforcement lives at
+      // `packages/shared/evaluation/sanitize-rankings.test.ts`.
       const mockOutput = {
         rankings: [
           { position: 1, tier: "A", confidence: 80, reasoning: "ok" },
           { position: 2, tier: "B", confidence: 70, reasoning: "ok" },
-          // Missing position 3 — the previous fallback fill at
-          // route.ts:573-592 would have inserted a C-tier default here.
-          // Now it fails zod .length(3) validation instead.
         ],
         skip_recommended: false,
       };
       const model = mockModelWithText(JSON.stringify(mockOutput));
       const schema = buildCardRewardSchema(items, false);
 
-      await expect(
-        generateText({
-          model,
-          prompt: "evaluate these cards",
-          output: Output.object({ schema }),
-        }),
-      ).rejects.toSatisfy(NoObjectGeneratedError.isInstance);
+      const result = await generateText({
+        model,
+        prompt: "evaluate these cards",
+        output: Output.object({ schema }),
+      });
+      expect(result.output.rankings).toHaveLength(2);
     });
 
     it("throws NoObjectGeneratedError when a required field is missing", async () => {
@@ -229,9 +237,14 @@ describe("AI SDK + zod integration (Phase 4.5 smoke)", () => {
       ).rejects.toSatisfy(NoObjectGeneratedError.isInstance);
     });
 
-    it("throws NoObjectGeneratedError when rankings count doesn't match optionCount", async () => {
+    it("accepts 2 rankings for a 3-option map at the schema layer (count enforcement lives in the route handler post-#54)", async () => {
+      // Same migration as the card_reward case above: count enforcement
+      // moved out of the schema into `sanitizeRankings`. The schema only
+      // validates shape (tier enum, required fields, node_preferences
+      // presence — which is the b11bef8 regression that MUST stay at the
+      // schema layer because it's about a missing required OBJECT, not a
+      // wrong array length).
       const mockOutput = {
-        // Only 2 rankings for a 3-option map — must fail .length(3)
         rankings: [
           { option_index: 1, tier: "A", confidence: 80, reasoning: "ok" },
           { option_index: 2, tier: "B", confidence: 70, reasoning: "ok" },
@@ -249,13 +262,12 @@ describe("AI SDK + zod integration (Phase 4.5 smoke)", () => {
       const model = mockModelWithText(JSON.stringify(mockOutput));
       const schema = buildMapEvalSchema(3);
 
-      await expect(
-        generateText({
-          model,
-          prompt: "evaluate these paths",
-          output: Output.object({ schema }),
-        }),
-      ).rejects.toSatisfy(NoObjectGeneratedError.isInstance);
+      const result = await generateText({
+        model,
+        prompt: "evaluate these paths",
+        output: Output.object({ schema }),
+      });
+      expect(result.output.rankings).toHaveLength(2);
     });
   });
 });

--- a/apps/web/src/app/api/evaluate/route.ts
+++ b/apps/web/src/app/api/evaluate/route.ts
@@ -19,6 +19,7 @@ import {
 } from "@sts2/shared/evaluation/eval-schemas";
 import { EVAL_MODELS } from "@sts2/shared/evaluation/models";
 import { toCardRewardEvaluation } from "@sts2/shared/evaluation/parse-tool-response";
+import { sanitizeRankings } from "@sts2/shared/evaluation/sanitize-rankings";
 import { getStatisticalEvaluation } from "@sts2/shared/evaluation/statistical-evaluator";
 import { logEvaluation } from "@sts2/shared/evaluation/evaluation-logger";
 import { tierToValue, type TierLetter } from "@sts2/shared/evaluation/tier-utils";
@@ -317,6 +318,32 @@ export async function POST(request: Request) {
         outputTokens: result.usage.outputTokens ?? 0,
       }).catch(console.error);
 
+      // Sanitize rankings for the map path only. Simple/generic evals don't
+      // have a fixed count to enforce. See #54 for the drift patterns
+      // (position 0 summaries, out-of-range placeholders) this handles.
+      if (isMapEval) {
+        const mapOutput = result.output as { rankings: { option_index: number }[] };
+        const cleaned = sanitizeRankings({
+          rankings: mapOutput.rankings,
+          indexKey: "option_index",
+          expectedCount: optionCount,
+        });
+        if (cleaned.length !== optionCount) {
+          console.error(
+            `[Evaluate] Map ranking count mismatch: expected ${optionCount}, got ${cleaned.length} valid (from ${mapOutput.rankings.length} returned). Raw:`,
+            JSON.stringify(mapOutput.rankings),
+          );
+          return NextResponse.json(
+            {
+              error: "Ranking count mismatch",
+              detail: `Expected ${optionCount} rankings, got ${cleaned.length} valid after sanitization`,
+            },
+            { status: 502 },
+          );
+        }
+        mapOutput.rankings = cleaned;
+      }
+
       console.log("[Evaluate] Map/freeform output:", JSON.stringify(result.output));
       return NextResponse.json(result.output);
     } catch (error) {
@@ -487,6 +514,30 @@ Return exactly ${items.length} rankings using position numbers (1, 2, 3...) matc
     }).catch(console.error);
 
     console.log("[Evaluate] Card/shop output:", JSON.stringify(result.output));
+
+    // Sanitize rankings before the camelCase adapter. See #54 for the drift
+    // patterns this handles (position 0 summary entries, out-of-range
+    // placeholders, out-of-order, duplicates).
+    const cleanedRankings = sanitizeRankings({
+      rankings: result.output.rankings,
+      indexKey: "position",
+      expectedCount: items.length,
+    });
+    if (cleanedRankings.length !== items.length) {
+      console.error(
+        `[Evaluate] Card/shop ranking count mismatch: expected ${items.length}, got ${cleanedRankings.length} valid (from ${result.output.rankings.length} returned). Raw:`,
+        JSON.stringify(result.output.rankings),
+      );
+      return NextResponse.json(
+        {
+          error: "Ranking count mismatch",
+          detail: `Expected ${items.length} rankings, got ${cleanedRankings.length} valid after sanitization`,
+        },
+        { status: 502 },
+      );
+    }
+    result.output.rankings = cleanedRankings;
+
     const evaluation = toCardRewardEvaluation(result.output, items);
     console.log("[Evaluate] Final rankings count:", evaluation.rankings.length);
 

--- a/packages/shared/evaluation/eval-schemas.test.ts
+++ b/packages/shared/evaluation/eval-schemas.test.ts
@@ -49,7 +49,12 @@ describe("eval-schemas", () => {
       expect(parsed.node_preferences.elite).toBe(0.5);
     });
 
-    it("rejects when rankings count does not match optionCount (strict-fail)", () => {
+    it("accepts wrong rankings count at schema layer — count enforcement lives in route handler post-#54", () => {
+      // Pre-#54 this threw via `.refine()`. Post-#54 the schema intentionally
+      // accepts any length so Claude's drift-added summary/placeholder
+      // entries don't hard-502 the real rankings. Count enforcement moved to
+      // `sanitizeRankings` in the route handler; see its unit tests in
+      // `sanitize-rankings.test.ts`.
       const schema = buildMapEvalSchema(3);
       expect(() =>
         schema.parse({
@@ -57,7 +62,7 @@ describe("eval-schemas", () => {
           overall_advice: "go right",
           node_preferences: validPrefs,
         }),
-      ).toThrow();
+      ).not.toThrow();
     });
 
     it("rejects missing node_preferences (the b11bef8 silent-drop case)", () => {
@@ -167,14 +172,16 @@ describe("eval-schemas", () => {
       expect(parsed.rankings).toHaveLength(3);
     });
 
-    it("rejects when rankings.length !== items.length (strict-fail, replaces fallback fill)", () => {
+    it("accepts wrong rankings count at schema layer — count enforcement lives in route handler post-#54", () => {
+      // Same migration as the map case above. See `sanitize-rankings.test.ts`
+      // for the count + drift-filtering coverage.
       const schema = buildCardRewardSchema(items, false);
       expect(() =>
         schema.parse({
           rankings: [validRanking(1), validRanking(2)], // only 2 of 3
           skip_recommended: false,
         }),
-      ).toThrow();
+      ).not.toThrow();
     });
 
     it("includes spending_plan only when includeShopPlan is true", () => {

--- a/packages/shared/evaluation/eval-schemas.ts
+++ b/packages/shared/evaluation/eval-schemas.ts
@@ -16,11 +16,23 @@ import { z } from "zod";
  *     • `z.number().int()` / `z.int()` → `minimum: -MAX_SAFE_INTEGER,
  *       maximum: MAX_SAFE_INTEGER` on integer type (#48). Use `z.number()`.
  *     • `z.array(...).length(N)` / `.min(N)` / `.max(N)` → `minItems: N,
- *       maxItems: N` (#52). Use `.refine()` to enforce count at parse time.
- *   When in doubt, run the schema through `z.toJSONSchema()` and eyeball
- *   the output before wiring it to `generateText`. The regression test in
+ *       maxItems: N` (#52). These cannot be replaced with `.refine()` at
+ *       the schema level either (see next point), so count enforcement
+ *       lives in the route handler via `sanitizeRankings`.
+ *   `z.toJSONSchema()` also throws on any schema containing a `.transform()`
+ *   ("Transforms cannot be represented in JSON Schema"), so transform-based
+ *   workarounds are off the table. The regression test in
  *   `eval-schemas.test.ts` walks every exported schema and fails on the
  *   known-rejected patterns above, so new instances trip CI.
+ * - ⚠️ Strict-fail count enforcement. After #52 removed the JSON Schema
+ *   `minItems/maxItems` constraint, Claude started drifting — adding
+ *   placeholder entries (position N+1) and summary entries (position 0)
+ *   that a schema-level `.refine()` rejected as hard 502s even though
+ *   the real rankings were all present. Count enforcement moved to the
+ *   route handler: `sanitizeRankings` filters to valid indices, dedupes,
+ *   and sorts, and the handler returns 502 only if the cleaned count is
+ *   still wrong. The describe() text on each array still hammers the
+ *   expected count as a prompt-level signal (#54).
  * - The `tier` enum mirrors `TierLetter` from `./tier-utils`. Kept inline as
  *   a zod enum (rather than imported) so this module has zero runtime deps
  *   beyond zod.
@@ -68,25 +80,18 @@ export type MapEvalRankingRaw = z.infer<typeof mapEvalRankingSchema>;
 /**
  * Server-side schema for map evals. Embeds the dynamic option count in the
  * `rankings` array description so Haiku is told exactly how many entries to
- * return. Enforces the exact count via `.refine()` so missing entries fail
- * zod validation → 502 (per the strict-fail decision).
- *
- * `.refine()` rather than `.length(optionCount)` because zod v4 emits
- * `.length(N)` as `minItems: N, maxItems: N` in the JSON Schema and
- * Anthropic's structured-output endpoint rejects any minItems/maxItems
- * value other than 0 or 1 ("For 'array' type, 'minItems' values other
- * than 0 or 1 are not supported"). `.refine()` runs only at parse time
- * and produces no JSON Schema constraints. This caused #52; regression
- * guard lives in `eval-schemas.test.ts`.
+ * return. Does NOT enforce count at the schema level — see the "strict-fail
+ * count enforcement" note in the header.
  */
 export function buildMapEvalSchema(optionCount: number) {
   return z.object({
     rankings: z
       .array(mapEvalRankingSchema)
-      .refine((arr) => arr.length === optionCount, {
-        message: `Expected exactly ${optionCount} rankings, one per path option`,
-      })
-      .describe(`Exactly ${optionCount} entries, one per path option in order.`),
+      .describe(
+        `Exactly ${optionCount} ranking objects, one per path option. ` +
+          `Use option_index values 1 through ${optionCount} (no duplicates, no gaps, no option_index 0). ` +
+          `Do NOT add placeholder entries. Do NOT add a summary entry.`,
+      ),
     overall_advice: z.string(),
     node_preferences: nodePreferencesSchema,
   });
@@ -151,24 +156,20 @@ interface CardRewardItem {
 /**
  * Per-call schema for card_reward and shop evals. Embeds exact item position
  * labels in the `rankings` description (mirroring the inline tool schema at
- * `route.ts:479-507`) and enforces the exact item count via `.refine()` so
- * Haiku returning fewer entries becomes a zod parse error → 502 (per the
- * strict-fail decision; replaces the silent fallback fill at route.ts:573-592).
- *
- * See `buildMapEvalSchema` for why `.refine()` rather than `.length()` —
- * same Anthropic minItems/maxItems rejection (#52).
+ * `route.ts:479-507`). Does NOT enforce count at the schema level — see the
+ * "strict-fail count enforcement" note in the header.
  */
 export function buildCardRewardSchema(items: CardRewardItem[], includeShopPlan: boolean) {
   const baseShape = {
     rankings: z
       .array(cardRewardRankingSchema)
-      .refine((arr) => arr.length === items.length, {
-        message: `Expected exactly ${items.length} rankings, one per offered item`,
-      })
       .describe(
-        `Exactly ${items.length} entries in this EXACT order: ${items
-          .map((it, i) => `${i + 1}=${it.name}`)
-          .join(", ")}.`,
+        `Exactly ${items.length} ranking objects, one per offered item. ` +
+          `Use position values 1 through ${items.length} in this EXACT order: ${items
+            .map((it, i) => `${i + 1}=${it.name}`)
+            .join(", ")}. ` +
+          `Do NOT add placeholder entries. Do NOT include a position 0 summary entry. ` +
+          `If skipping all, still return one ranking per item with the skip reason in each \`reasoning\`.`,
       ),
     skip_recommended: z.boolean(),
     skip_reasoning: z.string().nullish(),

--- a/packages/shared/evaluation/sanitize-rankings.test.ts
+++ b/packages/shared/evaluation/sanitize-rankings.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect } from "vitest";
+import { sanitizeRankings } from "./sanitize-rankings";
+
+describe("sanitizeRankings", () => {
+  const card = (position: number, reasoning = "ok") => ({
+    position,
+    tier: "B" as const,
+    confidence: 70,
+    reasoning,
+  });
+
+  describe("happy path", () => {
+    it("returns input unchanged when Claude behaves (exact count, in order)", () => {
+      const rankings = [card(1), card(2), card(3)];
+      expect(
+        sanitizeRankings({ rankings, indexKey: "position", expectedCount: 3 }),
+      ).toEqual(rankings);
+    });
+
+    it("sorts out-of-order entries ascending by index", () => {
+      const result = sanitizeRankings({
+        rankings: [card(3), card(1), card(2)],
+        indexKey: "position",
+        expectedCount: 3,
+      });
+      expect(result.map((r) => r.position)).toEqual([1, 2, 3]);
+    });
+  });
+
+  describe("#54 observed drift cases", () => {
+    it("drops a position-0 pick summary entry (card_reward 3-item case)", () => {
+      // The exact shape the user hit: Claude added a `position: 0` ranking
+      // with reasoning "PICK Twin Strike — ..." on top of the real 3.
+      const rankings = [
+        card(1, "2-cost exhaust"),
+        card(2, "double damage"),
+        card(3, "random top-deck"),
+        { ...card(0), tier: "S" as const, reasoning: "PICK Twin Strike — ..." },
+      ];
+      const result = sanitizeRankings({
+        rankings,
+        indexKey: "position",
+        expectedCount: 3,
+      });
+      expect(result.map((r) => r.position)).toEqual([1, 2, 3]);
+      expect(result.every((r) => !r.reasoning.startsWith("PICK"))).toBe(true);
+    });
+
+    it("drops an out-of-range placeholder entry (shop 12-item case)", () => {
+      // Claude added `{ position: 13, ..., reasoning: "Placeholder for schema
+      // validation; not a real shop item." }` on top of the real 12.
+      const rankings = [
+        ...Array.from({ length: 12 }, (_, i) => card(i + 1)),
+        { ...card(13), tier: "F" as const, reasoning: "Placeholder for schema validation; not a real shop item." },
+      ];
+      const result = sanitizeRankings({
+        rankings,
+        indexKey: "position",
+        expectedCount: 12,
+      });
+      expect(result.map((r) => r.position)).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
+      expect(result.find((r) => r.reasoning.includes("Placeholder"))).toBeUndefined();
+    });
+
+    it("drops both drift patterns in the same response", () => {
+      const rankings = [
+        { ...card(0), reasoning: "summary" },
+        card(1),
+        card(2),
+        card(3),
+        { ...card(4), reasoning: "placeholder" },
+      ];
+      const result = sanitizeRankings({
+        rankings,
+        indexKey: "position",
+        expectedCount: 3,
+      });
+      expect(result.map((r) => r.position)).toEqual([1, 2, 3]);
+    });
+  });
+
+  describe("invalid indices", () => {
+    it("drops negative indices", () => {
+      const result = sanitizeRankings({
+        rankings: [card(-1), card(1), card(2)],
+        indexKey: "position",
+        expectedCount: 2,
+      });
+      expect(result.map((r) => r.position)).toEqual([1, 2]);
+    });
+
+    it("drops non-integer (decimal) indices", () => {
+      const result = sanitizeRankings({
+        rankings: [card(1.5), card(1), card(2)],
+        indexKey: "position",
+        expectedCount: 2,
+      });
+      expect(result.map((r) => r.position)).toEqual([1, 2]);
+    });
+
+    it("drops NaN and Infinity indices", () => {
+      const result = sanitizeRankings({
+        rankings: [card(NaN), card(Infinity), card(1), card(2)],
+        indexKey: "position",
+        expectedCount: 2,
+      });
+      expect(result.map((r) => r.position)).toEqual([1, 2]);
+    });
+
+    it("drops indices above expectedCount", () => {
+      const result = sanitizeRankings({
+        rankings: [card(1), card(2), card(3), card(4), card(5)],
+        indexKey: "position",
+        expectedCount: 3,
+      });
+      expect(result.map((r) => r.position)).toEqual([1, 2, 3]);
+    });
+  });
+
+  describe("duplicates", () => {
+    it("keeps the first occurrence when Claude returns duplicates", () => {
+      const rankings = [
+        { ...card(1), reasoning: "first version" },
+        { ...card(2), reasoning: "correct" },
+        { ...card(1), reasoning: "second version" },
+      ];
+      const result = sanitizeRankings({
+        rankings,
+        indexKey: "position",
+        expectedCount: 2,
+      });
+      expect(result.map((r) => r.position)).toEqual([1, 2]);
+      expect(result[0].reasoning).toBe("first version");
+    });
+  });
+
+  describe("missing entries", () => {
+    it("returns fewer than expectedCount when Claude genuinely skipped entries (caller decides what to do)", () => {
+      // This is the case the caller should treat as a 502 — we return the
+      // best we can, but the length mismatch is a real failure.
+      const result = sanitizeRankings({
+        rankings: [card(1), card(3)],
+        indexKey: "position",
+        expectedCount: 3,
+      });
+      expect(result.map((r) => r.position)).toEqual([1, 3]);
+      expect(result.length).toBe(2); // caller will see 2 !== 3 and return 502
+    });
+
+    it("returns empty array for empty input", () => {
+      expect(
+        sanitizeRankings({ rankings: [], indexKey: "position", expectedCount: 3 }),
+      ).toEqual([]);
+    });
+  });
+
+  describe("indexKey variants", () => {
+    it("works with option_index for map eval rankings", () => {
+      const mapEntry = (option_index: number) => ({
+        option_index,
+        node_type: "monster",
+        tier: "A" as const,
+        confidence: 80,
+        reasoning: "ok",
+      });
+      const result = sanitizeRankings({
+        rankings: [mapEntry(2), mapEntry(1), { ...mapEntry(0), reasoning: "summary" }],
+        indexKey: "option_index",
+        expectedCount: 2,
+      });
+      expect(result.map((r) => r.option_index)).toEqual([1, 2]);
+    });
+  });
+});

--- a/packages/shared/evaluation/sanitize-rankings.ts
+++ b/packages/shared/evaluation/sanitize-rankings.ts
@@ -1,0 +1,54 @@
+/**
+ * Clean up Claude's ranking arrays so the route handler can rely on them.
+ *
+ * After #52 removed the JSON Schema `minItems/maxItems` constraint (which
+ * Anthropic was rejecting), Claude started drifting — adding placeholder
+ * entries past position N and summary entries at position 0 — see #54 for
+ * observed drift cases. A schema-level `.refine()` would reject those as
+ * hard 502s, and `.transform()` inside the schema blows up
+ * `z.toJSONSchema()` ("Transforms cannot be represented in JSON Schema"),
+ * so count enforcement lives here instead.
+ *
+ * Contract:
+ * - Filters to entries whose index is an integer in `[1, expectedCount]`.
+ *   Drops anything out of range, NaN, non-integer, or missing the key.
+ * - Dedupes by index, keeping the FIRST occurrence. Claude has been seen
+ *   returning duplicates when it "corrects" itself mid-output; the first
+ *   one is usually the intended answer.
+ * - Sorts ascending by index so callers can assume positional order even
+ *   when Claude returned the entries out of order.
+ * - Pure function, no throws. The caller decides what to do if the
+ *   sanitized length is still wrong (typically: return 502).
+ */
+export interface SanitizeRankingsArgs<T> {
+  rankings: readonly T[];
+  /** Which field on each entry holds the 1-indexed position. */
+  indexKey: keyof T;
+  /** Expected number of rankings. Indices must fall in `[1, expectedCount]`. */
+  expectedCount: number;
+}
+
+export function sanitizeRankings<T>({
+  rankings,
+  indexKey,
+  expectedCount,
+}: SanitizeRankingsArgs<T>): T[] {
+  const seen = new Set<number>();
+  const kept: T[] = [];
+
+  for (const entry of rankings) {
+    const raw = entry[indexKey];
+    if (typeof raw !== "number" || !Number.isInteger(raw)) continue;
+    if (raw < 1 || raw > expectedCount) continue;
+    if (seen.has(raw)) continue;
+    seen.add(raw);
+    kept.push(entry);
+  }
+
+  kept.sort((a, b) => {
+    // Safe — we just filtered to numeric integer indices above.
+    return (a[indexKey] as unknown as number) - (b[indexKey] as unknown as number);
+  });
+
+  return kept;
+}


### PR DESCRIPTION
## Summary
After #52 removed the JSON Schema length constraint (which Anthropic rejects), Claude's structured output started drifting in new ways — adding placeholder entries past position N and summary entries at position 0. The schema-level `.refine()` added in #52 rejected both as hard 502s even though the real rankings were present. `.transform()` inside the schema would work mathematically but `z.toJSONSchema()` throws `"Transforms cannot be represented in JSON Schema"` so count enforcement had to move to the route handler.

- Drop `.refine()` from `buildMapEvalSchema` and `buildCardRewardSchema`. Schema validates individual ranking shapes only; count enforcement lives in `sanitizeRankings`.
- Strengthen the `describe()` text on both array schemas — explicit no-placeholder, no-position-0, no-summary instructions. Defense in depth.
- New `packages/shared/evaluation/sanitize-rankings.ts` — pure function filtering to valid integer indices in `[1, expectedCount]`, deduping by index (first wins), sorting ascending. 13 unit tests cover both observed drift cases, all invalid-index variants, duplicates, missing entries, and the indexKey generic.
- Wire `sanitizeRankings` into route.ts for the map + card/shop paths. Sanitize → count check → 502 with diagnostic detail if still wrong, otherwise replace `result.output.rankings` with cleaned and continue.
- Update route.test.ts and eval-schemas.test.ts count-mismatch assertions — schema now accepts wrong counts, unit coverage of enforcement moved to sanitize-rankings.test.ts.
- Update the header comment in `eval-schemas.ts` to explain the strict-fail split (shape at schema, count at route handler) and the `.transform()` limitation, so the next person reaching for a zod array constraint understands why it's not there.

Closes #54

## Test plan
- [x] Replayed a real 2-option map body through local dev server → 200 with full map response.
- [x] Hand-crafted card_reward body (3 items) → 200 with clean 3-item response.
- [x] `npm test -w @sts2/web` — 145/145 (132 + 13 new sanitize tests).
- [x] `npm test -w @sts2/desktop` — 204/204.
- [x] `tsc --noEmit` in apps/web — clean.
- [ ] **Post-merge manual smoke:** fire a shop eval with 8+ items — if Claude drifts with a placeholder entry, logs should show `[Evaluate] Card/shop ranking count mismatch` with the raw rankings for analysis; if it doesn't drift, response is unchanged.

## Non-goals
- No retry loop on parse failures — latency is already the dominant eval cost.
- Genuinely-missing entries (count < expected *after* sanitization) still 502. This only handles the observed drift patterns where Claude *over-produces*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)