### PR TITLE
fix(map): skip eval when every next option is a forced Ancient node

### DIFF
--- a/apps/desktop/src/features/map/mapListeners.ts
+++ b/apps/desktop/src/features/map/mapListeners.ts
@@ -178,12 +178,23 @@ export function setupMapEvalListener() {
         }
         prevMapPosition = currentPos;
 
+        // STS2 places Ancient nodes alone in their row, so when an act starts
+        // on an Ancient the player's only next move is into the event. Skip
+        // the eval until after the event resolves and the player gets real
+        // options (#56). `.every()` is the defensive form — if the game ever
+        // ships a row with multiple ancient options, the gate still matches,
+        // and a hypothetical mixed Ancient/non-Ancient row would NOT match
+        // (the player would have a real choice worth evaluating).
+        const allOptionsAreAncient =
+          options.length > 0 && options.every((o) => o.type === "Ancient");
+
         const input = {
           optionCount: options.length,
           hasPrevContext: !!prevContext,
           actChanged: prevContext ? prevContext.act !== run.act : false,
           currentPosition: currentPos,
           isOnRecommendedPath: isOnPath,
+          allOptionsAreAncient,
           hpDropExceedsThreshold,
           goldCrossedThreshold,
           deckSizeChangedSignificantly,

--- a/apps/desktop/src/lib/__tests__/build-map-eval-input.test.ts
+++ b/apps/desktop/src/lib/__tests__/build-map-eval-input.test.ts
@@ -6,6 +6,7 @@ import { shouldEvaluateMap } from "../should-evaluate-map";
 function shouldEval(overrides: Partial<MapEvalInputSources>) {
   const base: MapEvalInputSources = {
     optionCount: 3,
+    allOptionsAreAncient: false,
     currentPosition: { col: 2, row: 5 },
     act: 1,
     prevContext: { hpPercent: 0.9, deckSize: 14, act: 1, gold: 100, ascension: 0 },

--- a/apps/desktop/src/lib/__tests__/should-evaluate-map.test.ts
+++ b/apps/desktop/src/lib/__tests__/should-evaluate-map.test.ts
@@ -8,6 +8,7 @@ const stable: ShouldEvaluateMapInput = {
   actChanged: false,
   currentPosition: { col: 2, row: 5 },
   isOnRecommendedPath: true,
+  allOptionsAreAncient: false,
   hpDropExceedsThreshold: false,
   goldCrossedThreshold: false,
   deckSizeChangedSignificantly: false,
@@ -103,6 +104,62 @@ describe("shouldEvaluateMap", () => {
 
     it("returns false with multiple options, on path, no changes", () => {
       expect(evaluate({ optionCount: 5 })).toBe(false);
+    });
+  });
+
+  describe("hard gate: forced ancient event (#56)", () => {
+    it("returns false when the only option is an Ancient node, even on act transition", () => {
+      // This is the exact Act 1 → Act 2 case: `actChanged` is true and
+      // `next_options` contains a single Ancient entry. Pre-fix, `actChanged`
+      // short-circuited to `true` and an eval fired with stale pre-Ancient
+      // context. Post-fix the Ancient gate takes precedence.
+      expect(
+        evaluate({
+          optionCount: 1,
+          actChanged: true,
+          hasPrevContext: true,
+          isOnRecommendedPath: false, // transitional state at act start
+          currentPosition: null,
+          allOptionsAreAncient: true,
+        }),
+      ).toBe(false);
+    });
+
+    it("returns false when all options are Ancient even with no prev context (fresh run)", () => {
+      expect(
+        evaluate({
+          optionCount: 1,
+          hasPrevContext: false,
+          allOptionsAreAncient: true,
+        }),
+      ).toBe(false);
+    });
+
+    it("returns true for a mixed row where only one option is Ancient (player has a real choice)", () => {
+      // Structurally disallowed in STS2 today — Ancient nodes sit alone in
+      // their row — but the gate is defensive: if the invariant is ever
+      // broken, a mixed row should still be evaluated.
+      expect(
+        evaluate({
+          optionCount: 2,
+          allOptionsAreAncient: false,
+          actChanged: true,
+        }),
+      ).toBe(true);
+    });
+
+    it("returns true for a normal non-Ancient act transition", () => {
+      // Act 2 start where the first row is Monster nodes — existing behavior.
+      expect(
+        evaluate({
+          optionCount: 3,
+          actChanged: true,
+          hasPrevContext: true,
+          currentPosition: null,
+          isOnRecommendedPath: false,
+          allOptionsAreAncient: false,
+        }),
+      ).toBe(true);
     });
   });
 

--- a/apps/desktop/src/lib/build-map-eval-input.ts
+++ b/apps/desktop/src/lib/build-map-eval-input.ts
@@ -3,6 +3,12 @@ import type { ShouldEvaluateMapInput } from "./should-evaluate-map";
 export interface MapEvalInputSources {
   /** Number of next path options */
   optionCount: number;
+  /**
+   * Whether every `next_options` entry is a forced Ancient event node.
+   * Caller computes via `options.every((o) => o.type === "Ancient")`.
+   * See `ShouldEvaluateMapInput.allOptionsAreAncient` for the rationale.
+   */
+  allOptionsAreAncient: boolean;
   /** Current map position */
   currentPosition: { col: number; row: number } | null;
   /** Current act */
@@ -32,6 +38,7 @@ export interface MapEvalInputSources {
 export function buildMapEvalInput(sources: MapEvalInputSources): ShouldEvaluateMapInput {
   const {
     optionCount,
+    allOptionsAreAncient,
     currentPosition,
     act,
     prevContext,
@@ -69,6 +76,7 @@ export function buildMapEvalInput(sources: MapEvalInputSources): ShouldEvaluateM
     actChanged,
     currentPosition,
     isOnRecommendedPath,
+    allOptionsAreAncient,
     hpDropExceedsThreshold,
     goldCrossedThreshold,
     deckSizeChangedSignificantly,

--- a/apps/desktop/src/lib/should-evaluate-map.ts
+++ b/apps/desktop/src/lib/should-evaluate-map.ts
@@ -9,6 +9,20 @@ export interface ShouldEvaluateMapInput {
   currentPosition: { col: number; row: number } | null;
   /** Whether the current position is in the set of recommended nodes */
   isOnRecommendedPath: boolean;
+  /**
+   * Every `next_options` entry is a forced Ancient event node (#56).
+   *
+   * STS2 places Ancient nodes alone in their row, so when the player
+   * transitions into an act whose first row is an Ancient, `next_options`
+   * has a single forced entry. Running an eval at that moment wastes an
+   * API call (there's no decision to make) AND bakes stale context into
+   * the result — the Ancient event grants a relic that isn't in the
+   * player's inventory yet. The gate defers the eval until after the
+   * event resolves; the next map poll sees `actChanged` still true (no
+   * eval ran to advance `prevContext.act`) and triggers a fresh eval
+   * with the new relic in context.
+   */
+  allOptionsAreAncient: boolean;
   /** Tier 2: HP dropped more than 20% since last eval */
   hpDropExceedsThreshold: boolean;
   /** Tier 2: Gold crossed a meaningful viability boundary */
@@ -30,6 +44,7 @@ export function shouldEvaluateMap(input: ShouldEvaluateMapInput): boolean {
     actChanged,
     currentPosition,
     isOnRecommendedPath,
+    allOptionsAreAncient,
     hpDropExceedsThreshold,
     goldCrossedThreshold,
     deckSizeChangedSignificantly,
@@ -37,6 +52,11 @@ export function shouldEvaluateMap(input: ShouldEvaluateMapInput): boolean {
 
   // Hard gate: no options at all — nothing to evaluate
   if (optionCount <= 0) return false;
+
+  // Hard gate: forced Ancient event (#56). See `allOptionsAreAncient` docstring.
+  // Must be above the `actChanged` branch so act transitions that land on an
+  // Ancient row don't trigger a stale-context eval.
+  if (allOptionsAreAncient) return false;
 
   // Soft gate: single path forward with existing eval and on path — no decision needed
   if (optionCount === 1 && hasPrevContext && isOnRecommendedPath) return false;


### PR DESCRIPTION
## Summary
- At Act 1 → Act 2 transition, `next_options` contains exactly one Ancient event node and the player is forced into it. The map eval listener was firing immediately, wasting an API call and baking in stale context (the Ancient's relic reward isn't in the player's inventory yet). Dev-log evidence: `mapPrompt` ended with "Return EXACTLY 1 rankings — ONE per path option (1=Ancient)" and `relicIds` was missing the Ancient reward.
- Add `allOptionsAreAncient` to `ShouldEvaluateMapInput` and a hard gate in `shouldEvaluateMap` above the `actChanged` branch. Compute it in `mapListeners` via `options.every((o) => o.type === "Ancient")`.
- The deferral resolves naturally: the skipped eval never advances `prevContext.act`, so the next map poll after the Ancient event resolves still sees `actChanged = true` and fires a fresh eval with the new relic in context. No post-event retrigger logic needed.
- 4 new unit tests covering: all-ancient skips even on act transition, all-ancient skips without prev context, defensive "mixed row still evaluates" (future-proofing), and the regular non-Ancient act-transition path unchanged.
- `.every()` is intentional over `.some()` / `options[0].type === "Ancient"` — a hypothetical mixed Ancient/non-Ancient row would represent a real decision worth evaluating, and the guard correctly lets those through.

Closes #56

## Test plan
- [x] `npm test -w @sts2/desktop` — 208/208 (204 + 4 new).
- [x] `tsc --noEmit` in apps/desktop — clean.
- [x] `npm test -w @sts2/web` — 145/145 (shared package tests unaffected).
- [ ] **Post-merge manual smoke:** run the desktop app through Act 1 boss → Act 2 start → first Ancient node. Confirm via dev-logger that `map_should_eval` logs `allOptionsAreAncient: true, shouldEval: false` while the player is on the Ancient row, then logs a fresh eval with the Ancient relic in `relicIds` after the event resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)