### PR TITLE
Sync all evaluation-relevant data from Spire Codex API

### DIFF
--- a/apps/web/src/game-data/sync-codex.ts
+++ b/apps/web/src/game-data/sync-codex.ts
@@ -137,6 +137,49 @@ interface CodexPower {
   image_url: string | null;
 }
 
+interface CodexEncounter {
+  id: string;
+  name: string;
+  room_type: string;
+  is_weak: boolean;
+  act: string | null;
+  tags: string[] | null;
+  monsters: { id: string; name: string }[] | null;
+  loss_text: string | null;
+}
+
+interface CodexOrb {
+  id: string;
+  name: string;
+  description: string;
+  description_raw: string | null;
+  image_url: string | null;
+}
+
+interface CodexAffliction {
+  id: string;
+  name: string;
+  description: string;
+  extra_card_text: string | null;
+  is_stackable: boolean;
+}
+
+interface CodexCharacter {
+  id: string;
+  name: string;
+  description: string | null;
+  starting_hp: number;
+  starting_gold: number;
+  max_energy: number;
+  orb_slots: number | null;
+  starting_deck: string[];
+  starting_relics: string[];
+  unlocks_after: string | null;
+  gender: string | null;
+  color: string | null;
+  image_url: string | null;
+}
+
 async function syncCards(version: string) {
   console.log("Syncing cards...");
   const cards = await fetchCodex<CodexCard[]>("/cards");
@@ -309,6 +352,90 @@ async function syncPowers(version: string) {
   const { error } = await supabase.from("powers").upsert(rows);
   if (error) throw error;
   console.log(`  ✓ ${rows.length} powers synced`);
+}
+
+async function syncEncounters(version: string) {
+  console.log("Syncing encounters...");
+  const encounters = await fetchCodex<CodexEncounter[]>("/encounters");
+
+  const rows = encounters.map((e) => ({
+    id: e.id,
+    name: e.name,
+    room_type: e.room_type,
+    is_weak: e.is_weak,
+    act: e.act ?? null,
+    tags: e.tags ?? null,
+    monsters: e.monsters ? JSON.parse(JSON.stringify(e.monsters)) : null,
+    loss_text: e.loss_text ?? null,
+    game_version: version,
+  }));
+
+  const { error } = await supabase.from("encounters").upsert(rows);
+  if (error) throw error;
+  console.log(`  ✓ ${rows.length} encounters synced`);
+}
+
+async function syncOrbs(version: string) {
+  console.log("Syncing orbs...");
+  const orbs = await fetchCodex<CodexOrb[]>("/orbs");
+
+  const rows = orbs.map((o) => ({
+    id: o.id,
+    name: o.name,
+    description: o.description,
+    description_raw: o.description_raw ?? null,
+    image_url: o.image_url ?? null,
+    game_version: version,
+  }));
+
+  const { error } = await supabase.from("orbs").upsert(rows);
+  if (error) throw error;
+  console.log(`  ✓ ${rows.length} orbs synced`);
+}
+
+async function syncAfflictions(version: string) {
+  console.log("Syncing afflictions...");
+  const afflictions = await fetchCodex<CodexAffliction[]>("/afflictions");
+
+  const rows = afflictions.map((a) => ({
+    id: a.id,
+    name: a.name,
+    description: a.description,
+    extra_card_text: a.extra_card_text ?? null,
+    is_stackable: a.is_stackable,
+    game_version: version,
+  }));
+
+  const { error } = await supabase.from("afflictions").upsert(rows);
+  if (error) throw error;
+  console.log(`  ✓ ${rows.length} afflictions synced`);
+}
+
+async function syncCharacters(version: string) {
+  console.log("Syncing characters...");
+  const characters = await fetchCodex<CodexCharacter[]>("/characters");
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- new columns may not be in generated types yet
+  const rows: any[] = characters.map((c) => ({
+    id: c.id,
+    name: c.name,
+    description: c.description ?? null,
+    starting_hp: c.starting_hp,
+    starting_gold: c.starting_gold,
+    starting_energy: c.max_energy,
+    orb_slots: c.orb_slots ?? null,
+    starting_deck: c.starting_deck,
+    starting_relics: c.starting_relics,
+    unlocks_after: c.unlocks_after ?? null,
+    gender: c.gender ?? null,
+    color: c.color ?? null,
+    image_url: c.image_url ?? null,
+    game_version: version,
+  }));
+
+  const { error } = await supabase.from("characters").upsert(rows);
+  if (error) throw error;
+  console.log(`  ✓ ${rows.length} characters synced`);
 }
 
 async function main() {

--- a/apps/web/src/game-data/sync-codex.ts
+++ b/apps/web/src/game-data/sync-codex.ts
@@ -447,8 +447,9 @@ async function main() {
     .from("game_versions")
     .upsert({ version, synced_at: new Date().toISOString() });
 
+  // Existing syncs
   await syncCards(version);
-  await delay(1200); // respect rate limit
+  await delay(1200);
   await syncRelics(version);
   await delay(1200);
   await syncPotions(version);
@@ -456,6 +457,22 @@ async function main() {
   await syncMonsters(version);
   await delay(1200);
   await syncKeywords(version);
+  await delay(1200);
+
+  // New syncs
+  await syncEvents(version);
+  await delay(1200);
+  await syncEnchantments(version);
+  await delay(1200);
+  await syncPowers(version);
+  await delay(1200);
+  await syncEncounters(version);
+  await delay(1200);
+  await syncOrbs(version);
+  await delay(1200);
+  await syncAfflictions(version);
+  await delay(1200);
+  await syncCharacters(version);
 
   console.log("\n✓ All game data synced successfully!\n");
 }

--- a/apps/web/src/game-data/sync-codex.ts
+++ b/apps/web/src/game-data/sync-codex.ts
@@ -99,6 +99,44 @@ interface CodexKeyword {
   description: string;
 }
 
+interface CodexEvent {
+  id: string;
+  name: string;
+  type: string;
+  act: string | null;
+  description: string | null;
+  preconditions: unknown[] | null;
+  options: { id: string; title: string; description: string }[] | null;
+  pages: { id: string; description: string; options: { id: string; title: string; description: string }[] | null }[] | null;
+  epithet: string | null;
+  dialogue: Record<string, { order: string; speaker: string; text: string }[]> | null;
+  image_url: string | null;
+  relics: string[] | null;
+}
+
+interface CodexEnchantment {
+  id: string;
+  name: string;
+  description: string;
+  description_raw: string | null;
+  extra_card_text: string | null;
+  card_type: string | null;
+  applicable_to: string | null;
+  is_stackable: boolean;
+  image_url: string | null;
+}
+
+interface CodexPower {
+  id: string;
+  name: string;
+  description: string;
+  description_raw: string | null;
+  type: string;
+  stack_type: string | null;
+  allow_negative: boolean | null;
+  image_url: string | null;
+}
+
 async function syncCards(version: string) {
   console.log("Syncing cards...");
   const cards = await fetchCodex<CodexCard[]>("/cards");
@@ -203,6 +241,74 @@ async function syncKeywords(version: string) {
   const { error } = await supabase.from("keywords").upsert(rows);
   if (error) throw error;
   console.log(`  ✓ ${rows.length} keywords synced`);
+}
+
+async function syncEvents(version: string) {
+  console.log("Syncing events...");
+  const events = await fetchCodex<CodexEvent[]>("/events");
+
+  const rows = events.map((e) => ({
+    id: e.id,
+    name: e.name,
+    type: e.type,
+    act: e.act ?? null,
+    description: e.description ?? null,
+    preconditions: e.preconditions ? JSON.parse(JSON.stringify(e.preconditions)) : null,
+    options: e.options ? JSON.parse(JSON.stringify(e.options)) : null,
+    pages: e.pages ? JSON.parse(JSON.stringify(e.pages)) : null,
+    epithet: e.epithet ?? null,
+    dialogue: e.dialogue ? JSON.parse(JSON.stringify(e.dialogue)) : null,
+    image_url: e.image_url ?? null,
+    relics: e.relics ?? null,
+    game_version: version,
+  }));
+
+  const { error } = await supabase.from("events").upsert(rows);
+  if (error) throw error;
+  console.log(`  ✓ ${rows.length} events synced`);
+}
+
+async function syncEnchantments(version: string) {
+  console.log("Syncing enchantments...");
+  const enchantments = await fetchCodex<CodexEnchantment[]>("/enchantments");
+
+  const rows = enchantments.map((e) => ({
+    id: e.id,
+    name: e.name,
+    description: e.description,
+    description_raw: e.description_raw ?? null,
+    extra_card_text: e.extra_card_text ?? null,
+    card_type: e.card_type ?? null,
+    applicable_to: e.applicable_to ?? null,
+    is_stackable: e.is_stackable,
+    image_url: e.image_url ?? null,
+    game_version: version,
+  }));
+
+  const { error } = await supabase.from("enchantments").upsert(rows);
+  if (error) throw error;
+  console.log(`  ✓ ${rows.length} enchantments synced`);
+}
+
+async function syncPowers(version: string) {
+  console.log("Syncing powers...");
+  const powers = await fetchCodex<CodexPower[]>("/powers");
+
+  const rows = powers.map((p) => ({
+    id: p.id,
+    name: p.name,
+    description: p.description,
+    description_raw: p.description_raw ?? null,
+    type: p.type,
+    stack_type: p.stack_type ?? null,
+    allow_negative: p.allow_negative ?? null,
+    image_url: p.image_url ?? null,
+    game_version: version,
+  }));
+
+  const { error } = await supabase.from("powers").upsert(rows);
+  if (error) throw error;
+  console.log(`  ✓ ${rows.length} powers synced`);
 }
 
 async function main() {

--- a/packages/shared/supabase/helpers.ts
+++ b/packages/shared/supabase/helpers.ts
@@ -11,6 +11,12 @@ export type GameVersion = Database["public"]["Tables"]["game_versions"]["Row"];
 export type Run = Database["public"]["Tables"]["runs"]["Row"];
 export type Evaluation = Database["public"]["Tables"]["evaluations"]["Row"];
 export type Choice = Database["public"]["Tables"]["choices"]["Row"];
+export type Event = Database["public"]["Tables"]["events"]["Row"];
+export type Enchantment = Database["public"]["Tables"]["enchantments"]["Row"];
+export type Power = Database["public"]["Tables"]["powers"]["Row"];
+export type Encounter = Database["public"]["Tables"]["encounters"]["Row"];
+export type Orb = Database["public"]["Tables"]["orbs"]["Row"];
+export type Affliction = Database["public"]["Tables"]["afflictions"]["Row"];
 
 // Insert types (what you pass to inserts)
 export type CardInsert = Database["public"]["Tables"]["cards"]["Insert"];
@@ -22,6 +28,12 @@ export type CharacterInsert = Database["public"]["Tables"]["characters"]["Insert
 export type RunInsert = Database["public"]["Tables"]["runs"]["Insert"];
 export type EvaluationInsert = Database["public"]["Tables"]["evaluations"]["Insert"];
 export type ChoiceInsert = Database["public"]["Tables"]["choices"]["Insert"];
+export type EventInsert = Database["public"]["Tables"]["events"]["Insert"];
+export type EnchantmentInsert = Database["public"]["Tables"]["enchantments"]["Insert"];
+export type PowerInsert = Database["public"]["Tables"]["powers"]["Insert"];
+export type EncounterInsert = Database["public"]["Tables"]["encounters"]["Insert"];
+export type OrbInsert = Database["public"]["Tables"]["orbs"]["Insert"];
+export type AfflictionInsert = Database["public"]["Tables"]["afflictions"]["Insert"];
 
 // View types
 export type EvaluationStat = Database["public"]["Views"]["evaluation_stats"]["Row"];

--- a/packages/shared/types/database.types.ts
+++ b/packages/shared/types/database.types.ts
@@ -183,34 +183,52 @@ export type Database = {
       }
       characters: {
         Row: {
+          color: string | null
+          description: string | null
           game_version: string | null
+          gender: string | null
           id: string
+          image_url: string | null
           name: string
+          orb_slots: number | null
           starting_deck: string[] | null
           starting_energy: number
           starting_gold: number
           starting_hp: number
           starting_relics: string[] | null
+          unlocks_after: string | null
         }
         Insert: {
+          color?: string | null
+          description?: string | null
           game_version?: string | null
+          gender?: string | null
           id: string
+          image_url?: string | null
           name: string
+          orb_slots?: number | null
           starting_deck?: string[] | null
           starting_energy: number
           starting_gold: number
           starting_hp: number
           starting_relics?: string[] | null
+          unlocks_after?: string | null
         }
         Update: {
+          color?: string | null
+          description?: string | null
           game_version?: string | null
+          gender?: string | null
           id?: string
+          image_url?: string | null
           name?: string
+          orb_slots?: number | null
           starting_deck?: string[] | null
           starting_energy?: number
           starting_gold?: number
           starting_hp?: number
           starting_relics?: string[] | null
+          unlocks_after?: string | null
         }
         Relationships: [
           {
@@ -746,6 +764,285 @@ export type Database = {
           win_rate_delta?: number | null
         }
         Relationships: []
+      }
+      afflictions: {
+        Row: {
+          description: string
+          extra_card_text: string | null
+          game_version: string | null
+          id: string
+          is_stackable: boolean
+          name: string
+          updated_at: string | null
+        }
+        Insert: {
+          description: string
+          extra_card_text?: string | null
+          game_version?: string | null
+          id: string
+          is_stackable?: boolean
+          name: string
+          updated_at?: string | null
+        }
+        Update: {
+          description?: string
+          extra_card_text?: string | null
+          game_version?: string | null
+          id?: string
+          is_stackable?: boolean
+          name?: string
+          updated_at?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "afflictions_game_version_fkey"
+            columns: ["game_version"]
+            isOneToOne: false
+            referencedRelation: "game_versions"
+            referencedColumns: ["version"]
+          },
+        ]
+      }
+      enchantments: {
+        Row: {
+          applicable_to: string | null
+          card_type: string | null
+          description: string
+          description_raw: string | null
+          extra_card_text: string | null
+          game_version: string | null
+          id: string
+          image_url: string | null
+          is_stackable: boolean
+          name: string
+          updated_at: string | null
+        }
+        Insert: {
+          applicable_to?: string | null
+          card_type?: string | null
+          description: string
+          description_raw?: string | null
+          extra_card_text?: string | null
+          game_version?: string | null
+          id: string
+          image_url?: string | null
+          is_stackable?: boolean
+          name: string
+          updated_at?: string | null
+        }
+        Update: {
+          applicable_to?: string | null
+          card_type?: string | null
+          description?: string
+          description_raw?: string | null
+          extra_card_text?: string | null
+          game_version?: string | null
+          id?: string
+          image_url?: string | null
+          is_stackable?: boolean
+          name?: string
+          updated_at?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "enchantments_game_version_fkey"
+            columns: ["game_version"]
+            isOneToOne: false
+            referencedRelation: "game_versions"
+            referencedColumns: ["version"]
+          },
+        ]
+      }
+      encounters: {
+        Row: {
+          act: string | null
+          game_version: string | null
+          id: string
+          is_weak: boolean
+          loss_text: string | null
+          monsters: Json | null
+          name: string
+          room_type: string
+          tags: string[] | null
+          updated_at: string | null
+        }
+        Insert: {
+          act?: string | null
+          game_version?: string | null
+          id: string
+          is_weak?: boolean
+          loss_text?: string | null
+          monsters?: Json | null
+          name: string
+          room_type: string
+          tags?: string[] | null
+          updated_at?: string | null
+        }
+        Update: {
+          act?: string | null
+          game_version?: string | null
+          id?: string
+          is_weak?: boolean
+          loss_text?: string | null
+          monsters?: Json | null
+          name?: string
+          room_type?: string
+          tags?: string[] | null
+          updated_at?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "encounters_game_version_fkey"
+            columns: ["game_version"]
+            isOneToOne: false
+            referencedRelation: "game_versions"
+            referencedColumns: ["version"]
+          },
+        ]
+      }
+      events: {
+        Row: {
+          act: string | null
+          description: string | null
+          dialogue: Json | null
+          epithet: string | null
+          game_version: string | null
+          id: string
+          image_url: string | null
+          name: string
+          options: Json | null
+          pages: Json | null
+          preconditions: Json | null
+          relics: string[] | null
+          type: string
+          updated_at: string | null
+        }
+        Insert: {
+          act?: string | null
+          description?: string | null
+          dialogue?: Json | null
+          epithet?: string | null
+          game_version?: string | null
+          id: string
+          image_url?: string | null
+          name: string
+          options?: Json | null
+          pages?: Json | null
+          preconditions?: Json | null
+          relics?: string[] | null
+          type: string
+          updated_at?: string | null
+        }
+        Update: {
+          act?: string | null
+          description?: string | null
+          dialogue?: Json | null
+          epithet?: string | null
+          game_version?: string | null
+          id?: string
+          image_url?: string | null
+          name?: string
+          options?: Json | null
+          pages?: Json | null
+          preconditions?: Json | null
+          relics?: string[] | null
+          type?: string
+          updated_at?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "events_game_version_fkey"
+            columns: ["game_version"]
+            isOneToOne: false
+            referencedRelation: "game_versions"
+            referencedColumns: ["version"]
+          },
+        ]
+      }
+      orbs: {
+        Row: {
+          description: string
+          description_raw: string | null
+          game_version: string | null
+          id: string
+          image_url: string | null
+          name: string
+          updated_at: string | null
+        }
+        Insert: {
+          description: string
+          description_raw?: string | null
+          game_version?: string | null
+          id: string
+          image_url?: string | null
+          name: string
+          updated_at?: string | null
+        }
+        Update: {
+          description?: string
+          description_raw?: string | null
+          game_version?: string | null
+          id?: string
+          image_url?: string | null
+          name?: string
+          updated_at?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "orbs_game_version_fkey"
+            columns: ["game_version"]
+            isOneToOne: false
+            referencedRelation: "game_versions"
+            referencedColumns: ["version"]
+          },
+        ]
+      }
+      powers: {
+        Row: {
+          allow_negative: boolean | null
+          description: string
+          description_raw: string | null
+          game_version: string | null
+          id: string
+          image_url: string | null
+          name: string
+          stack_type: string | null
+          type: string
+          updated_at: string | null
+        }
+        Insert: {
+          allow_negative?: boolean | null
+          description: string
+          description_raw?: string | null
+          game_version?: string | null
+          id: string
+          image_url?: string | null
+          name: string
+          stack_type?: string | null
+          type: string
+          updated_at?: string | null
+        }
+        Update: {
+          allow_negative?: boolean | null
+          description?: string
+          description_raw?: string | null
+          game_version?: string | null
+          id?: string
+          image_url?: string | null
+          name?: string
+          stack_type?: string | null
+          type?: string
+          updated_at?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "powers_game_version_fkey"
+            columns: ["game_version"]
+            isOneToOne: false
+            referencedRelation: "game_versions"
+            referencedColumns: ["version"]
+          },
+        ]
       }
     }
     Views: {

--- a/supabase/migrations/021_complete_codex_sync.sql
+++ b/supabase/migrations/021_complete_codex_sync.sql
@@ -1,0 +1,119 @@
+-- ============================================
+-- Complete Spire Codex data sync
+-- Adds: events, enchantments, powers, encounters, orbs, afflictions
+-- Extends: characters with additional API fields
+-- ============================================
+
+-- Events (shrine events + Ancient encounters)
+create table events (
+  id text primary key,
+  name text not null,
+  type text not null,
+  act text,
+  description text,
+  preconditions jsonb,
+  options jsonb,
+  pages jsonb,
+  epithet text,
+  dialogue jsonb,
+  image_url text,
+  relics text[],
+  game_version text references game_versions(version),
+  updated_at timestamptz default now()
+);
+
+-- Enchantments (card modifiers)
+create table enchantments (
+  id text primary key,
+  name text not null,
+  description text not null,
+  description_raw text,
+  extra_card_text text,
+  card_type text,
+  applicable_to text,
+  is_stackable boolean not null default false,
+  image_url text,
+  game_version text references game_versions(version),
+  updated_at timestamptz default now()
+);
+
+-- Powers (buffs, debuffs, status effects)
+create table powers (
+  id text primary key,
+  name text not null,
+  description text not null,
+  description_raw text,
+  type text not null,
+  stack_type text,
+  allow_negative boolean,
+  image_url text,
+  game_version text references game_versions(version),
+  updated_at timestamptz default now()
+);
+
+-- Encounters (combat encounters by act/room type)
+create table encounters (
+  id text primary key,
+  name text not null,
+  room_type text not null,
+  is_weak boolean not null default false,
+  act text,
+  tags text[],
+  monsters jsonb,
+  loss_text text,
+  game_version text references game_versions(version),
+  updated_at timestamptz default now()
+);
+
+-- Orbs (Defect-specific orb types)
+create table orbs (
+  id text primary key,
+  name text not null,
+  description text not null,
+  description_raw text,
+  image_url text,
+  game_version text references game_versions(version),
+  updated_at timestamptz default now()
+);
+
+-- Afflictions (card constraints: Bound, Galvanized, etc.)
+create table afflictions (
+  id text primary key,
+  name text not null,
+  description text not null,
+  extra_card_text text,
+  is_stackable boolean not null default false,
+  game_version text references game_versions(version),
+  updated_at timestamptz default now()
+);
+
+-- Extend characters with additional API fields
+alter table characters
+  add column if not exists description text,
+  add column if not exists orb_slots int,
+  add column if not exists unlocks_after text,
+  add column if not exists gender text,
+  add column if not exists color text,
+  add column if not exists image_url text;
+
+-- ============================================
+-- RLS policies (public read, same as existing tables)
+-- ============================================
+
+alter table events enable row level security;
+create policy "Public read" on events for select using (true);
+
+alter table enchantments enable row level security;
+create policy "Public read" on enchantments for select using (true);
+
+alter table powers enable row level security;
+create policy "Public read" on powers for select using (true);
+
+alter table encounters enable row level security;
+create policy "Public read" on encounters for select using (true);
+
+alter table orbs enable row level security;
+create policy "Public read" on orbs for select using (true);
+
+alter table afflictions enable row level security;
+create policy "Public read" on afflictions for select using (true);


### PR DESCRIPTION
## Summary
- Adds 6 new Supabase tables: `events`, `enchantments`, `powers`, `encounters`, `orbs`, `afflictions`
- Extends `characters` table with `description`, `orb_slots`, `unlocks_after`, `gender`, `color`, `image_url`
- Adds sync functions for all 7 new entity types to `sync-codex.ts` (events, enchantments, powers, encounters, orbs, afflictions, characters)
- Total synced endpoints goes from 5/14 to 12/14

Closes #61

## Test plan
- [ ] Apply migration `021_complete_codex_sync.sql` to Supabase
- [ ] Run `npx tsx apps/web/src/game-data/sync-codex.ts 0.3.2` with env vars
- [ ] Verify all 12 entity types sync successfully
- [ ] Spot-check: NEOW event has `type = 'Ancient'` and 20 relics in pool
- [ ] Spot-check: GOOPY enchantment has `applicable_to = 'Defend cards'`
- [ ] Spot-check: VULNERABLE power has `type = 'Debuff'`
- [ ] Verify characters have new columns populated (description, color, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)