### PR TITLE
Add ancient-specific eval type with DB enrichment

### DIFF
--- a/apps/desktop/src/features/evaluation/eventEvalListener.ts
+++ b/apps/desktop/src/features/evaluation/eventEvalListener.ts
@@ -72,6 +72,7 @@ export function setupEventEvalListener() {
         const mapPrompt = buildEventPrompt({
           context: ctx,
           eventName: eventState.event.event_name,
+          eventId: eventState.event.event_id,
           isAncient: eventState.event.is_ancient,
           options,
           runNarrative: getPromptContext(),
@@ -85,7 +86,7 @@ export function setupEventEvalListener() {
         const raw = await listenerApi
           .dispatch(
             evaluationApi.endpoints.evaluateEvent.initiate({
-              evalType: "event",
+              evalType: eventState.event.is_ancient ? "ancient" : "event",
               context: ctx,
               runNarrative: getPromptContext(),
               mapPrompt,

--- a/apps/desktop/src/lib/eval-inputs/event.ts
+++ b/apps/desktop/src/lib/eval-inputs/event.ts
@@ -23,6 +23,7 @@ export function computeEventEvalKey(
 export function buildEventPrompt(params: {
   context: EvaluationContext;
   eventName: string;
+  eventId: string;
   isAncient: boolean;
   options: EventOption[];
   runNarrative: string | null;
@@ -45,13 +46,13 @@ export function buildEventPrompt(params: {
     })
     .join("\n");
 
-  const ancientWarning = params.isAncient
-    ? " (ANCIENT — this is an STS2-specific event. Do NOT assume you know what enchantments, relics, or effects do. Evaluate ONLY from the descriptions provided. If an option mentions an enchantment or effect you don't recognize, set confidence below 50.)"
-    : "";
+  const eventHeader = params.isAncient
+    ? `ANCIENT_EVENT_ID: ${params.eventId}\nANCIENT EVENT: ${params.eventName}`
+    : `EVENT: ${params.eventName}`;
 
   return `${contextStr}
 
-EVENT: ${params.eventName}${ancientWarning}
+${eventHeader}
 You must choose EXACTLY ONE option:
 ${optionsStr}
 

--- a/apps/web/src/app/api/evaluate/route.ts
+++ b/apps/web/src/app/api/evaluate/route.ts
@@ -146,6 +146,33 @@ type WinRateRow = {
   times_skipped: number;
 };
 
+/**
+ * Categorize an ancient event option by pattern-matching its relic description.
+ * Returns a category tag that maps to guidance in the ancient addendum.
+ */
+function categorizeAncientOption(description: string): string {
+  const lower = description.toLowerCase();
+  if (lower.includes("remove") && lower.includes("card")) return "CARD REMOVAL";
+  if (lower.includes("transform")) return "TRANSFORM";
+  if (lower.includes("raise your max hp") || lower.includes("max hp")) return "MAX HP";
+  if (lower.includes("enchant")) return "ENCHANTMENT";
+  if (
+    (lower.includes("lose") && lower.includes("gold")) ||
+    (lower.includes("gain") && lower.includes("gold"))
+  ) return "GOLD TRADE";
+  if (lower.includes("obtain") && lower.includes("relic")) return "RELIC";
+  if (
+    (lower.includes("add") && lower.includes("deck")) ||
+    (lower.includes("obtain") && lower.includes("card")) ||
+    lower.includes("card reward")
+  ) return "CARD ADD";
+  if (
+    (lower.includes("lose") && lower.includes("hp")) ||
+    (lower.includes("lose") && lower.includes("max hp"))
+  ) return "HP TRADE";
+  return "UNKNOWN";
+}
+
 interface EvaluateRequest {
   type: "card_reward" | "shop" | "map";
   evalType?: string; // Specific eval type for system prompt (rest_site, event, etc.)
@@ -246,7 +273,62 @@ export async function POST(request: Request) {
 
   // ─── MAP/EVENT/REST/ETC EVALUATION (via mapPrompt) ───
   if (type === "map" && body.mapPrompt) {
+    // Ancient event enrichment: pull relic descriptions + pool from DB
+    let ancientReference = "";
+    if (evalType === "ancient") {
+      const eventIdMatch = body.mapPrompt.match(/ANCIENT_EVENT_ID:\s*(\S+)/);
+      const eventId = eventIdMatch?.[1] ?? null;
+
+      if (eventId) {
+        try {
+          const [eventResult, relicsResult] = await Promise.all([
+            supabase
+              .from("events")
+              .select("name, act, relics")
+              .eq("id", eventId)
+              .single(),
+            supabase
+              .from("relics")
+              .select("name, description")
+              .not("description", "is", null),
+          ]);
+
+          const ancientEvent = eventResult.data;
+          const allRelics = relicsResult.data;
+
+          if (ancientEvent && allRelics) {
+            const relicMap = new Map(allRelics.map((r) => [r.name, r.description]));
+            const poolSize = ancientEvent.relics?.length ?? 0;
+
+            // Extract offered option names from the mapPrompt (format: "N. Title: Description")
+            const optionMatches = body.mapPrompt.matchAll(/^\d+\.\s+(.+?):/gm);
+            const offeredOptions: { name: string; description: string; category: string }[] = [];
+            for (const match of optionMatches) {
+              const optionName = match[1].trim();
+              const relicDesc = relicMap.get(optionName) ?? "";
+              offeredOptions.push({
+                name: optionName,
+                description: relicDesc,
+                category: categorizeAncientOption(relicDesc),
+              });
+            }
+
+            if (offeredOptions.length > 0) {
+              const optionLines = offeredOptions
+                .map((o, i) => `${i + 1}. ${o.name} — ${o.description} [${o.category}]`)
+                .join("\n");
+              ancientReference = `[Ancient: ${ancientEvent.name} | ${ancientEvent.act ?? "Unknown Act"} | Pool: ${poolSize} options]\nOffered options with categories:\n${optionLines}\n\n`;
+            }
+          }
+        } catch (err) {
+          console.error("[Evaluate] Ancient enrichment failed:", err);
+          // Non-critical — continue without enrichment
+        }
+      }
+    }
+
     let mapPromptFull = "";
+    if (ancientReference) mapPromptFull += ancientReference;
     if (runHistory) mapPromptFull += `${runHistory}\n\n`;
     if (body.runNarrative) mapPromptFull += `${body.runNarrative}\n\n`;
     if (characterStrategy) mapPromptFull += `=== BUILD GUIDE ===\n${compactStrategy(characterStrategy) ?? characterStrategy}\n\n`;

--- a/packages/shared/evaluation/prompt-builder.ts
+++ b/packages/shared/evaluation/prompt-builder.ts
@@ -36,7 +36,7 @@ CORE RULES (priority order):
 6. DUPLICATES. Second copy of a core engine card (draw, scaling, key damage) is GOOD. Second copy of a mediocre card is bad. Evaluate duplicates by card quality, not by being a duplicate.
 
 GAME FACTS:
-- STS2 has 3 acts. There is no Act 4. Gold is worthless after the Act 3 boss.
+- STS2 has 3 acts. There is no Act 4.
 - Unplayable and Curse cards are always the #1 removal priority, above Strikes.
 - Relics are vital for clearing Act 3 — maximize relic acquisition opportunities (elites, treasures, events).
 - ENCHANTED CARDS: Ancient events transform deck cards into stronger versions (e.g., Bash → Break). Evaluate the card by its DESCRIPTION, not its name. A card that "applies Vulnerable" IS a Vulnerable card regardless of its name.
@@ -108,7 +108,6 @@ REST SITE:
 EVENT:
 - HP loss: only take if reward advances win condition AND HP >60%.
 - Curse: avoid unless reward is exceptional AND removal available soon.
-- Gold: only valuable if shop is coming AND you need something from it.
 - Card transform: only if transforming a Strike/Defend.
 - Max HP: always valuable at higher ascension.`,
 

--- a/packages/shared/evaluation/prompt-builder.ts
+++ b/packages/shared/evaluation/prompt-builder.ts
@@ -17,6 +17,7 @@ export type EvalType =
   | "map"
   | "rest_site"
   | "event"
+  | "ancient"
   | "card_removal"
   | "card_upgrade"
   | "card_select"
@@ -110,6 +111,22 @@ EVENT:
 - Curse: avoid unless reward is exceptional AND removal available soon.
 - Card transform: only if transforming a Strike/Defend.
 - Max HP: always valuable at higher ascension.`,
+
+  ancient: `
+ANCIENT EVENT:
+- You MUST choose exactly one option. Evaluate all three against your current deck needs, act timing, and ascension.
+- OPTION CATEGORIES — identify each option's category tag and apply the matching framework:
+  - CARD REMOVAL (remove N cards): High priority when Strikes/Defends remain. Value decreases as deck thins. In Acts 1-2, removal is almost always the best option.
+  - GOLD TRADE (lose/gain gold): Gold buys card removal (75-100g), relics, and potions at shops. Evaluate gold loss against remaining shop opportunities. Losing 99g at Act 1 is significant — that is one card removal. Gaining 150-300g is strong if shops remain.
+  - TRANSFORM (transform N cards): Strong when transforming Strikes/Defends into random cards. Risky when transforming engine cards. Transform + upgrade is premium.
+  - MAX HP (raise max HP by N): Scales with ascension — more valuable at Ascension 8+. Always solid, never bad.
+  - RELIC (obtain random relic/specific relic): Permanent power. High priority unless the specific relic has a downside (curse, HP loss, boss relics with drawbacks).
+  - ENCHANTMENT (enchant cards with X): Archetype-dependent. Evaluate the enchantment effect against current deck composition. Strong when it enhances core cards.
+  - CARD ADD (add specific cards): Evaluate added cards the same as a card reward — do they advance the deck's win condition?
+  - HP TRADE (lose HP/Max HP for reward): Only take if reward is high-value AND current HP can absorb the cost safely.
+- Evaluate based on DESCRIPTIONS PROVIDED. Do not assume you know what an enchantment, relic, or card does beyond what the description says.
+- If unsure about an option's effect, set confidence below 50.
+- Reasoning must reference the specific trade-off: what you gain vs what you lose.`,
 
   card_removal: `
 CARD REMOVAL:


### PR DESCRIPTION
## Summary
- Removes gold language from base prompt GAME FACTS and event addendum (root cause of "Gold worthless post-Act3" hallucination)
- Adds `ancient` eval type with dedicated addendum containing category-based option guidance (CARD REMOVAL, GOLD TRADE, TRANSFORM, MAX HP, RELIC, ENCHANTMENT, CARD ADD, HP TRADE)
- Desktop passes `evalType: "ancient"` + `event_id` when evaluating ancient events
- API route enriches ancient prompts with relic descriptions and option categories from Supabase `events` + `relics` tables

Closes #63

## Test plan
- [ ] All 394 tests pass, all 3 packages type-check clean
- [ ] Start a run, trigger an ancient event — verify eval uses "ANCIENT EVENT:" addendum
- [ ] Verify reasoning references specific trade-offs, not "gold worthless" hallucinations
- [ ] Verify `[Ancient Reference]` section appears in server logs with correct categories
- [ ] Verify non-ancient events still use generic event addendum

🤖 Generated with [Claude Code](https://claude.com/claude-code)