### PR TITLE
Add community tier list signal to card evaluations

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -2,6 +2,12 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   transpilePackages: ["@sts2/shared"],
+  experimental: {
+    // Tier list admin uploads full-page screenshots which can exceed the
+    // default 10MB request body limit. Our extract route enforces a stricter
+    // per-file MIME + size check on top of this.
+    proxyClientMaxBodySize: 26_214_400, // 25 MB
+  },
 };
 
 export default nextConfig;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^3.0.67",
+    "@ai-sdk/google": "^3.0.63",
     "@sts2/shared": "workspace:*",
     "@supabase/ssr": "^0.9.0",
     "@supabase/supabase-js": "^2.100.1",

--- a/apps/web/src/app/account/page.tsx
+++ b/apps/web/src/app/account/page.tsx
@@ -7,7 +7,6 @@ import { createClient } from "@sts2/shared/supabase/client";
 
 export default function AccountPage() {
   const { user, loading, signOut } = useAuth();
-  const isDev = process.env.NODE_ENV === "development";
 
   if (loading) {
     return (
@@ -17,7 +16,7 @@ export default function AccountPage() {
     );
   }
 
-  if (!user && !isDev) {
+  if (!user) {
     return (
       <div className="min-h-screen bg-background text-foreground flex flex-col">
         <LoginScreen />

--- a/apps/web/src/app/admin/tier-lists/page.tsx
+++ b/apps/web/src/app/admin/tier-lists/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useRef, useEffect, useMemo } from "react";
 import { useAuth } from "@/features/auth/auth-provider";
 import { LoginScreen } from "@/features/auth/login-screen";
 import type { TierExtractionResult } from "@sts2/shared/evaluation/tier-extraction";
@@ -711,23 +711,14 @@ function PreviewStep({
                               {card.name}
                             </span>
                             <span className="text-xs text-orange-500/60 shrink-0">→</span>
-                            <input
-                              list={`cards-${idx}`}
+                            <CardCombobox
                               value={card.matchedName ?? ""}
-                              onChange={(e) => {
-                                const val = e.target.value;
-                                updateCard(idx, {
-                                  matchedName: cardIdMap[val] ? val : undefined,
-                                });
-                              }}
-                              placeholder="Match to card…"
-                              className={`flex-1 min-w-0 ${inputCls}`}
+                              cardIdMap={cardIdMap}
+                              defaultQuery={card.name}
+                              onChange={(name) =>
+                                updateCard(idx, { matchedName: name ?? undefined })
+                              }
                             />
-                            <datalist id={`cards-${idx}`}>
-                              {Object.keys(cardIdMap).map((name) => (
-                                <option key={name} value={name} />
-                              ))}
-                            </datalist>
                           </div>
                         )}
                         <div className="flex items-center gap-2 shrink-0">
@@ -830,6 +821,131 @@ function SuccessStep({
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
+
+// Filterable combobox for matching extracted names to canonical cards.
+// Substring match, case-insensitive, prefix matches rank first, up to 20 results.
+// Keyboard: ↑↓ navigate, Enter select, Esc close. Seeds the input with the
+// extracted name so the admin can skim matches without retyping.
+function CardCombobox({
+  value,
+  cardIdMap,
+  defaultQuery,
+  onChange,
+}: {
+  value: string;
+  cardIdMap: Record<string, string>;
+  defaultQuery?: string;
+  onChange: (name: string | null) => void;
+}) {
+  const allNames = useMemo(
+    () => Object.keys(cardIdMap).sort((a, b) => a.localeCompare(b)),
+    [cardIdMap],
+  );
+
+  const [query, setQuery] = useState(value || defaultQuery || "");
+  const [open, setOpen] = useState(false);
+  const [highlight, setHighlight] = useState(0);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Close when clicking outside
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [open]);
+
+  // Sync external value changes (e.g. "Unmatch" button)
+  useEffect(() => {
+    setQuery(value || "");
+  }, [value]);
+
+  const matches = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return allNames.slice(0, 20);
+    const prefix: string[] = [];
+    const contains: string[] = [];
+    for (const name of allNames) {
+      const lower = name.toLowerCase();
+      if (lower.startsWith(q)) prefix.push(name);
+      else if (lower.includes(q)) contains.push(name);
+    }
+    return [...prefix, ...contains].slice(0, 20);
+  }, [query, allNames]);
+
+  const commit = (name: string) => {
+    setQuery(name);
+    onChange(name);
+    setOpen(false);
+  };
+
+  const handleKey = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setOpen(true);
+      setHighlight((h) => Math.min(h + 1, matches.length - 1));
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setHighlight((h) => Math.max(h - 1, 0));
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      if (open && matches[highlight]) commit(matches[highlight]);
+    } else if (e.key === "Escape") {
+      setOpen(false);
+    }
+  };
+
+  const isValidMatch = !!cardIdMap[query];
+
+  return (
+    <div ref={containerRef} className="relative flex-1 min-w-0">
+      <input
+        type="text"
+        value={query}
+        onChange={(e) => {
+          setQuery(e.target.value);
+          setHighlight(0);
+          setOpen(true);
+          // Clear matched state if query no longer corresponds to a valid card
+          if (!cardIdMap[e.target.value] && value) onChange(null);
+        }}
+        onFocus={() => setOpen(true)}
+        onKeyDown={handleKey}
+        placeholder="Type to search cards…"
+        className={`w-full rounded border ${
+          isValidMatch
+            ? "border-emerald-600/50 bg-emerald-900/10"
+            : "border-zinc-700 bg-zinc-900"
+        } px-2 py-1 text-xs text-zinc-200 focus:outline-none focus:border-zinc-500`}
+      />
+      {open && matches.length > 0 && (
+        <ul className="absolute left-0 right-0 top-full z-10 mt-1 max-h-60 overflow-y-auto rounded-md border border-zinc-700 bg-zinc-900 shadow-lg">
+          {matches.map((name, i) => (
+            <li
+              key={name}
+              onMouseDown={(e) => {
+                e.preventDefault();
+                commit(name);
+              }}
+              onMouseEnter={() => setHighlight(i)}
+              className={`cursor-pointer px-2 py-1 text-xs ${
+                i === highlight
+                  ? "bg-zinc-800 text-zinc-100"
+                  : "text-zinc-300"
+              }`}
+            >
+              {name}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
 
 function ConfidenceBadge({ confidence }: { confidence: number }) {
   const pct = Math.round(confidence * 100);

--- a/apps/web/src/app/admin/tier-lists/page.tsx
+++ b/apps/web/src/app/admin/tier-lists/page.tsx
@@ -168,11 +168,25 @@ function TierListContent() {
     const result = data as ExtractResult;
     setExtractResult(result);
 
-    // Flatten tiers → card rows
+    // Build a normalized lookup so we can auto-match common variants
+    // (case differences, trailing "+", whitespace) without bothering the admin.
+    const normalizedLookup = new Map<string, string>();
+    for (const canonical of Object.keys(result.cardIdMap)) {
+      normalizedLookup.set(normalizeCardName(canonical), canonical);
+    }
+
+    // Flatten tiers → card rows. Auto-populate matchedName for fuzzy matches
+    // so the admin only has to resolve truly unknown cards.
     const flat: ExtractedCard[] = [];
     for (const tier of result.extraction.tiers ?? []) {
       for (const card of tier.cards) {
-        flat.push({ name: card.name, tier: tier.label, confidence: card.confidence });
+        const matched = resolveExtractedName(card.name, result.cardIdMap, normalizedLookup);
+        flat.push({
+          name: card.name,
+          tier: tier.label,
+          confidence: card.confidence,
+          matchedName: matched && matched !== card.name ? matched : undefined,
+        });
       }
     }
     setCards(flat);
@@ -899,6 +913,31 @@ function CheckIcon() {
       <polyline points="20 6 9 17 4 12" />
     </svg>
   );
+}
+
+// Normalize a card name for fuzzy matching: lowercase, strip trailing "+"
+// variants, collapse whitespace. Used to auto-resolve OCR/casing drift
+// from the extracted text against the canonical cardIdMap.
+function normalizeCardName(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/\+/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+// Resolve an extracted name to a canonical one via:
+//   1. Exact match against cardIdMap (return as-is, no matchedName needed)
+//   2. Normalized match against the pre-built lookup (return canonical)
+// Returns null when no match is found — card goes to the unmatched section.
+function resolveExtractedName(
+  extracted: string,
+  cardIdMap: Record<string, string>,
+  normalizedLookup: Map<string, string>,
+): string | null {
+  if (cardIdMap[extracted]) return extracted;
+  const canonical = normalizedLookup.get(normalizeCardName(extracted));
+  return canonical ?? null;
 }
 
 // Resize an image file so its longest edge is at most `maxEdge` pixels,

--- a/apps/web/src/app/admin/tier-lists/page.tsx
+++ b/apps/web/src/app/admin/tier-lists/page.tsx
@@ -126,11 +126,16 @@ export default function TierListIngestionPage() {
 // ── Main content ──────────────────────────────────────────────────────────────
 
 function TierListContent() {
-  const [step, setStep] = useState<Step>("upload");
-  const [meta, setMeta] = useState<SourceMeta>(defaultMeta);
+  // Lazy init from localStorage so a page reload (HMR, accidental close)
+  // restores an in-progress extraction without re-running the upload.
+  const draft = typeof window !== "undefined" ? loadDraft() : null;
+  const [step, setStep] = useState<Step>(draft?.step ?? "upload");
+  const [meta, setMeta] = useState<SourceMeta>(draft?.meta ?? defaultMeta);
   const [imageFile, setImageFile] = useState<File | null>(null);
-  const [extractResult, setExtractResult] = useState<ExtractResult | null>(null);
-  const [cards, setCards] = useState<ExtractedCard[]>([]);
+  const [extractResult, setExtractResult] = useState<ExtractResult | null>(
+    draft?.extractResult ?? null,
+  );
+  const [cards, setCards] = useState<ExtractedCard[]>(draft?.cards ?? []);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [savedCount, setSavedCount] = useState(0);
@@ -263,6 +268,7 @@ function TierListContent() {
     setRefreshWarning(data.refreshWarning ?? null);
     setStep("success");
     setSubmitting(false);
+    clearDraft();
   };
 
   // ── Step 3: Reset ───────────────────────────────────────────────────────────
@@ -276,7 +282,17 @@ function TierListContent() {
     setError(null);
     setSavedCount(0);
     setRefreshWarning(null);
+    clearDraft();
   };
+
+  // Persist in-progress extraction draft so page reloads / HMR don't
+  // wipe out an extraction the admin is mid-way through reviewing.
+  // Only persist when there's actual extraction state to save.
+  useEffect(() => {
+    if (step === "preview" && extractResult) {
+      saveDraft({ step, meta, extractResult, cards });
+    }
+  }, [step, meta, extractResult, cards]);
 
   return (
     <div className="min-h-screen bg-background text-foreground">
@@ -323,6 +339,7 @@ function TierListContent() {
             submitting={submitting}
             onCardsChange={setCards}
             onBack={() => setStep("upload")}
+            onDiscard={handleReset}
             onConfirm={handleConfirm}
           />
         )}
@@ -524,6 +541,7 @@ function PreviewStep({
   submitting,
   onCardsChange,
   onBack,
+  onDiscard,
   onConfirm,
 }: {
   meta: SourceMeta;
@@ -532,6 +550,7 @@ function PreviewStep({
   submitting: boolean;
   onCardsChange: (cards: ExtractedCard[]) => void;
   onBack: () => void;
+  onDiscard: () => void;
   onConfirm: () => void;
 }) {
   const { extraction, imageUrl, cardIdMap } = result;
@@ -575,7 +594,20 @@ function PreviewStep({
   return (
     <div className="space-y-6">
       <div className="flex items-center justify-between">
-        <h2 className="text-lg font-semibold text-zinc-100">Review Extraction</h2>
+        <div>
+          <h2 className="text-lg font-semibold text-zinc-100">Review Extraction</h2>
+          <p className="text-xs text-zinc-500 mt-0.5">
+            Draft auto-saved — safe to reload.{" "}
+            <button
+              onClick={() => {
+                if (confirm("Discard the current extraction draft?")) onDiscard();
+              }}
+              className="text-zinc-500 hover:text-red-400 underline-offset-2 hover:underline transition-colors"
+            >
+              Discard
+            </button>
+          </p>
+        </div>
         <div className="flex gap-2">
           <button
             onClick={onBack}
@@ -1000,6 +1032,49 @@ function CheckIcon() {
       <polyline points="20 6 9 17 4 12" />
     </svg>
   );
+}
+
+// Persist in-progress extraction drafts to localStorage. The image lives
+// in Supabase Storage so only its URL needs to be persisted — no binary
+// data. Versioned key so schema changes don't resurrect stale drafts.
+const DRAFT_KEY = "sts2-tier-list-draft-v1";
+
+interface Draft {
+  step: Step;
+  meta: SourceMeta;
+  extractResult: ExtractResult;
+  cards: ExtractedCard[];
+}
+
+function loadDraft(): Draft | null {
+  try {
+    const raw = localStorage.getItem(DRAFT_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Draft;
+    // Minimal sanity check — require the shape we need to render preview
+    if (!parsed.extractResult?.imageUrl || !Array.isArray(parsed.cards)) {
+      return null;
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+function saveDraft(draft: Draft): void {
+  try {
+    localStorage.setItem(DRAFT_KEY, JSON.stringify(draft));
+  } catch {
+    // Quota exceeded or storage unavailable — not critical, skip silently
+  }
+}
+
+function clearDraft(): void {
+  try {
+    localStorage.removeItem(DRAFT_KEY);
+  } catch {
+    // Ignore
+  }
 }
 
 // Normalize a card name for fuzzy matching: lowercase, strip trailing "+"

--- a/apps/web/src/app/admin/tier-lists/page.tsx
+++ b/apps/web/src/app/admin/tier-lists/page.tsx
@@ -1078,13 +1078,19 @@ function clearDraft(): void {
   }
 }
 
-// Normalize a card name for fuzzy matching: lowercase, strip trailing "+"
-// variants, collapse whitespace. Used to auto-resolve OCR/casing drift
-// from the extracted text against the canonical cardIdMap.
+// Normalize a card name for fuzzy matching. Common OCR / source-format drift
+// that should still match the canonical entry:
+//   - Casing ("Pact's End" vs "pact's end")
+//   - Upgraded variants ("Strike+" vs "Strike")
+//   - Apostrophes dropped by OCR ("Pacts End" vs "Pact's End")
+//   - Hyphen/en-dash variants
+//   - Extra whitespace
+// We strip all non-alphanumeric characters (except spaces) to canonicalize.
 function normalizeCardName(name: string): string {
   return name
     .toLowerCase()
     .replace(/\+/g, "")
+    .replace(/[^a-z0-9\s]/g, "") // drop apostrophes, hyphens, punctuation
     .replace(/\s+/g, " ")
     .trim();
 }

--- a/apps/web/src/app/admin/tier-lists/page.tsx
+++ b/apps/web/src/app/admin/tier-lists/page.tsx
@@ -150,9 +150,10 @@ function TierListContent() {
     setSubmitting(true);
     setError(null);
 
-    // Downscale full-page screenshots before upload. Gemini is happy with
-    // 2048px long-edge and this cuts 15MB screenshots to ~1-2MB.
-    const uploadFile = await downscaleImage(imageFile, 2048);
+    // Prepare image for upload — preserves original when under Gemini's
+    // 20MB cap, otherwise lossless-resizes to 3000px long-edge (enough
+    // pixels for card-name OCR on dense grids). No lossy compression.
+    const uploadFile = await downscaleImage(imageFile, 3000);
 
     const formData = new FormData();
     formData.append("image", uploadFile);
@@ -1102,11 +1103,22 @@ function resolveExtractedName(
   return canonical ?? null;
 }
 
-// Resize an image file so its longest edge is at most `maxEdge` pixels,
-// re-encoding as JPEG at 0.92 quality. Skips re-encoding if the image is
-// already smaller than the target and the source is PNG/JPEG (keeps the
-// original to preserve transparency on PNG).
+// Prepare a tier list screenshot for upload without sacrificing text quality.
+// Card name OCR is the bottleneck — lossy compression softens text edges
+// and hurts extraction accuracy, so we avoid it whenever possible.
+//
+// Strategy:
+//   1. File is small enough → send as-is (no processing, no quality loss).
+//   2. Dimensions are too large → lossless resize via canvas, output as PNG.
+//   3. Source is something else weird → fall through and send the original.
+//
+// We never use JPEG here — tier list text would suffer.
 async function downscaleImage(file: File, maxEdge: number): Promise<File> {
+  const MAX_SIZE_NO_TOUCH = 20 * 1024 * 1024; // 20MB — Gemini's per-image cap
+
+  // Fast path: file is already under Gemini's limit, don't re-encode.
+  if (file.size <= MAX_SIZE_NO_TOUCH) return file;
+
   const bitmap = await createImageBitmap(file);
   const { width, height } = bitmap;
   const longest = Math.max(width, height);
@@ -1128,16 +1140,21 @@ async function downscaleImage(file: File, maxEdge: number): Promise<File> {
     bitmap.close();
     return file;
   }
+  // High-quality downscale for text legibility
+  ctx.imageSmoothingEnabled = true;
+  ctx.imageSmoothingQuality = "high";
   ctx.drawImage(bitmap, 0, 0, targetW, targetH);
   bitmap.close();
 
+  // Lossless PNG preserves text edges — size cost is acceptable at these
+  // dimensions and we've already resized so it won't be huge.
   const blob = await new Promise<Blob | null>((resolve) =>
-    canvas.toBlob(resolve, "image/jpeg", 0.92),
+    canvas.toBlob(resolve, "image/png"),
   );
   if (!blob) return file;
 
-  return new File([blob], file.name.replace(/\.\w+$/, ".jpg"), {
-    type: "image/jpeg",
+  return new File([blob], file.name.replace(/\.\w+$/, ".png"), {
+    type: "image/png",
     lastModified: Date.now(),
   });
 }

--- a/apps/web/src/app/admin/tier-lists/page.tsx
+++ b/apps/web/src/app/admin/tier-lists/page.tsx
@@ -145,8 +145,12 @@ function TierListContent() {
     setSubmitting(true);
     setError(null);
 
+    // Downscale full-page screenshots before upload. Gemini is happy with
+    // 2048px long-edge and this cuts 15MB screenshots to ~1-2MB.
+    const uploadFile = await downscaleImage(imageFile, 2048);
+
     const formData = new FormData();
-    formData.append("image", imageFile);
+    formData.append("image", uploadFile);
 
     const res = await fetch("/api/admin/tier-lists/extract", {
       method: "POST",
@@ -895,4 +899,44 @@ function CheckIcon() {
       <polyline points="20 6 9 17 4 12" />
     </svg>
   );
+}
+
+// Resize an image file so its longest edge is at most `maxEdge` pixels,
+// re-encoding as JPEG at 0.92 quality. Skips re-encoding if the image is
+// already smaller than the target and the source is PNG/JPEG (keeps the
+// original to preserve transparency on PNG).
+async function downscaleImage(file: File, maxEdge: number): Promise<File> {
+  const bitmap = await createImageBitmap(file);
+  const { width, height } = bitmap;
+  const longest = Math.max(width, height);
+
+  if (longest <= maxEdge) {
+    bitmap.close();
+    return file;
+  }
+
+  const scale = maxEdge / longest;
+  const targetW = Math.round(width * scale);
+  const targetH = Math.round(height * scale);
+
+  const canvas = document.createElement("canvas");
+  canvas.width = targetW;
+  canvas.height = targetH;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) {
+    bitmap.close();
+    return file;
+  }
+  ctx.drawImage(bitmap, 0, 0, targetW, targetH);
+  bitmap.close();
+
+  const blob = await new Promise<Blob | null>((resolve) =>
+    canvas.toBlob(resolve, "image/jpeg", 0.92),
+  );
+  if (!blob) return file;
+
+  return new File([blob], file.name.replace(/\.\w+$/, ".jpg"), {
+    type: "image/jpeg",
+    lastModified: Date.now(),
+  });
 }

--- a/apps/web/src/app/admin/tier-lists/page.tsx
+++ b/apps/web/src/app/admin/tier-lists/page.tsx
@@ -1,0 +1,743 @@
+"use client";
+
+import { useState } from "react";
+import { useAuth } from "@/features/auth/auth-provider";
+import { LoginScreen } from "@/features/auth/login-screen";
+import type { TierExtractionResult } from "@sts2/shared/evaluation/tier-extraction";
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+type SourceType = "image" | "spreadsheet" | "website" | "reddit" | "youtube";
+type ScaleType = "letter_6" | "letter_5" | "numeric_10" | "numeric_5" | "binary";
+type Character = "any" | "ironclad" | "silent" | "defect" | "regent" | "necrobinder";
+
+interface SourceMeta {
+  id: string;
+  author: string;
+  source_type: SourceType;
+  source_url: string;
+  trust_weight: number;
+  scale_type: ScaleType;
+  character: Character;
+  game_version: string;
+  published_at: string;
+}
+
+interface ExtractedCard {
+  name: string;
+  tier: string;
+  confidence: number;
+}
+
+interface ExtractResult {
+  imageUrl: string;
+  extraction: TierExtractionResult;
+  cardIdMap: Record<string, string>;
+}
+
+type Step = "upload" | "preview" | "success";
+
+// ── Default form values ───────────────────────────────────────────────────────
+
+const defaultMeta: SourceMeta = {
+  id: "",
+  author: "",
+  source_type: "image",
+  source_url: "",
+  trust_weight: 1.0,
+  scale_type: "letter_6",
+  character: "any",
+  game_version: "",
+  published_at: new Date().toISOString().split("T")[0],
+};
+
+// ── Page shell ────────────────────────────────────────────────────────────────
+
+export default function TierListIngestionPage() {
+  const { user, loading } = useAuth();
+  const isDev = process.env.NODE_ENV === "development";
+
+  if (loading) {
+    return (
+      <div className="flex flex-1 items-center justify-center min-h-screen bg-background text-foreground">
+        <p className="text-sm text-zinc-500">Loading...</p>
+      </div>
+    );
+  }
+
+  if (!user && !isDev) {
+    return (
+      <div className="min-h-screen bg-background text-foreground flex flex-col">
+        <LoginScreen />
+      </div>
+    );
+  }
+
+  return <TierListContent />;
+}
+
+// ── Main content ──────────────────────────────────────────────────────────────
+
+function TierListContent() {
+  const [step, setStep] = useState<Step>("upload");
+  const [meta, setMeta] = useState<SourceMeta>(defaultMeta);
+  const [imageFile, setImageFile] = useState<File | null>(null);
+  const [extractResult, setExtractResult] = useState<ExtractResult | null>(null);
+  const [cards, setCards] = useState<ExtractedCard[]>([]);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [savedCount, setSavedCount] = useState(0);
+
+  // ── Step 1: Extract ─────────────────────────────────────────────────────────
+
+  const handleExtract = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!imageFile) return;
+
+    setSubmitting(true);
+    setError(null);
+
+    const formData = new FormData();
+    formData.append("image", imageFile);
+
+    const res = await fetch("/api/admin/tier-lists/extract", {
+      method: "POST",
+      body: formData,
+    });
+
+    const data = await res.json();
+
+    if (!res.ok) {
+      setError(data.error ?? "Extraction failed");
+      setSubmitting(false);
+      return;
+    }
+
+    const result = data as ExtractResult;
+    setExtractResult(result);
+
+    // Flatten tiers → card rows
+    const flat: ExtractedCard[] = [];
+    for (const tier of result.extraction.tiers ?? []) {
+      for (const card of tier.cards) {
+        flat.push({ name: card.name, tier: tier.label, confidence: card.confidence });
+      }
+    }
+    setCards(flat);
+    setStep("preview");
+    setSubmitting(false);
+  };
+
+  // ── Step 2: Confirm ─────────────────────────────────────────────────────────
+
+  const handleConfirm = async () => {
+    if (!extractResult) return;
+
+    setSubmitting(true);
+    setError(null);
+
+    const { cardIdMap, imageUrl } = extractResult;
+    const skipped: string[] = [];
+
+    const entries = cards
+      .map((c) => {
+        const card_id = cardIdMap[c.name];
+        if (!card_id) {
+          skipped.push(c.name);
+          return null;
+        }
+        return {
+          card_id,
+          raw_tier: c.tier,
+          extraction_confidence: c.confidence,
+        };
+      })
+      .filter((e): e is NonNullable<typeof e> => e !== null);
+
+    if (skipped.length > 0) {
+      console.warn("[TierListIngestion] Skipped unresolved cards:", skipped);
+    }
+
+    const body = {
+      imageUrl,
+      source: {
+        id: meta.id,
+        author: meta.author,
+        source_type: meta.source_type,
+        source_url: meta.source_url || null,
+        trust_weight: meta.trust_weight,
+        scale_type: meta.scale_type,
+        scale_config: null,
+        notes: null,
+      },
+      list: {
+        game_version: meta.game_version || null,
+        published_at: meta.published_at,
+        character: meta.character === "any" ? null : meta.character,
+      },
+      entries,
+    };
+
+    const res = await fetch("/api/admin/tier-lists/confirm", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+
+    const data = await res.json();
+
+    if (!res.ok) {
+      setError(data.error ?? "Save failed");
+      setSubmitting(false);
+      return;
+    }
+
+    setSavedCount(data.entry_count ?? entries.length);
+    setStep("success");
+    setSubmitting(false);
+  };
+
+  // ── Step 3: Reset ───────────────────────────────────────────────────────────
+
+  const handleReset = () => {
+    setStep("upload");
+    setMeta(defaultMeta);
+    setImageFile(null);
+    setExtractResult(null);
+    setCards([]);
+    setError(null);
+    setSavedCount(0);
+  };
+
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      <header className="border-b border-zinc-800 px-6 py-3">
+        <div className="flex items-center justify-between max-w-4xl mx-auto">
+          <div className="flex items-center gap-4">
+            <a
+              href="/"
+              className="text-sm font-semibold text-zinc-100 tracking-tight hover:text-zinc-300 transition-colors"
+            >
+              STS2 Replay
+            </a>
+            <div className="h-4 w-px bg-zinc-800" />
+            <span className="text-sm font-medium text-zinc-300">Admin</span>
+            <div className="h-4 w-px bg-zinc-800" />
+            <span className="text-sm text-zinc-500">Tier List Ingestion</span>
+          </div>
+        </div>
+      </header>
+
+      <main className="max-w-4xl mx-auto p-6 space-y-6">
+        {error && (
+          <div className="rounded-md border border-red-500/30 bg-red-500/10 px-4 py-3">
+            <p className="text-sm text-red-400">{error}</p>
+          </div>
+        )}
+
+        {step === "upload" && (
+          <UploadStep
+            meta={meta}
+            imageFile={imageFile}
+            submitting={submitting}
+            onMetaChange={setMeta}
+            onImageChange={setImageFile}
+            onSubmit={handleExtract}
+          />
+        )}
+
+        {step === "preview" && extractResult && (
+          <PreviewStep
+            meta={meta}
+            result={extractResult}
+            cards={cards}
+            submitting={submitting}
+            onCardsChange={setCards}
+            onBack={() => setStep("upload")}
+            onConfirm={handleConfirm}
+          />
+        )}
+
+        {step === "success" && (
+          <SuccessStep count={savedCount} onReset={handleReset} />
+        )}
+      </main>
+    </div>
+  );
+}
+
+// ── Step 1: Upload form ───────────────────────────────────────────────────────
+
+function UploadStep({
+  meta,
+  imageFile,
+  submitting,
+  onMetaChange,
+  onImageChange,
+  onSubmit,
+}: {
+  meta: SourceMeta;
+  imageFile: File | null;
+  submitting: boolean;
+  onMetaChange: (m: SourceMeta) => void;
+  onImageChange: (f: File | null) => void;
+  onSubmit: (e: React.FormEvent) => void;
+}) {
+  const set = <K extends keyof SourceMeta>(k: K, v: SourceMeta[K]) =>
+    onMetaChange({ ...meta, [k]: v });
+
+  const inputCls =
+    "w-full rounded-md border border-zinc-800 bg-zinc-900 px-3 py-2 text-sm text-zinc-200 placeholder-zinc-600 focus:outline-none focus:border-zinc-600";
+  const labelCls = "text-sm text-zinc-400";
+
+  return (
+    <form onSubmit={onSubmit} className="space-y-6">
+      <h2 className="text-lg font-semibold text-zinc-100">Ingest Tier List</h2>
+
+      {/* Image upload */}
+      <section className="rounded-lg border border-zinc-800 bg-zinc-950 p-4 space-y-3">
+        <h3 className="text-sm font-medium text-zinc-300">Image</h3>
+        <div>
+          <label className={labelCls}>Tier list image</label>
+          <input
+            type="file"
+            accept="image/*"
+            required
+            onChange={(e) => onImageChange(e.target.files?.[0] ?? null)}
+            className="mt-1 block w-full text-sm text-zinc-400 file:mr-3 file:rounded-md file:border-0 file:bg-zinc-800 file:px-3 file:py-1.5 file:text-sm file:text-zinc-300 hover:file:bg-zinc-700 cursor-pointer"
+          />
+        </div>
+        {imageFile && (
+          <p className="text-xs text-zinc-500">{imageFile.name}</p>
+        )}
+      </section>
+
+      {/* Source metadata */}
+      <section className="rounded-lg border border-zinc-800 bg-zinc-950 p-4 space-y-4">
+        <h3 className="text-sm font-medium text-zinc-300">Source Metadata</h3>
+
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <label className={labelCls}>Source ID (slug)</label>
+            <input
+              type="text"
+              required
+              value={meta.id}
+              onChange={(e) => set("id", e.target.value)}
+              placeholder="e.g. alphabetical-ironclad-v035"
+              className={`mt-1 ${inputCls}`}
+            />
+          </div>
+          <div>
+            <label className={labelCls}>Author</label>
+            <input
+              type="text"
+              required
+              value={meta.author}
+              onChange={(e) => set("author", e.target.value)}
+              placeholder="e.g. alphabetical"
+              className={`mt-1 ${inputCls}`}
+            />
+          </div>
+        </div>
+
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <label className={labelCls}>Source Type</label>
+            <select
+              value={meta.source_type}
+              onChange={(e) => set("source_type", e.target.value as SourceType)}
+              className={`mt-1 ${inputCls}`}
+            >
+              <option value="image">Image</option>
+              <option value="spreadsheet">Spreadsheet</option>
+              <option value="website">Website</option>
+              <option value="reddit">Reddit</option>
+              <option value="youtube">YouTube</option>
+            </select>
+          </div>
+          <div>
+            <label className={labelCls}>Source URL (optional)</label>
+            <input
+              type="url"
+              value={meta.source_url}
+              onChange={(e) => set("source_url", e.target.value)}
+              placeholder="https://..."
+              className={`mt-1 ${inputCls}`}
+            />
+          </div>
+        </div>
+
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <label className={labelCls}>Trust Weight (0–2)</label>
+            <input
+              type="number"
+              min={0}
+              max={2}
+              step={0.1}
+              value={meta.trust_weight}
+              onChange={(e) => set("trust_weight", parseFloat(e.target.value))}
+              className={`mt-1 ${inputCls}`}
+            />
+          </div>
+          <div>
+            <label className={labelCls}>Scale Type</label>
+            <select
+              value={meta.scale_type}
+              onChange={(e) => set("scale_type", e.target.value as ScaleType)}
+              className={`mt-1 ${inputCls}`}
+            >
+              <option value="letter_6">Letter 6 (S/A/B/C/D/F)</option>
+              <option value="letter_5">Letter 5 (S/A/B/C/D)</option>
+              <option value="numeric_10">Numeric 10 (1–10)</option>
+              <option value="numeric_5">Numeric 5 (1–5)</option>
+              <option value="binary">Binary (good/bad)</option>
+            </select>
+          </div>
+        </div>
+      </section>
+
+      {/* List metadata */}
+      <section className="rounded-lg border border-zinc-800 bg-zinc-950 p-4 space-y-4">
+        <h3 className="text-sm font-medium text-zinc-300">List Metadata</h3>
+
+        <div className="grid grid-cols-3 gap-4">
+          <div>
+            <label className={labelCls}>Character</label>
+            <select
+              value={meta.character}
+              onChange={(e) => set("character", e.target.value as Character)}
+              className={`mt-1 ${inputCls}`}
+            >
+              <option value="any">(Any / cross-character)</option>
+              <option value="ironclad">Ironclad</option>
+              <option value="silent">Silent</option>
+              <option value="defect">Defect</option>
+              <option value="regent">Regent</option>
+              <option value="necrobinder">Necrobinder</option>
+            </select>
+          </div>
+          <div>
+            <label className={labelCls}>Game Version</label>
+            <input
+              type="text"
+              value={meta.game_version}
+              onChange={(e) => set("game_version", e.target.value)}
+              placeholder="e.g. 0.3.5"
+              className={`mt-1 ${inputCls}`}
+            />
+          </div>
+          <div>
+            <label className={labelCls}>Published Date</label>
+            <input
+              type="date"
+              required
+              value={meta.published_at}
+              onChange={(e) => set("published_at", e.target.value)}
+              className={`mt-1 ${inputCls}`}
+            />
+          </div>
+        </div>
+      </section>
+
+      <div className="flex justify-end">
+        <button
+          type="submit"
+          disabled={submitting || !imageFile}
+          className="rounded-md bg-emerald-600 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-500 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {submitting ? "Extracting..." : "Extract Tiers"}
+        </button>
+      </div>
+    </form>
+  );
+}
+
+// ── Step 2: Preview ───────────────────────────────────────────────────────────
+
+function PreviewStep({
+  meta,
+  result,
+  cards,
+  submitting,
+  onCardsChange,
+  onBack,
+  onConfirm,
+}: {
+  meta: SourceMeta;
+  result: ExtractResult;
+  cards: ExtractedCard[];
+  submitting: boolean;
+  onCardsChange: (cards: ExtractedCard[]) => void;
+  onBack: () => void;
+  onConfirm: () => void;
+}) {
+  const { extraction, imageUrl, cardIdMap } = result;
+
+  const removeCard = (idx: number) =>
+    onCardsChange(cards.filter((_, i) => i !== idx));
+
+  // Group cards by tier for display
+  const byTier = cards.reduce<Record<string, ExtractedCard[]>>((acc, card) => {
+    acc[card.tier] = acc[card.tier] ?? [];
+    acc[card.tier].push(card);
+    return acc;
+  }, {});
+
+  const unresolvedNames = cards
+    .filter((c) => !cardIdMap[c.name])
+    .map((c) => c.name);
+
+  const detectedScale = extraction.detected_scale;
+  const detectedCharacter = extraction.detected_character;
+  const scaleMismatch =
+    detectedScale && detectedScale !== meta.scale_type;
+  const characterMismatch =
+    detectedCharacter &&
+    meta.character !== "any" &&
+    detectedCharacter.toLowerCase() !== meta.character;
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-semibold text-zinc-100">Review Extraction</h2>
+        <div className="flex gap-2">
+          <button
+            onClick={onBack}
+            disabled={submitting}
+            className="rounded-md border border-zinc-800 px-4 py-2 text-sm text-zinc-300 hover:border-zinc-600 transition-colors disabled:opacity-50"
+          >
+            Back
+          </button>
+          <button
+            onClick={onConfirm}
+            disabled={submitting || cards.length === 0}
+            className="rounded-md bg-emerald-600 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-500 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {submitting ? "Saving..." : `Confirm & Save (${cards.length} cards)`}
+          </button>
+        </div>
+      </div>
+
+      {/* Warnings */}
+      {extraction.warnings && extraction.warnings.length > 0 && (
+        <div className="rounded-md border border-yellow-500/30 bg-yellow-500/10 px-4 py-3 space-y-1">
+          <p className="text-xs font-medium text-yellow-400 uppercase tracking-wide">
+            Extraction Warnings
+          </p>
+          {extraction.warnings.map((w, i) => (
+            <p key={i} className="text-sm text-yellow-300">
+              {w}
+            </p>
+          ))}
+        </div>
+      )}
+
+      {/* Scale / character mismatch notices */}
+      {(scaleMismatch || characterMismatch) && (
+        <div className="rounded-md border border-yellow-500/30 bg-yellow-500/10 px-4 py-3 space-y-1">
+          <p className="text-xs font-medium text-yellow-400 uppercase tracking-wide">
+            Detection Mismatch
+          </p>
+          {scaleMismatch && (
+            <p className="text-sm text-yellow-300">
+              Detected scale <strong>{detectedScale}</strong> differs from form
+              value <strong>{meta.scale_type}</strong>. Using form value.
+            </p>
+          )}
+          {characterMismatch && (
+            <p className="text-sm text-yellow-300">
+              Detected character <strong>{detectedCharacter}</strong> differs
+              from form value <strong>{meta.character}</strong>. Using form
+              value.
+            </p>
+          )}
+        </div>
+      )}
+
+      {/* Unresolved cards warning */}
+      {unresolvedNames.length > 0 && (
+        <div className="rounded-md border border-orange-500/30 bg-orange-500/10 px-4 py-3 space-y-1">
+          <p className="text-xs font-medium text-orange-400 uppercase tracking-wide">
+            Unresolved Cards ({unresolvedNames.length})
+          </p>
+          <p className="text-sm text-orange-300">
+            These cards were not found in the card database and will be skipped:{" "}
+            {unresolvedNames.join(", ")}
+          </p>
+        </div>
+      )}
+
+      <div className="grid grid-cols-[1fr_2fr] gap-6">
+        {/* Uploaded image */}
+        <div className="space-y-2">
+          <p className="text-xs text-zinc-500 uppercase tracking-wide">
+            Source Image
+          </p>
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={imageUrl}
+            alt="Uploaded tier list"
+            className="w-full rounded-md border border-zinc-800 object-contain max-h-[600px]"
+          />
+          <div className="rounded-md border border-zinc-800 bg-zinc-950 p-3 space-y-1 text-xs text-zinc-500">
+            <p>
+              <span className="text-zinc-400">Detected scale:</span>{" "}
+              {detectedScale ?? "—"}
+            </p>
+            <p>
+              <span className="text-zinc-400">Detected character:</span>{" "}
+              {detectedCharacter ?? "—"}
+            </p>
+            <p>
+              <span className="text-zinc-400">Total extracted:</span>{" "}
+              {cards.length} cards
+            </p>
+          </div>
+        </div>
+
+        {/* Card list grouped by tier */}
+        <div className="space-y-4">
+          <p className="text-xs text-zinc-500 uppercase tracking-wide">
+            Extracted Tiers
+          </p>
+          {Object.entries(byTier).map(([tier, tierCards]) => (
+            <div key={tier} className="rounded-lg border border-zinc-800 bg-zinc-950 overflow-hidden">
+              <div className="px-3 py-2 border-b border-zinc-800 bg-zinc-900">
+                <span className="text-sm font-semibold text-zinc-100">
+                  Tier {tier}
+                </span>
+                <span className="ml-2 text-xs text-zinc-500">
+                  {tierCards.length} cards
+                </span>
+              </div>
+              <div className="divide-y divide-zinc-900">
+                {tierCards.map((card) => {
+                  const globalIdx = cards.indexOf(card);
+                  const isUnresolved = !cardIdMap[card.name];
+                  return (
+                    <div
+                      key={`${tier}-${card.name}`}
+                      className="flex items-center justify-between px-3 py-2 hover:bg-zinc-900/50 transition-colors"
+                    >
+                      <div className="flex items-center gap-3 min-w-0">
+                        <span
+                          className={`text-sm truncate ${isUnresolved ? "text-orange-400" : "text-zinc-200"}`}
+                        >
+                          {card.name}
+                          {isUnresolved && (
+                            <span className="ml-1 text-xs text-orange-500">
+                              (unresolved)
+                            </span>
+                          )}
+                        </span>
+                      </div>
+                      <div className="flex items-center gap-3 shrink-0">
+                        <ConfidenceBadge confidence={card.confidence} />
+                        <button
+                          onClick={() => removeCard(globalIdx)}
+                          className="text-zinc-600 hover:text-red-400 transition-colors"
+                          aria-label={`Remove ${card.name}`}
+                        >
+                          <TrashIcon />
+                        </button>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          ))}
+
+          {cards.length === 0 && (
+            <div className="rounded-lg border border-zinc-800 bg-zinc-950 px-4 py-8 text-center">
+              <p className="text-sm text-zinc-500">No cards remaining.</p>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── Step 3: Success ───────────────────────────────────────────────────────────
+
+function SuccessStep({ count, onReset }: { count: number; onReset: () => void }) {
+  return (
+    <div className="flex flex-col items-center justify-center py-24 space-y-6">
+      <div className="rounded-full bg-emerald-500/10 border border-emerald-500/30 p-6">
+        <CheckIcon />
+      </div>
+      <div className="text-center space-y-2">
+        <h2 className="text-xl font-semibold text-zinc-100">Tier list saved</h2>
+        <p className="text-sm text-zinc-400">
+          {count} {count === 1 ? "entry" : "entries"} persisted to the database.
+        </p>
+      </div>
+      <button
+        onClick={onReset}
+        className="rounded-md bg-emerald-600 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-500 transition-colors"
+      >
+        Ingest another
+      </button>
+    </div>
+  );
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function ConfidenceBadge({ confidence }: { confidence: number }) {
+  const pct = Math.round(confidence * 100);
+  const cls =
+    confidence >= 0.9
+      ? "text-emerald-400 bg-emerald-500/10"
+      : confidence >= 0.7
+        ? "text-yellow-400 bg-yellow-500/10"
+        : "text-red-400 bg-red-500/10";
+  return (
+    <span className={`text-xs font-mono px-1.5 py-0.5 rounded ${cls}`}>
+      {pct}%
+    </span>
+  );
+}
+
+function TrashIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <polyline points="3 6 5 6 21 6" />
+      <path d="M19 6l-1 14a2 2 0 01-2 2H8a2 2 0 01-2-2L5 6" />
+      <path d="M10 11v6M14 11v6" />
+      <path d="M9 6V4a1 1 0 011-1h4a1 1 0 011 1v2" />
+    </svg>
+  );
+}
+
+function CheckIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="32"
+      height="32"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="text-emerald-400"
+    >
+      <polyline points="20 6 9 17 4 12" />
+    </svg>
+  );
+}

--- a/apps/web/src/app/admin/tier-lists/page.tsx
+++ b/apps/web/src/app/admin/tier-lists/page.tsx
@@ -12,7 +12,6 @@ type ScaleType = "letter_6" | "letter_5" | "numeric_10" | "numeric_5" | "binary"
 type Character = "any" | "ironclad" | "silent" | "defect" | "regent" | "necrobinder";
 
 interface SourceMeta {
-  id: string;
   author: string;
   source_type: SourceType;
   source_url: string;
@@ -21,6 +20,19 @@ interface SourceMeta {
   character: Character;
   game_version: string;
   published_at: string;
+}
+
+/**
+ * Derive a stable source_id slug from author + source_type.
+ * Same author + type always maps to the same row, so re-uploads hit
+ * upsert correctly and share trust history.
+ */
+function deriveSourceId(author: string, sourceType: SourceType): string {
+  const slug = author
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return `${slug || "unknown"}-${sourceType}`;
 }
 
 interface ExtractedCard {
@@ -77,7 +89,6 @@ function getTierColor(tier: string): string {
 // ── Default form values ───────────────────────────────────────────────────────
 
 const defaultMeta: SourceMeta = {
-  id: "",
   author: "",
   source_type: "image",
   source_url: "",
@@ -199,7 +210,7 @@ function TierListContent() {
     const body = {
       imageUrl,
       source: {
-        id: meta.id,
+        id: deriveSourceId(meta.author, meta.source_type),
         author: meta.author,
         source_type: meta.source_type,
         source_url: meta.source_url || null,
@@ -358,17 +369,6 @@ function UploadStep({
 
         <div className="grid grid-cols-2 gap-4">
           <div>
-            <label className={labelCls}>Source ID (slug)</label>
-            <input
-              type="text"
-              required
-              value={meta.id}
-              onChange={(e) => set("id", e.target.value)}
-              placeholder="e.g. alphabetical-ironclad-v035"
-              className={`mt-1 ${inputCls}`}
-            />
-          </div>
-          <div>
             <label className={labelCls}>Author</label>
             <input
               type="text"
@@ -378,10 +378,12 @@ function UploadStep({
               placeholder="e.g. alphabetical"
               className={`mt-1 ${inputCls}`}
             />
+            {meta.author && (
+              <p className="mt-1 text-[11px] text-zinc-600">
+                source_id: <code className="font-mono text-zinc-500">{deriveSourceId(meta.author, meta.source_type)}</code>
+              </p>
+            )}
           </div>
-        </div>
-
-        <div className="grid grid-cols-2 gap-4">
           <div>
             <label className={labelCls}>Source Type</label>
             <select
@@ -396,16 +398,17 @@ function UploadStep({
               <option value="youtube">YouTube</option>
             </select>
           </div>
-          <div>
-            <label className={labelCls}>Source URL (optional)</label>
-            <input
-              type="url"
-              value={meta.source_url}
-              onChange={(e) => set("source_url", e.target.value)}
-              placeholder="https://..."
-              className={`mt-1 ${inputCls}`}
-            />
-          </div>
+        </div>
+
+        <div>
+          <label className={labelCls}>Source URL (optional)</label>
+          <input
+            type="url"
+            value={meta.source_url}
+            onChange={(e) => set("source_url", e.target.value)}
+            placeholder="https://..."
+            className={`mt-1 ${inputCls}`}
+          />
         </div>
 
         <div className="grid grid-cols-2 gap-4">

--- a/apps/web/src/app/admin/tier-lists/page.tsx
+++ b/apps/web/src/app/admin/tier-lists/page.tsx
@@ -87,6 +87,7 @@ function TierListContent() {
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [savedCount, setSavedCount] = useState(0);
+  const [refreshWarning, setRefreshWarning] = useState<string | null>(null);
 
   // ── Step 1: Extract ─────────────────────────────────────────────────────────
 
@@ -193,6 +194,7 @@ function TierListContent() {
     }
 
     setSavedCount(data.entry_count ?? entries.length);
+    setRefreshWarning(data.refreshWarning ?? null);
     setStep("success");
     setSubmitting(false);
   };
@@ -207,6 +209,7 @@ function TierListContent() {
     setCards([]);
     setError(null);
     setSavedCount(0);
+    setRefreshWarning(null);
   };
 
   return (
@@ -259,7 +262,7 @@ function TierListContent() {
         )}
 
         {step === "success" && (
-          <SuccessStep count={savedCount} onReset={handleReset} />
+          <SuccessStep count={savedCount} refreshWarning={refreshWarning} onReset={handleReset} />
         )}
       </main>
     </div>
@@ -663,7 +666,15 @@ function PreviewStep({
 
 // ── Step 3: Success ───────────────────────────────────────────────────────────
 
-function SuccessStep({ count, onReset }: { count: number; onReset: () => void }) {
+function SuccessStep({
+  count,
+  refreshWarning,
+  onReset,
+}: {
+  count: number;
+  refreshWarning: string | null;
+  onReset: () => void;
+}) {
   return (
     <div className="flex flex-col items-center justify-center py-24 space-y-6">
       <div className="rounded-full bg-emerald-500/10 border border-emerald-500/30 p-6">
@@ -675,6 +686,23 @@ function SuccessStep({ count, onReset }: { count: number; onReset: () => void })
           {count} {count === 1 ? "entry" : "entries"} persisted to the database.
         </p>
       </div>
+      {refreshWarning && (
+        <div className="max-w-md rounded-md border border-yellow-500/30 bg-yellow-500/10 p-3 text-sm text-yellow-300">
+          <p className="font-medium">Consensus view not refreshed</p>
+          <p className="mt-1 text-xs text-yellow-400/80">
+            Data saved but the aggregation view could not be refreshed (likely
+            a concurrent write). Retry another ingest to trigger a refresh, or
+            run{" "}
+            <code className="font-mono">
+              select refresh_community_tier_consensus();
+            </code>{" "}
+            manually.
+          </p>
+          <p className="mt-1 font-mono text-[11px] text-yellow-400/60">
+            {refreshWarning}
+          </p>
+        </div>
+      )}
       <button
         onClick={onReset}
         className="rounded-md bg-emerald-600 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-500 transition-colors"

--- a/apps/web/src/app/admin/tier-lists/page.tsx
+++ b/apps/web/src/app/admin/tier-lists/page.tsx
@@ -542,26 +542,22 @@ function PreviewStep({
   const updateCard = (idx: number, patch: Partial<ExtractedCard>) =>
     onCardsChange(cards.map((c, i) => (i === idx ? { ...c, ...patch } : c)));
 
-  // Separate matched vs unmatched
-  const unmatchedCards = cards
+  // Group ALL cards (matched + unmatched) by tier so unmatched cards stay
+  // in their extracted position — admin can match them inline while
+  // comparing against the source image.
+  const allByTier = cards
     .map((c, i) => ({ card: c, idx: i }))
-    .filter(({ card }) => !cardIdMap[card.matchedName ?? card.name]);
-
-  const matchedCards = cards
-    .map((c, i) => ({ card: c, idx: i }))
-    .filter(({ card }) => !!cardIdMap[card.matchedName ?? card.name]);
-
-  // Group matched cards by tier for display
-  const byTier = matchedCards.reduce<Record<string, Array<{ card: ExtractedCard; idx: number }>>>(
-    (acc, entry) => {
-      acc[entry.card.tier] = acc[entry.card.tier] ?? [];
-      acc[entry.card.tier].push(entry);
-      return acc;
-    },
-    {}
-  );
+    .reduce<Record<string, Array<{ card: ExtractedCard; idx: number }>>>(
+      (acc, entry) => {
+        acc[entry.card.tier] = acc[entry.card.tier] ?? [];
+        acc[entry.card.tier].push(entry);
+        return acc;
+      },
+      {},
+    );
 
   const saveableCount = cards.filter((c) => cardIdMap[c.matchedName ?? c.name]).length;
+  const unmatchedCount = cards.length - saveableCount;
 
   const detectedScale = extraction.detected_scale;
   const detectedCharacter = extraction.detected_character;
@@ -664,74 +660,25 @@ function PreviewStep({
           </div>
         </div>
 
-        {/* Right column: unmatched + tier groups */}
+        {/* Right column: tier groups with inline matched/unmatched cards */}
         <div className="space-y-4">
-          {/* Unmatched cards section */}
-          {unmatchedCards.length > 0 && (
-            <div className="rounded-lg border border-orange-500/40 bg-orange-500/5 overflow-hidden">
-              <div className="px-3 py-2 border-b border-orange-500/30 bg-orange-500/10">
-                <span className="text-sm font-semibold text-orange-300">
-                  Unmatched Cards
-                </span>
-                <span className="ml-2 text-xs text-orange-400/70">
-                  {unmatchedCards.length} — resolve or skip before saving
-                </span>
-              </div>
-              <div className="divide-y divide-orange-500/10">
-                {unmatchedCards.map(({ card, idx }) => (
-                  <div
-                    key={`unmatched-${idx}`}
-                    className="px-3 py-2.5 space-y-2"
-                  >
-                    <div className="flex items-center justify-between">
-                      <span className="text-xs text-orange-300 font-mono truncate max-w-[60%]">
-                        {card.name}
-                      </span>
-                      <button
-                        onClick={() => removeCard(idx)}
-                        className="text-xs text-zinc-600 hover:text-red-400 transition-colors px-1.5 py-0.5 rounded border border-zinc-800 hover:border-red-500/40"
-                        aria-label={`Skip ${card.name}`}
-                      >
-                        Skip
-                      </button>
-                    </div>
-                    <div className="flex items-center gap-2">
-                      <input
-                        list={`cards-${idx}`}
-                        value={card.matchedName ?? ""}
-                        onChange={(e) => {
-                          const val = e.target.value;
-                          if (cardIdMap[val]) {
-                            updateCard(idx, { matchedName: val });
-                          } else {
-                            updateCard(idx, { matchedName: undefined });
-                          }
-                        }}
-                        placeholder="Search card name..."
-                        className={`flex-1 ${inputCls}`}
-                      />
-                      <datalist id={`cards-${idx}`}>
-                        {Object.keys(cardIdMap).map((name) => (
-                          <option key={name} value={name} />
-                        ))}
-                      </datalist>
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </div>
-          )}
+          <div className="flex items-center justify-between">
+            <p className="text-xs text-zinc-500 uppercase tracking-wide">
+              Extracted Tiers
+            </p>
+            {unmatchedCount > 0 && (
+              <span className="text-xs text-orange-300">
+                {unmatchedCount} unmatched — resolve inline
+              </span>
+            )}
+          </div>
 
-          {/* Tier groups (matched cards only) */}
-          <p className="text-xs text-zinc-500 uppercase tracking-wide">
-            Extracted Tiers
-          </p>
-          {Object.entries(byTier).map(([tier, entries]) => (
+          {Object.entries(allByTier).map(([tier, entries]) => (
             <div
               key={tier}
               className="rounded-lg border border-zinc-800 bg-zinc-950 overflow-hidden"
             >
-              <div className="px-3 py-2 border-b border-zinc-800 bg-zinc-900">
+              <div className="px-3 py-2 border-b border-zinc-800 bg-zinc-900 flex items-center">
                 <span className={`text-sm font-semibold ${getTierColor(tier)}`}>
                   Tier {tier}
                 </span>
@@ -740,52 +687,84 @@ function PreviewStep({
                 </span>
               </div>
               <div className="divide-y divide-zinc-900">
-                {entries.map(({ card, idx }) => (
-                  <div
-                    key={`${tier}-${card.name}-${idx}`}
-                    className="flex items-center justify-between px-3 py-2 hover:bg-zinc-900/50 transition-colors"
-                  >
-                    <span className="text-sm text-zinc-200 truncate min-w-0 mr-2">
-                      {card.matchedName ?? card.name}
-                      {card.matchedName && card.matchedName !== card.name && (
-                        <span className="ml-1 text-xs text-zinc-500">
-                          ({card.name})
-                        </span>
-                      )}
-                    </span>
-                    <div className="flex items-center gap-2 shrink-0">
-                      <ConfidenceBadge confidence={card.confidence} />
-                      <select
-                        value={card.tier}
-                        onChange={(e) => updateCard(idx, { tier: e.target.value })}
-                        className={inputCls}
-                        aria-label={`Tier for ${card.name}`}
-                      >
-                        {tierOptions.map((t) => (
-                          <option key={t} value={t}>
-                            {t}
-                          </option>
-                        ))}
-                      </select>
-                      {card.matchedName && card.matchedName !== card.name && (
-                        <button
-                          onClick={() => updateCard(idx, { matchedName: undefined })}
-                          className="text-xs text-zinc-600 hover:text-orange-400 transition-colors"
-                          aria-label={`Unmatch ${card.name}`}
-                        >
-                          Unmatch
-                        </button>
-                      )}
-                      <button
-                        onClick={() => removeCard(idx)}
-                        className="text-zinc-600 hover:text-red-400 transition-colors"
-                        aria-label={`Remove ${card.name}`}
-                      >
-                        <TrashIcon />
-                      </button>
+                {entries.map(({ card, idx }) => {
+                  const resolvedName = card.matchedName ?? card.name;
+                  const isMatched = !!cardIdMap[resolvedName];
+                  return (
+                    <div
+                      key={`${tier}-${idx}`}
+                      className={`px-3 py-2 ${isMatched ? "hover:bg-zinc-900/50" : "bg-orange-500/5 border-l-2 border-orange-500/50"} transition-colors`}
+                    >
+                      <div className="flex items-center gap-2">
+                        {isMatched ? (
+                          <span className="text-sm text-zinc-200 truncate min-w-0 flex-1">
+                            {resolvedName}
+                            {card.matchedName && card.matchedName !== card.name && (
+                              <span className="ml-1 text-xs text-zinc-500">
+                                ({card.name})
+                              </span>
+                            )}
+                          </span>
+                        ) : (
+                          <div className="flex-1 flex items-center gap-2 min-w-0">
+                            <span className="text-xs text-orange-300 font-mono truncate shrink-0 max-w-[45%]">
+                              {card.name}
+                            </span>
+                            <span className="text-xs text-orange-500/60 shrink-0">→</span>
+                            <input
+                              list={`cards-${idx}`}
+                              value={card.matchedName ?? ""}
+                              onChange={(e) => {
+                                const val = e.target.value;
+                                updateCard(idx, {
+                                  matchedName: cardIdMap[val] ? val : undefined,
+                                });
+                              }}
+                              placeholder="Match to card…"
+                              className={`flex-1 min-w-0 ${inputCls}`}
+                            />
+                            <datalist id={`cards-${idx}`}>
+                              {Object.keys(cardIdMap).map((name) => (
+                                <option key={name} value={name} />
+                              ))}
+                            </datalist>
+                          </div>
+                        )}
+                        <div className="flex items-center gap-2 shrink-0">
+                          <ConfidenceBadge confidence={card.confidence} />
+                          <select
+                            value={card.tier}
+                            onChange={(e) => updateCard(idx, { tier: e.target.value })}
+                            className={inputCls}
+                            aria-label={`Tier for ${card.name}`}
+                          >
+                            {tierOptions.map((t) => (
+                              <option key={t} value={t}>
+                                {t}
+                              </option>
+                            ))}
+                          </select>
+                          {card.matchedName && card.matchedName !== card.name && (
+                            <button
+                              onClick={() => updateCard(idx, { matchedName: undefined })}
+                              className="text-xs text-zinc-600 hover:text-orange-400 transition-colors"
+                              aria-label={`Unmatch ${card.name}`}
+                            >
+                              Unmatch
+                            </button>
+                          )}
+                          <button
+                            onClick={() => removeCard(idx)}
+                            className="text-zinc-600 hover:text-red-400 transition-colors"
+                            aria-label={`Remove ${card.name}`}
+                          >
+                            <TrashIcon />
+                          </button>
+                        </div>
+                      </div>
                     </div>
-                  </div>
-                ))}
+                  );
+                })}
               </div>
             </div>
           ))}
@@ -793,14 +772,6 @@ function PreviewStep({
           {cards.length === 0 && (
             <div className="rounded-lg border border-zinc-800 bg-zinc-950 px-4 py-8 text-center">
               <p className="text-sm text-zinc-500">No cards remaining.</p>
-            </div>
-          )}
-
-          {cards.length > 0 && matchedCards.length === 0 && unmatchedCards.length > 0 && (
-            <div className="rounded-lg border border-zinc-800 bg-zinc-950 px-4 py-8 text-center">
-              <p className="text-sm text-zinc-500">
-                All cards are unmatched. Resolve or skip them above.
-              </p>
             </div>
           )}
         </div>

--- a/apps/web/src/app/admin/tier-lists/page.tsx
+++ b/apps/web/src/app/admin/tier-lists/page.tsx
@@ -27,6 +27,7 @@ interface ExtractedCard {
   name: string;
   tier: string;
   confidence: number;
+  matchedName?: string;
 }
 
 interface ExtractResult {
@@ -36,6 +37,42 @@ interface ExtractResult {
 }
 
 type Step = "upload" | "preview" | "success";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function getTierOptions(scale: ScaleType): string[] {
+  switch (scale) {
+    case "letter_6":
+      return ["S", "A", "B", "C", "D", "F"];
+    case "letter_5":
+      return ["S", "A", "B", "C", "D"];
+    case "numeric_10":
+      return ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"];
+    case "numeric_5":
+      return ["1", "2", "3", "4", "5"];
+    case "binary":
+      return ["good", "bad"];
+  }
+}
+
+function getTierColor(tier: string): string {
+  switch (tier.toUpperCase()) {
+    case "S":
+      return "text-yellow-300";
+    case "A":
+      return "text-emerald-400";
+    case "B":
+      return "text-blue-400";
+    case "C":
+      return "text-zinc-300";
+    case "D":
+      return "text-orange-400";
+    case "F":
+      return "text-red-400";
+    default:
+      return "text-zinc-400";
+  }
+}
 
 // ── Default form values ───────────────────────────────────────────────────────
 
@@ -142,7 +179,8 @@ function TierListContent() {
 
     const entries = cards
       .map((c) => {
-        const card_id = cardIdMap[c.name];
+        const resolvedName = c.matchedName ?? c.name;
+        const card_id = cardIdMap[resolvedName];
         if (!card_id) {
           skipped.push(c.name);
           return null;
@@ -481,25 +519,42 @@ function PreviewStep({
   const removeCard = (idx: number) =>
     onCardsChange(cards.filter((_, i) => i !== idx));
 
-  // Group cards by tier for display
-  const byTier = cards.reduce<Record<string, ExtractedCard[]>>((acc, card) => {
-    acc[card.tier] = acc[card.tier] ?? [];
-    acc[card.tier].push(card);
-    return acc;
-  }, {});
+  const updateCard = (idx: number, patch: Partial<ExtractedCard>) =>
+    onCardsChange(cards.map((c, i) => (i === idx ? { ...c, ...patch } : c)));
 
-  const unresolvedNames = cards
-    .filter((c) => !cardIdMap[c.name])
-    .map((c) => c.name);
+  // Separate matched vs unmatched
+  const unmatchedCards = cards
+    .map((c, i) => ({ card: c, idx: i }))
+    .filter(({ card }) => !cardIdMap[card.matchedName ?? card.name]);
+
+  const matchedCards = cards
+    .map((c, i) => ({ card: c, idx: i }))
+    .filter(({ card }) => !!cardIdMap[card.matchedName ?? card.name]);
+
+  // Group matched cards by tier for display
+  const byTier = matchedCards.reduce<Record<string, Array<{ card: ExtractedCard; idx: number }>>>(
+    (acc, entry) => {
+      acc[entry.card.tier] = acc[entry.card.tier] ?? [];
+      acc[entry.card.tier].push(entry);
+      return acc;
+    },
+    {}
+  );
+
+  const saveableCount = cards.filter((c) => cardIdMap[c.matchedName ?? c.name]).length;
 
   const detectedScale = extraction.detected_scale;
   const detectedCharacter = extraction.detected_character;
-  const scaleMismatch =
-    detectedScale && detectedScale !== meta.scale_type;
+  const scaleMismatch = detectedScale && detectedScale !== meta.scale_type;
   const characterMismatch =
     detectedCharacter &&
     meta.character !== "any" &&
     detectedCharacter.toLowerCase() !== meta.character;
+
+  const tierOptions = getTierOptions(meta.scale_type);
+
+  const inputCls =
+    "rounded border border-zinc-700 bg-zinc-900 px-2 py-1 text-xs text-zinc-200 focus:outline-none focus:border-zinc-500";
 
   return (
     <div className="space-y-6">
@@ -515,10 +570,12 @@ function PreviewStep({
           </button>
           <button
             onClick={onConfirm}
-            disabled={submitting || cards.length === 0}
+            disabled={submitting || saveableCount === 0}
             className="rounded-md bg-emerald-600 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-500 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
           >
-            {submitting ? "Saving..." : `Confirm & Save (${cards.length} cards)`}
+            {submitting
+              ? "Saving..."
+              : `Confirm & Save (${saveableCount} cards${saveableCount < cards.length ? `, ${cards.length - saveableCount} unmatched` : ""})`}
           </button>
         </div>
       </div>
@@ -559,19 +616,6 @@ function PreviewStep({
         </div>
       )}
 
-      {/* Unresolved cards warning */}
-      {unresolvedNames.length > 0 && (
-        <div className="rounded-md border border-orange-500/30 bg-orange-500/10 px-4 py-3 space-y-1">
-          <p className="text-xs font-medium text-orange-400 uppercase tracking-wide">
-            Unresolved Cards ({unresolvedNames.length})
-          </p>
-          <p className="text-sm text-orange-300">
-            These cards were not found in the card database and will be skipped:{" "}
-            {unresolvedNames.join(", ")}
-          </p>
-        </div>
-      )}
-
       <div className="grid grid-cols-[1fr_2fr] gap-6">
         {/* Uploaded image */}
         <div className="space-y-2">
@@ -600,55 +644,128 @@ function PreviewStep({
           </div>
         </div>
 
-        {/* Card list grouped by tier */}
+        {/* Right column: unmatched + tier groups */}
         <div className="space-y-4">
+          {/* Unmatched cards section */}
+          {unmatchedCards.length > 0 && (
+            <div className="rounded-lg border border-orange-500/40 bg-orange-500/5 overflow-hidden">
+              <div className="px-3 py-2 border-b border-orange-500/30 bg-orange-500/10">
+                <span className="text-sm font-semibold text-orange-300">
+                  Unmatched Cards
+                </span>
+                <span className="ml-2 text-xs text-orange-400/70">
+                  {unmatchedCards.length} — resolve or skip before saving
+                </span>
+              </div>
+              <div className="divide-y divide-orange-500/10">
+                {unmatchedCards.map(({ card, idx }) => (
+                  <div
+                    key={`unmatched-${idx}`}
+                    className="px-3 py-2.5 space-y-2"
+                  >
+                    <div className="flex items-center justify-between">
+                      <span className="text-xs text-orange-300 font-mono truncate max-w-[60%]">
+                        {card.name}
+                      </span>
+                      <button
+                        onClick={() => removeCard(idx)}
+                        className="text-xs text-zinc-600 hover:text-red-400 transition-colors px-1.5 py-0.5 rounded border border-zinc-800 hover:border-red-500/40"
+                        aria-label={`Skip ${card.name}`}
+                      >
+                        Skip
+                      </button>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <input
+                        list={`cards-${idx}`}
+                        value={card.matchedName ?? ""}
+                        onChange={(e) => {
+                          const val = e.target.value;
+                          if (cardIdMap[val]) {
+                            updateCard(idx, { matchedName: val });
+                          } else {
+                            updateCard(idx, { matchedName: undefined });
+                          }
+                        }}
+                        placeholder="Search card name..."
+                        className={`flex-1 ${inputCls}`}
+                      />
+                      <datalist id={`cards-${idx}`}>
+                        {Object.keys(cardIdMap).map((name) => (
+                          <option key={name} value={name} />
+                        ))}
+                      </datalist>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Tier groups (matched cards only) */}
           <p className="text-xs text-zinc-500 uppercase tracking-wide">
             Extracted Tiers
           </p>
-          {Object.entries(byTier).map(([tier, tierCards]) => (
-            <div key={tier} className="rounded-lg border border-zinc-800 bg-zinc-950 overflow-hidden">
+          {Object.entries(byTier).map(([tier, entries]) => (
+            <div
+              key={tier}
+              className="rounded-lg border border-zinc-800 bg-zinc-950 overflow-hidden"
+            >
               <div className="px-3 py-2 border-b border-zinc-800 bg-zinc-900">
-                <span className="text-sm font-semibold text-zinc-100">
+                <span className={`text-sm font-semibold ${getTierColor(tier)}`}>
                   Tier {tier}
                 </span>
                 <span className="ml-2 text-xs text-zinc-500">
-                  {tierCards.length} cards
+                  {entries.length} cards
                 </span>
               </div>
               <div className="divide-y divide-zinc-900">
-                {tierCards.map((card) => {
-                  const globalIdx = cards.indexOf(card);
-                  const isUnresolved = !cardIdMap[card.name];
-                  return (
-                    <div
-                      key={`${tier}-${card.name}`}
-                      className="flex items-center justify-between px-3 py-2 hover:bg-zinc-900/50 transition-colors"
-                    >
-                      <div className="flex items-center gap-3 min-w-0">
-                        <span
-                          className={`text-sm truncate ${isUnresolved ? "text-orange-400" : "text-zinc-200"}`}
-                        >
-                          {card.name}
-                          {isUnresolved && (
-                            <span className="ml-1 text-xs text-orange-500">
-                              (unresolved)
-                            </span>
-                          )}
+                {entries.map(({ card, idx }) => (
+                  <div
+                    key={`${tier}-${card.name}-${idx}`}
+                    className="flex items-center justify-between px-3 py-2 hover:bg-zinc-900/50 transition-colors"
+                  >
+                    <span className="text-sm text-zinc-200 truncate min-w-0 mr-2">
+                      {card.matchedName ?? card.name}
+                      {card.matchedName && card.matchedName !== card.name && (
+                        <span className="ml-1 text-xs text-zinc-500">
+                          ({card.name})
                         </span>
-                      </div>
-                      <div className="flex items-center gap-3 shrink-0">
-                        <ConfidenceBadge confidence={card.confidence} />
+                      )}
+                    </span>
+                    <div className="flex items-center gap-2 shrink-0">
+                      <ConfidenceBadge confidence={card.confidence} />
+                      <select
+                        value={card.tier}
+                        onChange={(e) => updateCard(idx, { tier: e.target.value })}
+                        className={inputCls}
+                        aria-label={`Tier for ${card.name}`}
+                      >
+                        {tierOptions.map((t) => (
+                          <option key={t} value={t}>
+                            {t}
+                          </option>
+                        ))}
+                      </select>
+                      {card.matchedName && card.matchedName !== card.name && (
                         <button
-                          onClick={() => removeCard(globalIdx)}
-                          className="text-zinc-600 hover:text-red-400 transition-colors"
-                          aria-label={`Remove ${card.name}`}
+                          onClick={() => updateCard(idx, { matchedName: undefined })}
+                          className="text-xs text-zinc-600 hover:text-orange-400 transition-colors"
+                          aria-label={`Unmatch ${card.name}`}
                         >
-                          <TrashIcon />
+                          Unmatch
                         </button>
-                      </div>
+                      )}
+                      <button
+                        onClick={() => removeCard(idx)}
+                        className="text-zinc-600 hover:text-red-400 transition-colors"
+                        aria-label={`Remove ${card.name}`}
+                      >
+                        <TrashIcon />
+                      </button>
                     </div>
-                  );
-                })}
+                  </div>
+                ))}
               </div>
             </div>
           ))}
@@ -656,6 +773,14 @@ function PreviewStep({
           {cards.length === 0 && (
             <div className="rounded-lg border border-zinc-800 bg-zinc-950 px-4 py-8 text-center">
               <p className="text-sm text-zinc-500">No cards remaining.</p>
+            </div>
+          )}
+
+          {cards.length > 0 && matchedCards.length === 0 && unmatchedCards.length > 0 && (
+            <div className="rounded-lg border border-zinc-800 bg-zinc-950 px-4 py-8 text-center">
+              <p className="text-sm text-zinc-500">
+                All cards are unmatched. Resolve or skip them above.
+              </p>
             </div>
           )}
         </div>

--- a/apps/web/src/app/admin/tier-lists/page.tsx
+++ b/apps/web/src/app/admin/tier-lists/page.tsx
@@ -92,7 +92,6 @@ const defaultMeta: SourceMeta = {
 
 export default function TierListIngestionPage() {
   const { user, loading } = useAuth();
-  const isDev = process.env.NODE_ENV === "development";
 
   if (loading) {
     return (
@@ -102,7 +101,7 @@ export default function TierListIngestionPage() {
     );
   }
 
-  if (!user && !isDev) {
+  if (!user) {
     return (
       <div className="min-h-screen bg-background text-foreground flex flex-col">
         <LoginScreen />

--- a/apps/web/src/app/api/admin/tier-lists/confirm/route.ts
+++ b/apps/web/src/app/api/admin/tier-lists/confirm/route.ts
@@ -85,17 +85,35 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "Source upsert failed" }, { status: 500 });
   }
 
-  // 2. Mark prior active lists inactive for same source/character scope
-  await supabase
-    .from("tier_lists")
-    .update({ is_active: false })
-    .eq("source_id", source.id)
-    .eq("is_active", true)
-    .filter(
-      "character",
-      list.character === null ? "is" : "eq",
-      list.character,
-    );
+  // 2. Mark prior active lists inactive for the SAME (source, game_version, character)
+  // scope only. Deactivating across versions would hide legitimate historical
+  // snapshots (e.g. a v0.3.5 list when uploading a v0.4.0 list).
+  //
+  // NOTE: steps 2–5 are NOT wrapped in a transaction. If step 4 fails, step 3
+  // leaves an orphan tier_lists row with entry_count > 0 but no entries, and
+  // step 2 has already deactivated the prior list. Monitor logs for partial
+  // failures and clean up manually. Moving to a single RPC is a follow-up.
+  {
+    let q = supabase
+      .from("tier_lists")
+      .update({ is_active: false })
+      .eq("source_id", source.id)
+      .eq("is_active", true);
+    q = list.game_version === null
+      ? q.is("game_version", null)
+      : q.eq("game_version", list.game_version);
+    q = list.character === null
+      ? q.is("character", null)
+      : q.eq("character", list.character);
+    const { error: deactivateError } = await q;
+    if (deactivateError) {
+      console.error("[Tier Lists Confirm] Deactivation failed:", deactivateError);
+      return NextResponse.json(
+        { error: "Failed to deactivate prior lists", detail: deactivateError.message },
+        { status: 500 },
+      );
+    }
+  }
 
   // 3. Insert new tier_lists row
   const { data: newList, error: listError } = await supabase
@@ -115,6 +133,16 @@ export async function POST(request: Request) {
 
   if (listError || !newList) {
     console.error("[Tier Lists Confirm] List insert failed:", listError);
+    // Postgres unique_violation — same (source_id, game_version, published_at, character)
+    // tuple already exists. Tell the admin how to fix it.
+    if (listError && (listError as { code?: string }).code === "23505") {
+      return NextResponse.json(
+        {
+          error: "Tier list already exists for this source, version, date, and character. Change the published_at date or use a different source ID to create a new snapshot.",
+        },
+        { status: 409 },
+      );
+    }
     return NextResponse.json({ error: "List insert failed" }, { status: 500 });
   }
 
@@ -148,7 +176,11 @@ export async function POST(request: Request) {
     );
   }
 
-  // 5. Refresh materialized view (best-effort)
+  // 5. Refresh materialized view (best-effort). The RPC uses REFRESH MATERIALIZED
+  // VIEW CONCURRENTLY which requires an exclusive lock — concurrent admin
+  // submissions can collide. Surface the error to the client so the UI can
+  // prompt a retry rather than silently serving stale consensus.
+  //
   // NOTE: refresh_community_tier_consensus is defined in migration 024 but not
   // yet reflected in the generated types. Cast to any to bypass the type-level
   // restriction until types are regenerated.
@@ -156,7 +188,9 @@ export async function POST(request: Request) {
   const { error: refreshError } = await (supabase as any).rpc(
     "refresh_community_tier_consensus",
   );
+  let refreshWarning: string | null = null;
   if (refreshError) {
+    refreshWarning = refreshError.message ?? "Refresh failed";
     console.warn(
       "[Tier Lists Confirm] MV refresh failed (data saved, admin can retry):",
       refreshError,
@@ -167,5 +201,6 @@ export async function POST(request: Request) {
     success: true,
     tier_list_id: newList.id,
     entry_count: entryRows.length,
+    refreshWarning,
   });
 }

--- a/apps/web/src/app/api/admin/tier-lists/confirm/route.ts
+++ b/apps/web/src/app/api/admin/tier-lists/confirm/route.ts
@@ -146,16 +146,31 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "List insert failed" }, { status: 500 });
   }
 
-  // 4. Normalize tiers and insert entries
+  // 4. Normalize tiers, dedupe by card_id (fuzzy client-side matching can
+  // collapse variants like "Pacts End" + "Pact's End" to the same card_id),
+  // and insert entries. When a card appears multiple times, keep the entry
+  // with the highest extraction_confidence — ties go to the first seen.
   const normSource = {
     scale_type: source.scale_type as ScaleType,
     scale_config: (source.scale_config ?? null) as {
       map?: Record<string, number>;
     } | null,
   };
-  const entryRows = entries.map((e) => {
+
+  type EntryRow = {
+    tier_list_id: string;
+    card_id: string;
+    raw_tier: string;
+    normalized_tier: number;
+    note: string | null;
+    extraction_confidence: number | null;
+  };
+  const byCardId = new Map<string, EntryRow>();
+  const duplicates: string[] = [];
+
+  for (const e of entries) {
     const { normalizedTier } = normalizeTier(e.raw_tier, normSource);
-    return {
+    const row: EntryRow = {
       tier_list_id: newList.id,
       card_id: e.card_id,
       raw_tier: e.raw_tier,
@@ -163,7 +178,24 @@ export async function POST(request: Request) {
       note: e.note ?? null,
       extraction_confidence: e.extraction_confidence ?? null,
     };
-  });
+    const existing = byCardId.get(e.card_id);
+    if (!existing) {
+      byCardId.set(e.card_id, row);
+      continue;
+    }
+    duplicates.push(e.card_id);
+    if ((row.extraction_confidence ?? 0) > (existing.extraction_confidence ?? 0)) {
+      byCardId.set(e.card_id, row);
+    }
+  }
+  const entryRows = Array.from(byCardId.values());
+
+  if (duplicates.length > 0) {
+    console.warn(
+      "[Tier Lists Confirm] Collapsed duplicate card_ids (kept highest confidence):",
+      duplicates,
+    );
+  }
 
   const { error: entriesError } = await supabase
     .from("tier_list_entries")
@@ -174,6 +206,14 @@ export async function POST(request: Request) {
       { error: "Entries insert failed" },
       { status: 500 },
     );
+  }
+
+  // Update entry_count on the list to reflect post-dedup count
+  if (duplicates.length > 0) {
+    await supabase
+      .from("tier_lists")
+      .update({ entry_count: entryRows.length })
+      .eq("id", newList.id);
   }
 
   // 5. Refresh materialized view (best-effort). The RPC uses REFRESH MATERIALIZED

--- a/apps/web/src/app/api/admin/tier-lists/confirm/route.ts
+++ b/apps/web/src/app/api/admin/tier-lists/confirm/route.ts
@@ -1,0 +1,171 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { requireAdmin } from "@/lib/api-admin-auth";
+import { createServiceClient } from "@/lib/supabase/server";
+import {
+  normalizeTier,
+  type ScaleType,
+} from "@sts2/shared/evaluation/tier-normalize";
+import type { Json } from "@sts2/shared/types/database.types";
+
+const confirmSchema = z.object({
+  imageUrl: z.string().url(),
+  source: z.object({
+    id: z.string(),
+    author: z.string(),
+    source_type: z.enum([
+      "image",
+      "spreadsheet",
+      "website",
+      "reddit",
+      "youtube",
+    ]),
+    source_url: z.string().url().nullable().optional(),
+    trust_weight: z.number().min(0).max(2).default(1.0),
+    scale_type: z.enum([
+      "letter_6",
+      "letter_5",
+      "numeric_10",
+      "numeric_5",
+      "binary",
+    ]),
+    scale_config: z.record(z.string(), z.unknown()).nullable().optional(),
+    notes: z.string().nullable().optional(),
+  }),
+  list: z.object({
+    game_version: z.string().nullable(),
+    published_at: z.string(),
+    character: z.string().nullable(),
+  }),
+  entries: z.array(
+    z.object({
+      card_id: z.string(),
+      raw_tier: z.string(),
+      note: z.string().nullable().optional(),
+      extraction_confidence: z.number().min(0).max(1).nullable().optional(),
+    }),
+  ),
+});
+
+export async function POST(request: Request) {
+  const auth = await requireAdmin();
+  if ("error" in auth) return auth.error;
+
+  const body = await request.json();
+  const parsed = confirmSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Invalid request body", detail: parsed.error.format() },
+      { status: 400 },
+    );
+  }
+  const { imageUrl, source, list, entries } = parsed.data;
+
+  const supabase = createServiceClient();
+
+  // 1. Upsert source
+  const { error: sourceError } = await supabase
+    .from("tier_list_sources")
+    .upsert(
+      {
+        id: source.id,
+        author: source.author,
+        source_type: source.source_type,
+        source_url: source.source_url ?? null,
+        trust_weight: source.trust_weight,
+        scale_type: source.scale_type,
+        scale_config: (source.scale_config ?? null) as Json | null,
+        notes: source.notes ?? null,
+        updated_at: new Date().toISOString(),
+      },
+      { onConflict: "id" },
+    );
+  if (sourceError) {
+    console.error("[Tier Lists Confirm] Source upsert failed:", sourceError);
+    return NextResponse.json({ error: "Source upsert failed" }, { status: 500 });
+  }
+
+  // 2. Mark prior active lists inactive for same source/character scope
+  await supabase
+    .from("tier_lists")
+    .update({ is_active: false })
+    .eq("source_id", source.id)
+    .eq("is_active", true)
+    .filter(
+      "character",
+      list.character === null ? "is" : "eq",
+      list.character,
+    );
+
+  // 3. Insert new tier_lists row
+  const { data: newList, error: listError } = await supabase
+    .from("tier_lists")
+    .insert({
+      source_id: source.id,
+      game_version: list.game_version,
+      published_at: list.published_at,
+      character: list.character,
+      is_active: true,
+      source_image_url: imageUrl,
+      ingestion_method: "vision_llm",
+      entry_count: entries.length,
+    })
+    .select("id")
+    .single();
+
+  if (listError || !newList) {
+    console.error("[Tier Lists Confirm] List insert failed:", listError);
+    return NextResponse.json({ error: "List insert failed" }, { status: 500 });
+  }
+
+  // 4. Normalize tiers and insert entries
+  const normSource = {
+    scale_type: source.scale_type as ScaleType,
+    scale_config: (source.scale_config ?? null) as {
+      map?: Record<string, number>;
+    } | null,
+  };
+  const entryRows = entries.map((e) => {
+    const { normalizedTier } = normalizeTier(e.raw_tier, normSource);
+    return {
+      tier_list_id: newList.id,
+      card_id: e.card_id,
+      raw_tier: e.raw_tier,
+      normalized_tier: normalizedTier,
+      note: e.note ?? null,
+      extraction_confidence: e.extraction_confidence ?? null,
+    };
+  });
+
+  const { error: entriesError } = await supabase
+    .from("tier_list_entries")
+    .insert(entryRows);
+  if (entriesError) {
+    console.error("[Tier Lists Confirm] Entries insert failed:", entriesError);
+    return NextResponse.json(
+      { error: "Entries insert failed" },
+      { status: 500 },
+    );
+  }
+
+  // 5. Refresh materialized view (best-effort)
+  // NOTE: refresh_community_tier_consensus is defined in migration 024 but not
+  // yet reflected in the generated types. Cast to any to bypass the type-level
+  // restriction until types are regenerated.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { error: refreshError } = await (supabase as any).rpc(
+    "refresh_community_tier_consensus",
+  );
+  if (refreshError) {
+    console.warn(
+      "[Tier Lists Confirm] MV refresh failed (data saved, admin can retry):",
+      refreshError,
+    );
+  }
+
+  return NextResponse.json({
+    success: true,
+    tier_list_id: newList.id,
+    entry_count: entryRows.length,
+  });
+}

--- a/apps/web/src/app/api/admin/tier-lists/extract/route.ts
+++ b/apps/web/src/app/api/admin/tier-lists/extract/route.ts
@@ -1,13 +1,17 @@
 import { NextResponse } from "next/server";
 import { generateText, Output } from "ai";
-import { anthropic } from "@ai-sdk/anthropic";
+import { google } from "@ai-sdk/google";
 import { requireAdmin } from "@/lib/api-admin-auth";
 import { createServiceClient } from "@/lib/supabase/server";
 import {
   tierExtractionSchema,
   buildTierExtractionSystemPrompt,
 } from "@sts2/shared/evaluation/tier-extraction";
-import { EVAL_MODELS } from "@sts2/shared/evaluation/models";
+
+// Gemini 2.5 Pro one-shots tier list extraction where Claude Opus 4.6 struggled
+// (tested against dense horizontal-row tier list screenshots with ~150 cards).
+// Requires GOOGLE_GENERATIVE_AI_API_KEY env var.
+const VISION_MODEL = "gemini-2.5-pro";
 
 // Allowlist MIME types to prevent attacker-controlled extensions serving as HTML
 // from the public storage bucket. Keep in sync with migration 023 bucket config.
@@ -78,8 +82,8 @@ export async function POST(request: Request) {
 
   try {
     const result = await generateText({
-      model: anthropic(EVAL_MODELS.vision),
-      maxOutputTokens: 4096,
+      model: google(VISION_MODEL),
+      maxOutputTokens: 8192,
       system: systemPrompt,
       messages: [
         {

--- a/apps/web/src/app/api/admin/tier-lists/extract/route.ts
+++ b/apps/web/src/app/api/admin/tier-lists/extract/route.ts
@@ -85,7 +85,10 @@ export async function POST(request: Request) {
   try {
     const result = await generateText({
       model: google(VISION_MODEL),
-      maxOutputTokens: 8192,
+      // Gemini 2.5 Pro reserves part of this budget for internal "thinking"
+      // tokens, leaving less for the actual structured-output JSON. A
+      // 150-card tier list needs ~12K output tokens; give plenty of headroom.
+      maxOutputTokens: 32768,
       system: systemPrompt,
       messages: [
         {
@@ -120,11 +123,29 @@ export async function POST(request: Request) {
       cardIdMap,
     });
   } catch (err) {
-    console.error("[Tier Lists Extract] Vision call failed:", err);
+    // Surface the raw model output (when available) so we can diagnose
+    // whether it's a token-budget issue, schema-mismatch, or refusal.
+    const rawOutput =
+      err && typeof err === "object" && "text" in err
+        ? (err as { text?: unknown }).text
+        : undefined;
+    const finishReason =
+      err && typeof err === "object" && "finishReason" in err
+        ? (err as { finishReason?: unknown }).finishReason
+        : undefined;
+
+    console.error("[Tier Lists Extract] Vision call failed:", {
+      message: err instanceof Error ? err.message : String(err),
+      finishReason,
+      rawOutputPreview:
+        typeof rawOutput === "string" ? rawOutput.slice(0, 500) : rawOutput,
+    });
+
     return NextResponse.json(
       {
         error: "Extraction failed",
         detail: err instanceof Error ? err.message : String(err),
+        finishReason,
       },
       { status: 500 },
     );

--- a/apps/web/src/app/api/admin/tier-lists/extract/route.ts
+++ b/apps/web/src/app/api/admin/tier-lists/extract/route.ts
@@ -22,7 +22,7 @@ const ALLOWED_MIME_TO_EXT: Record<string, string> = {
   "image/jpeg": "jpg",
   "image/webp": "webp",
 };
-const MAX_IMAGE_BYTES = 10 * 1024 * 1024; // 10 MB
+const MAX_IMAGE_BYTES = 25 * 1024 * 1024; // 25 MB — matches next.config proxyClientMaxBodySize
 
 export async function POST(request: Request) {
   const auth = await requireAdmin();

--- a/apps/web/src/app/api/admin/tier-lists/extract/route.ts
+++ b/apps/web/src/app/api/admin/tier-lists/extract/route.ts
@@ -43,9 +43,13 @@ export async function POST(request: Request) {
     .getPublicUrl(filename);
   const imageUrl = publicUrlData.publicUrl;
 
-  // Fetch all known card names for the extraction prompt
-  const { data: cards } = await supabase.from("cards").select("name");
+  // Fetch all known cards for the extraction prompt and name→id map
+  const { data: cards } = await supabase.from("cards").select("id, name");
   const cardNames = (cards ?? []).map((c) => c.name);
+  const cardIdMap: Record<string, string> = {};
+  for (const c of cards ?? []) {
+    cardIdMap[c.name] = c.id;
+  }
 
   // Call Claude Sonnet with vision
   const systemPrompt = buildTierExtractionSystemPrompt(cardNames);
@@ -76,6 +80,7 @@ export async function POST(request: Request) {
     return NextResponse.json({
       imageUrl,
       extraction: result.output,
+      cardIdMap,
     });
   } catch (err) {
     console.error("[Tier Lists Extract] Vision call failed:", err);

--- a/apps/web/src/app/api/admin/tier-lists/extract/route.ts
+++ b/apps/web/src/app/api/admin/tier-lists/extract/route.ts
@@ -99,9 +99,18 @@ export async function POST(request: Request) {
       output: Output.object({ schema: tierExtractionSchema }),
     });
 
+    // Clamp confidence values to [0, 1] — schema can't enforce bounds
+    // on number fields (Anthropic rejects min/max on number/integer types)
+    const extraction = result.output;
+    for (const tier of extraction.tiers ?? []) {
+      for (const card of tier.cards) {
+        card.confidence = Math.max(0, Math.min(1, card.confidence));
+      }
+    }
+
     return NextResponse.json({
       imageUrl,
-      extraction: result.output,
+      extraction,
       cardIdMap,
     });
   } catch (err) {

--- a/apps/web/src/app/api/admin/tier-lists/extract/route.ts
+++ b/apps/web/src/app/api/admin/tier-lists/extract/route.ts
@@ -9,6 +9,15 @@ import {
 } from "@sts2/shared/evaluation/tier-extraction";
 import { EVAL_MODELS } from "@sts2/shared/evaluation/models";
 
+// Allowlist MIME types to prevent attacker-controlled extensions serving as HTML
+// from the public storage bucket. Keep in sync with migration 023 bucket config.
+const ALLOWED_MIME_TO_EXT: Record<string, string> = {
+  "image/png": "png",
+  "image/jpeg": "jpg",
+  "image/webp": "webp",
+};
+const MAX_IMAGE_BYTES = 10 * 1024 * 1024; // 10 MB
+
 export async function POST(request: Request) {
   const auth = await requireAdmin();
   if ("error" in auth) return auth.error;
@@ -19,10 +28,23 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "Missing image file" }, { status: 400 });
   }
 
+  const ext = ALLOWED_MIME_TO_EXT[file.type];
+  if (!ext) {
+    return NextResponse.json(
+      { error: `Unsupported image type: ${file.type}. Allowed: PNG, JPEG, WEBP.` },
+      { status: 400 },
+    );
+  }
+  if (file.size > MAX_IMAGE_BYTES) {
+    return NextResponse.json(
+      { error: `Image too large (${file.size} bytes). Max ${MAX_IMAGE_BYTES} bytes.` },
+      { status: 413 },
+    );
+  }
+
   const supabase = createServiceClient();
 
-  // Upload to Supabase Storage
-  const ext = file.name.split(".").pop() || "png";
+  // Upload to Supabase Storage with canonical extension + server-controlled content-type
   const filename = `${Date.now()}-${crypto.randomUUID()}.${ext}`;
   const bytes = await file.arrayBuffer();
 

--- a/apps/web/src/app/api/admin/tier-lists/extract/route.ts
+++ b/apps/web/src/app/api/admin/tier-lists/extract/route.ts
@@ -71,16 +71,15 @@ export async function POST(request: Request) {
     .getPublicUrl(filename);
   const imageUrl = publicUrlData.publicUrl;
 
-  // Fetch all known cards for the extraction prompt and name→id map
+  // Fetch all known cards — client uses this to match extracted names
+  // to canonical IDs (matching happens client-side, not in the prompt).
   const { data: cards } = await supabase.from("cards").select("id, name");
-  const cardNames = (cards ?? []).map((c) => c.name);
   const cardIdMap: Record<string, string> = {};
   for (const c of cards ?? []) {
     cardIdMap[c.name] = c.id;
   }
 
-  // Call Claude Sonnet with vision
-  const systemPrompt = buildTierExtractionSystemPrompt(cardNames);
+  const systemPrompt = buildTierExtractionSystemPrompt();
 
   try {
     const result = await generateText({

--- a/apps/web/src/app/api/admin/tier-lists/extract/route.ts
+++ b/apps/web/src/app/api/admin/tier-lists/extract/route.ts
@@ -1,0 +1,90 @@
+import { NextResponse } from "next/server";
+import { generateText, Output } from "ai";
+import { anthropic } from "@ai-sdk/anthropic";
+import { requireAdmin } from "@/lib/api-admin-auth";
+import { createServiceClient } from "@/lib/supabase/server";
+import {
+  tierExtractionSchema,
+  buildTierExtractionSystemPrompt,
+} from "@sts2/shared/evaluation/tier-extraction";
+import { EVAL_MODELS } from "@sts2/shared/evaluation/models";
+
+export async function POST(request: Request) {
+  const auth = await requireAdmin();
+  if ("error" in auth) return auth.error;
+
+  const formData = await request.formData();
+  const file = formData.get("image");
+  if (!(file instanceof File)) {
+    return NextResponse.json({ error: "Missing image file" }, { status: 400 });
+  }
+
+  const supabase = createServiceClient();
+
+  // Upload to Supabase Storage
+  const ext = file.name.split(".").pop() || "png";
+  const filename = `${Date.now()}-${crypto.randomUUID()}.${ext}`;
+  const bytes = await file.arrayBuffer();
+
+  const { error: uploadError } = await supabase.storage
+    .from("tier-list-images")
+    .upload(filename, bytes, {
+      contentType: file.type,
+      upsert: false,
+    });
+
+  if (uploadError) {
+    console.error("[Tier Lists Extract] Upload failed:", uploadError);
+    return NextResponse.json({ error: "Upload failed" }, { status: 500 });
+  }
+
+  const { data: publicUrlData } = supabase.storage
+    .from("tier-list-images")
+    .getPublicUrl(filename);
+  const imageUrl = publicUrlData.publicUrl;
+
+  // Fetch all known card names for the extraction prompt
+  const { data: cards } = await supabase.from("cards").select("name");
+  const cardNames = (cards ?? []).map((c) => c.name);
+
+  // Call Claude Sonnet with vision
+  const systemPrompt = buildTierExtractionSystemPrompt(cardNames);
+
+  try {
+    const result = await generateText({
+      model: anthropic(EVAL_MODELS.vision),
+      maxOutputTokens: 4096,
+      system: systemPrompt,
+      messages: [
+        {
+          role: "user",
+          content: [
+            {
+              type: "image",
+              image: new URL(imageUrl),
+            },
+            {
+              type: "text",
+              text: "Extract the tier list from this image. Return the structured JSON per the schema.",
+            },
+          ],
+        },
+      ],
+      output: Output.object({ schema: tierExtractionSchema }),
+    });
+
+    return NextResponse.json({
+      imageUrl,
+      extraction: result.output,
+    });
+  } catch (err) {
+    console.error("[Tier Lists Extract] Vision call failed:", err);
+    return NextResponse.json(
+      {
+        error: "Extraction failed",
+        detail: err instanceof Error ? err.message : String(err),
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/web/src/app/api/admin/tier-lists/extract/route.ts
+++ b/apps/web/src/app/api/admin/tier-lists/extract/route.ts
@@ -8,10 +8,11 @@ import {
   buildTierExtractionSystemPrompt,
 } from "@sts2/shared/evaluation/tier-extraction";
 
-// Gemini 2.5 Pro one-shots tier list extraction where Claude Opus 4.6 struggled
+// Gemini one-shots tier list extraction where Claude Opus 4.6 struggled
 // (tested against dense horizontal-row tier list screenshots with ~150 cards).
 // Requires GOOGLE_GENERATIVE_AI_API_KEY env var.
-const VISION_MODEL = "gemini-2.5-pro";
+// Flash works on AI Studio free tier; Pro requires paid billing.
+const VISION_MODEL = "gemini-2.5-flash";
 
 // Allowlist MIME types to prevent attacker-controlled extensions serving as HTML
 // from the public storage bucket. Keep in sync with migration 023 bucket config.

--- a/apps/web/src/app/api/admin/tier-lists/extract/route.ts
+++ b/apps/web/src/app/api/admin/tier-lists/extract/route.ts
@@ -8,11 +8,12 @@ import {
   buildTierExtractionSystemPrompt,
 } from "@sts2/shared/evaluation/tier-extraction";
 
-// Gemini one-shots tier list extraction where Claude Opus 4.6 struggled
-// (tested against dense horizontal-row tier list screenshots with ~150 cards).
-// Requires GOOGLE_GENERATIVE_AI_API_KEY env var.
-// Flash works on AI Studio free tier; Pro requires paid billing.
-const VISION_MODEL = "gemini-2.5-flash";
+// Gemini 2.5 Pro one-shots tier list extraction where Claude Opus 4.6 and
+// Gemini 2.5 Flash both struggled (tested against dense horizontal-row tier
+// list screenshots with ~150 cards). Requires GOOGLE_GENERATIVE_AI_API_KEY
+// with paid billing on the associated Cloud project.
+// Extraction cost: ~$0.05 per image.
+const VISION_MODEL = "gemini-2.5-pro";
 
 // Allowlist MIME types to prevent attacker-controlled extensions serving as HTML
 // from the public storage bucket. Keep in sync with migration 023 bucket config.

--- a/apps/web/src/app/api/cron/sync-codex/route.ts
+++ b/apps/web/src/app/api/cron/sync-codex/route.ts
@@ -1,0 +1,46 @@
+/**
+ * Cron job: sync Spire Codex game data into Supabase.
+ *
+ * Schedule: daily at 06:00 UTC (configured in vercel.json)
+ *
+ * Required env var: CRON_SECRET
+ *   Vercel auto-injects this header when invoking cron routes. Set the value
+ *   in your Vercel project settings under Environment Variables.
+ *
+ * Manual trigger:
+ *   curl -H "Authorization: Bearer $CRON_SECRET" \
+ *     https://sts2.bollesmedia.com/api/cron/sync-codex
+ *
+ * Pass ?version=0.3.5 to sync under a specific version label; omit to use
+ * the rolling "latest" row (default).
+ */
+
+import { NextResponse } from "next/server";
+import { createServiceClient } from "@/lib/supabase/server";
+import { runCodexSync } from "@/game-data/sync-codex";
+
+export const maxDuration = 300; // 5 min — codex sync takes ~15s but leave headroom
+
+export async function GET(request: Request) {
+  const authHeader = request.headers.get("authorization");
+  if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const supabase = createServiceClient();
+  const version = new URL(request.url).searchParams.get("version") ?? "latest";
+
+  try {
+    await runCodexSync(supabase, version);
+    return NextResponse.json({ success: true, version });
+  } catch (err) {
+    console.error("[Cron sync-codex] Failed:", err);
+    return NextResponse.json(
+      {
+        error: "Sync failed",
+        detail: err instanceof Error ? err.message : String(err),
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/web/src/app/api/evaluate/route.ts
+++ b/apps/web/src/app/api/evaluate/route.ts
@@ -21,6 +21,7 @@ import { EVAL_MODELS } from "@sts2/shared/evaluation/models";
 import { toCardRewardEvaluation } from "@sts2/shared/evaluation/parse-tool-response";
 import { sanitizeRankings } from "@sts2/shared/evaluation/sanitize-rankings";
 import { getStatisticalEvaluation } from "@sts2/shared/evaluation/statistical-evaluator";
+import { getCommunityTierSignals } from "@sts2/shared/evaluation/community-tier";
 import { logEvaluation } from "@sts2/shared/evaluation/evaluation-logger";
 import { tierToValue, type TierLetter } from "@sts2/shared/evaluation/tier-utils";
 import { applyPostEvalWeights, buildWeightContext, adjustTier as adjustTierByDelta, reconcileSkipRecommended } from "@sts2/shared/evaluation/post-eval-weights";
@@ -646,6 +647,36 @@ export async function POST(request: Request) {
     }
   }
 
+  // Community tier list consensus — prior from pro player / community sources
+  let communityTierContext = "";
+  try {
+    const signals = await getCommunityTierSignals(
+      supabase,
+      items.map((i) => i.id),
+      context.character,
+      gameVersion,
+    );
+    if (signals.size > 0) {
+      const ctLines = items
+        .filter((i) => signals.has(i.id))
+        .map((i) => {
+          const s = signals.get(i.id)!;
+          const agreementTag =
+            s.agreement === "strong" ? " [consensus]"
+            : s.agreement === "split" ? ` [sources disagree: stddev ${s.stddev.toFixed(2)}]`
+            : "";
+          const stalenessTag = s.staleness === "aging" ? " [aging]" : "";
+          return `${i.name}: community ${s.consensusTierLetter}-tier (${s.sourceCount} source${s.sourceCount === 1 ? "" : "s"}${agreementTag})${stalenessTag}`;
+        });
+      if (ctLines.length > 0) {
+        communityTierContext = `\n[Community tier lists]\n${ctLines.join("\n")}\nTreat as a prior; trust your analysis of the current deck over it.`;
+      }
+    }
+  } catch (err) {
+    console.warn("[Evaluate] Community tier signal fetch failed:", err);
+    // Non-critical — continue without the signal
+  }
+
   // Build compact prompt — history + narrative + strategy + compact context + items LAST (Haiku recency bias)
   let contextStr = "";
   if (runHistory) {
@@ -668,6 +699,7 @@ export async function POST(request: Request) {
   // Inject historical data before items (gives Claude context without overriding)
   if (historicalContext) contextStr += historicalContext;
   if (winRateContext) contextStr += winRateContext;
+  if (communityTierContext) contextStr += communityTierContext;
 
   // Items go LAST for Haiku's recency bias
   // Flag duplicates and cost inline so Claude can't miss them

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -1,8 +1,7 @@
 @import "tailwindcss" source(none);
 @source "../";
 
-/* Outfit (display) + DM Sans (body) */
-@import url("https://fonts.googleapis.com/css2?family=Outfit:wght@400;500;600;700&family=DM+Sans:ital,opsz,wght@0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700;1,9..40,400&display=swap");
+/* Outfit (display) + DM Sans (body) are loaded via next/font in layout.tsx */
 
 :root {
   /* STS2-inspired palette — blue-violet undertone, not pure grey */
@@ -44,8 +43,8 @@
   --color-spire-text-muted: var(--spire-text-muted);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
-  --font-display: "Outfit", system-ui, sans-serif;
-  --font-body: "DM Sans", system-ui, sans-serif;
+  --font-display: var(--font-outfit), system-ui, sans-serif;
+  --font-body: var(--font-dm-sans), system-ui, sans-serif;
 }
 
 body {

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Geist, Geist_Mono, Outfit, DM_Sans } from "next/font/google";
 import { AuthProvider } from "@/features/auth/auth-provider";
 import "./globals.css";
 
@@ -10,6 +10,17 @@ const geistSans = Geist({
 
 const geistMono = Geist_Mono({
   variable: "--font-geist-mono",
+  subsets: ["latin"],
+});
+
+const outfit = Outfit({
+  variable: "--font-outfit",
+  subsets: ["latin"],
+  weight: ["400", "500", "600", "700"],
+});
+
+const dmSans = DM_Sans({
+  variable: "--font-dm-sans",
   subsets: ["latin"],
 });
 
@@ -26,7 +37,7 @@ export default function RootLayout({
   return (
     <html
       lang="en"
-      className={`${geistSans.variable} ${geistMono.variable} h-full antialiased dark`}
+      className={`${geistSans.variable} ${geistMono.variable} ${outfit.variable} ${dmSans.variable} h-full antialiased dark`}
     >
       <body className="min-h-full flex flex-col bg-background text-foreground font-sans">
         <AuthProvider>{children}</AuthProvider>

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -14,8 +14,7 @@ export default function HomePage() {
     );
   }
 
-  const isDev = process.env.NODE_ENV === "development";
-  if (!user && !isDev) {
+  if (!user) {
     return <LoginScreen />;
   }
 

--- a/apps/web/src/app/runs/page.tsx
+++ b/apps/web/src/app/runs/page.tsx
@@ -51,7 +51,6 @@ function formatDate(dateStr: string): string {
 
 export default function RunsPage() {
   const { user, loading: authLoading } = useAuth();
-  const isDev = process.env.NODE_ENV === "development";
 
   if (authLoading) {
     return (
@@ -61,7 +60,7 @@ export default function RunsPage() {
     );
   }
 
-  if (!user && !isDev) {
+  if (!user) {
     return (
       <div className="min-h-screen bg-background text-foreground flex flex-col">
         <LoginScreen />

--- a/apps/web/src/features/auth/auth-provider.tsx
+++ b/apps/web/src/features/auth/auth-provider.tsx
@@ -3,6 +3,7 @@
 import {
   createContext,
   useContext,
+  useEffect,
   useState,
   useCallback,
   type ReactNode,
@@ -44,11 +45,9 @@ export function useAuth() {
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<User | null>(null);
   const [loading, setLoading] = useState(true);
-  const [initialized, setInitialized] = useState(false);
 
-  if (!initialized) {
-    setInitialized(true);
-    // Initialize shared Supabase client with web app env vars
+  useEffect(() => {
+    // Initialize shared Supabase client with web app env vars (client-only)
     initSupabase(
       process.env.NEXT_PUBLIC_SUPABASE_URL ?? "",
       process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? ""
@@ -63,7 +62,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       }
     });
 
-    supabase.auth.onAuthStateChange((_event, session) => {
+    const { data: sub } = supabase.auth.onAuthStateChange((_event, session) => {
       setUser(session?.user ?? null);
       setLoading(false);
       if (session?.user?.id) {
@@ -72,7 +71,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         localStorage.removeItem("sts2-user-id");
       }
     });
-  }
+
+    return () => sub.subscription.unsubscribe();
+  }, []);
 
   const signOut = useCallback(async () => {
     await authSignOut();

--- a/apps/web/src/game-data/sync-codex.ts
+++ b/apps/web/src/game-data/sync-codex.ts
@@ -6,6 +6,7 @@
  */
 
 import { createClient } from "@supabase/supabase-js";
+import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@sts2/shared/types/database.types";
 import type {
   CardInsert,
@@ -16,16 +17,6 @@ import type {
 } from "@sts2/shared/supabase/helpers";
 
 const CODEX_BASE = "https://spire-codex.com/api";
-
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
-
-if (!supabaseUrl || !supabaseKey) {
-  console.error("Missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY");
-  process.exit(1);
-}
-
-const supabase = createClient<Database>(supabaseUrl, supabaseKey);
 
 async function fetchCodex<T>(path: string): Promise<T> {
   const url = `${CODEX_BASE}${path}`;
@@ -180,7 +171,7 @@ interface CodexCharacter {
   image_url: string | null;
 }
 
-async function syncCards(version: string) {
+async function syncCards(supabase: SupabaseClient<Database>, version: string) {
   console.log("Syncing cards...");
   const cards = await fetchCodex<CodexCard[]>("/cards");
 
@@ -212,7 +203,7 @@ async function syncCards(version: string) {
   console.log(`  ✓ ${rows.length} cards synced`);
 }
 
-async function syncRelics(version: string) {
+async function syncRelics(supabase: SupabaseClient<Database>, version: string) {
   console.log("Syncing relics...");
   const relics = await fetchCodex<CodexRelic[]>("/relics");
 
@@ -231,7 +222,7 @@ async function syncRelics(version: string) {
   console.log(`  ✓ ${rows.length} relics synced`);
 }
 
-async function syncPotions(version: string) {
+async function syncPotions(supabase: SupabaseClient<Database>, version: string) {
   console.log("Syncing potions...");
   const potions = await fetchCodex<CodexPotion[]>("/potions");
 
@@ -250,7 +241,7 @@ async function syncPotions(version: string) {
   console.log(`  ✓ ${rows.length} potions synced`);
 }
 
-async function syncMonsters(version: string) {
+async function syncMonsters(supabase: SupabaseClient<Database>, version: string) {
   console.log("Syncing monsters...");
   const monsters = await fetchCodex<CodexMonster[]>("/monsters");
 
@@ -270,7 +261,7 @@ async function syncMonsters(version: string) {
   console.log(`  ✓ ${rows.length} monsters synced`);
 }
 
-async function syncKeywords(version: string) {
+async function syncKeywords(supabase: SupabaseClient<Database>, version: string) {
   console.log("Syncing keywords...");
   const keywords = await fetchCodex<CodexKeyword[]>("/keywords");
 
@@ -286,7 +277,7 @@ async function syncKeywords(version: string) {
   console.log(`  ✓ ${rows.length} keywords synced`);
 }
 
-async function syncEvents(version: string) {
+async function syncEvents(supabase: SupabaseClient<Database>, version: string) {
   console.log("Syncing events...");
   const events = await fetchCodex<CodexEvent[]>("/events");
 
@@ -311,7 +302,7 @@ async function syncEvents(version: string) {
   console.log(`  ✓ ${rows.length} events synced`);
 }
 
-async function syncEnchantments(version: string) {
+async function syncEnchantments(supabase: SupabaseClient<Database>, version: string) {
   console.log("Syncing enchantments...");
   const enchantments = await fetchCodex<CodexEnchantment[]>("/enchantments");
 
@@ -333,7 +324,7 @@ async function syncEnchantments(version: string) {
   console.log(`  ✓ ${rows.length} enchantments synced`);
 }
 
-async function syncPowers(version: string) {
+async function syncPowers(supabase: SupabaseClient<Database>, version: string) {
   console.log("Syncing powers...");
   const powers = await fetchCodex<CodexPower[]>("/powers");
 
@@ -354,7 +345,7 @@ async function syncPowers(version: string) {
   console.log(`  ✓ ${rows.length} powers synced`);
 }
 
-async function syncEncounters(version: string) {
+async function syncEncounters(supabase: SupabaseClient<Database>, version: string) {
   console.log("Syncing encounters...");
   const encounters = await fetchCodex<CodexEncounter[]>("/encounters");
 
@@ -375,7 +366,7 @@ async function syncEncounters(version: string) {
   console.log(`  ✓ ${rows.length} encounters synced`);
 }
 
-async function syncOrbs(version: string) {
+async function syncOrbs(supabase: SupabaseClient<Database>, version: string) {
   console.log("Syncing orbs...");
   const orbs = await fetchCodex<CodexOrb[]>("/orbs");
 
@@ -393,7 +384,7 @@ async function syncOrbs(version: string) {
   console.log(`  ✓ ${rows.length} orbs synced`);
 }
 
-async function syncAfflictions(version: string) {
+async function syncAfflictions(supabase: SupabaseClient<Database>, version: string) {
   console.log("Syncing afflictions...");
   const afflictions = await fetchCodex<CodexAffliction[]>("/afflictions");
 
@@ -411,7 +402,7 @@ async function syncAfflictions(version: string) {
   console.log(`  ✓ ${rows.length} afflictions synced`);
 }
 
-async function syncCharacters(version: string) {
+async function syncCharacters(supabase: SupabaseClient<Database>, version: string) {
   console.log("Syncing characters...");
   const characters = await fetchCodex<CodexCharacter[]>("/characters");
 
@@ -438,8 +429,7 @@ async function syncCharacters(version: string) {
   console.log(`  ✓ ${rows.length} characters synced`);
 }
 
-async function main() {
-  const version = process.argv[2] ?? "unknown";
+export async function runCodexSync(supabase: SupabaseClient<Database>, version: string) {
   console.log(`\nSyncing Spire Codex data (version: ${version})...\n`);
 
   // Ensure version exists
@@ -447,34 +437,46 @@ async function main() {
     .from("game_versions")
     .upsert({ version, synced_at: new Date().toISOString() });
 
-  // Existing syncs
-  await syncCards(version);
+  await syncCards(supabase, version);
   await delay(1200);
-  await syncRelics(version);
+  await syncRelics(supabase, version);
   await delay(1200);
-  await syncPotions(version);
+  await syncPotions(supabase, version);
   await delay(1200);
-  await syncMonsters(version);
+  await syncMonsters(supabase, version);
   await delay(1200);
-  await syncKeywords(version);
+  await syncKeywords(supabase, version);
   await delay(1200);
-
-  // New syncs
-  await syncEvents(version);
+  await syncEvents(supabase, version);
   await delay(1200);
-  await syncEnchantments(version);
+  await syncEnchantments(supabase, version);
   await delay(1200);
-  await syncPowers(version);
+  await syncPowers(supabase, version);
   await delay(1200);
-  await syncEncounters(version);
+  await syncEncounters(supabase, version);
   await delay(1200);
-  await syncOrbs(version);
+  await syncOrbs(supabase, version);
   await delay(1200);
-  await syncAfflictions(version);
+  await syncAfflictions(supabase, version);
   await delay(1200);
-  await syncCharacters(version);
+  await syncCharacters(supabase, version);
 
   console.log("\n✓ All game data synced successfully!\n");
+}
+
+// CLI entrypoint — only runs when executed directly via tsx/node
+async function main() {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!supabaseUrl || !supabaseKey) {
+    console.error("Missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY");
+    process.exit(1);
+  }
+
+  const supabase = createClient<Database>(supabaseUrl, supabaseKey);
+  const version = process.argv[2] ?? "unknown";
+  await runCodexSync(supabase, version);
 }
 
 main().catch((err) => {

--- a/apps/web/src/lib/api-admin-auth.ts
+++ b/apps/web/src/lib/api-admin-auth.ts
@@ -1,0 +1,38 @@
+import { createServiceClient } from "./supabase/server";
+import { requireAuth } from "./api-auth";
+import { NextResponse } from "next/server";
+
+/**
+ * Validates auth AND checks the user has role='admin' in profiles table.
+ * Returns { userId } on success, or { error } with appropriate status response.
+ *
+ * NOTE: The `profiles` table is not yet reflected in the generated database
+ * types (migration 018 post-dates the last type gen run). Using `any` cast
+ * on the client to bypass the type-level table restriction until types are
+ * regenerated.
+ */
+export async function requireAdmin(): Promise<
+  { userId: string } | { error: NextResponse }
+> {
+  const auth = await requireAuth();
+  if ("error" in auth) return auth;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const supabase = createServiceClient() as any;
+  const { data, error } = await supabase
+    .from("profiles")
+    .select("role")
+    .eq("id", auth.userId)
+    .single();
+
+  if (error || !data || data.role !== "admin") {
+    return {
+      error: NextResponse.json(
+        { error: "Admin access required" },
+        { status: 403 },
+      ),
+    };
+  }
+
+  return { userId: auth.userId };
+}

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,0 +1,8 @@
+{
+  "crons": [
+    {
+      "path": "/api/cron/sync-codex",
+      "schedule": "0 6 * * *"
+    }
+  ]
+}

--- a/packages/shared/evaluation/community-tier.test.ts
+++ b/packages/shared/evaluation/community-tier.test.ts
@@ -1,0 +1,567 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "../types/database.types";
+import {
+  getCommunityTierSignals,
+  classifyByTime,
+  classifyByVersion,
+  buildSignal,
+  computeStaleness,
+  type ConsensusRow,
+  type GameVersionMeta,
+} from "./community-tier";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function daysAgo(n: number): string {
+  const d = new Date(Date.now() - n * 24 * 60 * 60 * 1000);
+  return d.toISOString();
+}
+
+function makeRow(overrides: Partial<ConsensusRow> = {}): ConsensusRow {
+  return {
+    card_id: "STRIKE",
+    character_scope: "any",
+    source_count: 3,
+    weighted_tier: 4,
+    tier_stddev: 0.3,
+    most_recent_published: daysAgo(10),
+    game_versions: ["1.0"],
+    ...overrides,
+  };
+}
+
+function makeVersionMeta(
+  overrides: Partial<GameVersionMeta> = {},
+): GameVersionMeta {
+  return {
+    version: "1.0",
+    released_at: daysAgo(10),
+    is_major_balance_patch: false,
+    ...overrides,
+  };
+}
+
+/** Build a minimal Supabase mock that chains .from().select().in().in() */
+function makeSupabaseMock(options: {
+  consensusRows?: ConsensusRow[];
+  gameVersionRows?: Array<{
+    version: string;
+    released_at: string | null;
+    is_major_balance_patch: boolean;
+  }>;
+  consensusError?: { message: string };
+}): SupabaseClient<Database> {
+  const { consensusRows = [], gameVersionRows = [], consensusError } = options;
+
+  const makeChainable = (finalData: unknown, finalError?: { message: string }) => {
+    const chain: Record<string, unknown> = {};
+    const then = (resolve: (v: { data: unknown; error: unknown }) => void) =>
+      resolve({ data: finalData, error: finalError ?? null });
+
+    const methods = ["select", "in", "eq", "is", "single"];
+    for (const m of methods) {
+      chain[m] = () => ({ ...chain, then });
+    }
+    chain["then"] = then;
+    return chain;
+  };
+
+  const fromMock = (table: string) => {
+    if (table === "community_tier_consensus") {
+      return makeChainable(consensusRows, consensusError);
+    }
+    if (table === "game_versions") {
+      return makeChainable(gameVersionRows);
+    }
+    return makeChainable([]);
+  };
+
+  return { from: fromMock } as unknown as SupabaseClient<Database>;
+}
+
+// ---------------------------------------------------------------------------
+// getCommunityTierSignals
+// ---------------------------------------------------------------------------
+
+describe("getCommunityTierSignals", () => {
+  it("returns empty Map when cardIds is empty", async () => {
+    const supabase = makeSupabaseMock({});
+    const result = await getCommunityTierSignals(supabase, [], null, null);
+    expect(result.size).toBe(0);
+  });
+
+  it("returns empty Map when Supabase returns an error", async () => {
+    const supabase = makeSupabaseMock({
+      consensusError: { message: "db error" },
+    });
+    const result = await getCommunityTierSignals(
+      supabase,
+      ["STRIKE"],
+      null,
+      null,
+    );
+    expect(result.size).toBe(0);
+  });
+
+  it("returns empty Map when no rows returned", async () => {
+    const supabase = makeSupabaseMock({ consensusRows: [] });
+    const result = await getCommunityTierSignals(
+      supabase,
+      ["STRIKE"],
+      null,
+      null,
+    );
+    expect(result.size).toBe(0);
+  });
+
+  it("maps a valid 'any' row to a signal", async () => {
+    const supabase = makeSupabaseMock({
+      consensusRows: [makeRow()],
+      gameVersionRows: [
+        {
+          version: "1.0",
+          released_at: daysAgo(10),
+          is_major_balance_patch: false,
+        },
+      ],
+    });
+    const result = await getCommunityTierSignals(
+      supabase,
+      ["STRIKE"],
+      null,
+      "1.0",
+    );
+    expect(result.has("STRIKE")).toBe(true);
+    const signal = result.get("STRIKE")!;
+    expect(signal.sourceCount).toBe(3);
+    expect(signal.consensusTierLetter).toBe("B"); // weighted_tier: 4
+    expect(signal.agreement).toBe("strong"); // stddev 0.3 < 0.5
+    expect(signal.staleness).toBe("fresh");
+  });
+
+  it("excludes cards with source_count 0", async () => {
+    const supabase = makeSupabaseMock({
+      consensusRows: [makeRow({ source_count: 0 })],
+    });
+    const result = await getCommunityTierSignals(
+      supabase,
+      ["STRIKE"],
+      null,
+      null,
+    );
+    expect(result.size).toBe(0);
+  });
+
+  it("excludes cards with null card_id", async () => {
+    const supabase = makeSupabaseMock({
+      consensusRows: [makeRow({ card_id: null })],
+    });
+    const result = await getCommunityTierSignals(
+      supabase,
+      ["STRIKE"],
+      null,
+      null,
+    );
+    expect(result.size).toBe(0);
+  });
+
+  it("handles multiple cards", async () => {
+    const supabase = makeSupabaseMock({
+      consensusRows: [
+        makeRow({ card_id: "STRIKE" }),
+        makeRow({ card_id: "DEFEND", weighted_tier: 2 }),
+      ],
+    });
+    const result = await getCommunityTierSignals(
+      supabase,
+      ["STRIKE", "DEFEND"],
+      null,
+      null,
+    );
+    expect(result.size).toBe(2);
+    expect(result.get("DEFEND")?.consensusTierLetter).toBe("D");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// classifyByTime
+// ---------------------------------------------------------------------------
+
+describe("classifyByTime", () => {
+  it("null publishedAt → 'fresh' (no date, no penalty)", () => {
+    expect(classifyByTime(null)).toBe("fresh");
+  });
+
+  it("invalid date string → 'fresh'", () => {
+    expect(classifyByTime("not-a-date")).toBe("fresh");
+  });
+
+  it("published today → 'fresh'", () => {
+    expect(classifyByTime(daysAgo(0))).toBe("fresh");
+  });
+
+  it("published 100 days ago → 'fresh'", () => {
+    expect(classifyByTime(daysAgo(100))).toBe("fresh");
+  });
+
+  it("published 179 days ago → 'fresh' (just under AGING_DAYS threshold)", () => {
+    expect(classifyByTime(daysAgo(179))).toBe("fresh");
+  });
+
+  it("published 200 days ago → 'aging'", () => {
+    expect(classifyByTime(daysAgo(200))).toBe("aging");
+  });
+
+  it("published 364 days ago → 'aging' (just under STALE_DAYS threshold)", () => {
+    expect(classifyByTime(daysAgo(364))).toBe("aging");
+  });
+
+  it("published 400 days ago → 'excluded'", () => {
+    expect(classifyByTime(daysAgo(400))).toBe("excluded");
+  });
+
+  it("published 366 days ago → 'excluded'", () => {
+    expect(classifyByTime(daysAgo(366))).toBe("excluded");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// classifyByVersion
+// ---------------------------------------------------------------------------
+
+describe("classifyByVersion", () => {
+  it("no currentGameVersion → 'fresh'", () => {
+    expect(classifyByVersion(["1.0"], null, new Map())).toBe("fresh");
+  });
+
+  it("no listVersions → 'fresh'", () => {
+    expect(classifyByVersion(null, "1.0", new Map())).toBe("fresh");
+  });
+
+  it("empty listVersions → 'fresh'", () => {
+    expect(classifyByVersion([], "1.0", new Map())).toBe("fresh");
+  });
+
+  it("currentGameVersion has no metadata → 'fresh'", () => {
+    const meta = new Map<string, GameVersionMeta>();
+    // version present in map but no released_at
+    meta.set("1.0", makeVersionMeta({ released_at: null }));
+    expect(classifyByVersion(["1.0"], "1.0", meta)).toBe("fresh");
+  });
+
+  it("list version matches current version → 'fresh'", () => {
+    const meta = new Map<string, GameVersionMeta>();
+    const date = daysAgo(30);
+    meta.set("1.0", makeVersionMeta({ version: "1.0", released_at: date }));
+    expect(classifyByVersion(["1.0"], "1.0", meta)).toBe("fresh");
+  });
+
+  it("list version is older but no balance patch between → 'aging'", () => {
+    const meta = new Map<string, GameVersionMeta>();
+    meta.set("0.9", makeVersionMeta({ version: "0.9", released_at: daysAgo(60) }));
+    meta.set("1.0", makeVersionMeta({ version: "1.0", released_at: daysAgo(10) }));
+    // No balance patches
+    expect(classifyByVersion(["0.9"], "1.0", meta)).toBe("aging");
+  });
+
+  it("list version is older AND a balance patch exists between → 'stale'", () => {
+    const meta = new Map<string, GameVersionMeta>();
+    meta.set("0.9", makeVersionMeta({ version: "0.9", released_at: daysAgo(60) }));
+    meta.set("1.0-balance", makeVersionMeta({
+      version: "1.0-balance",
+      released_at: daysAgo(30),
+      is_major_balance_patch: true,
+    }));
+    meta.set("1.0", makeVersionMeta({ version: "1.0", released_at: daysAgo(10) }));
+    expect(classifyByVersion(["0.9"], "1.0", meta)).toBe("stale");
+  });
+
+  it("balance patch is AFTER current version, not between → 'aging'", () => {
+    const meta = new Map<string, GameVersionMeta>();
+    meta.set("0.9", makeVersionMeta({ version: "0.9", released_at: daysAgo(20) }));
+    meta.set("1.0", makeVersionMeta({ version: "1.0", released_at: daysAgo(10) }));
+    // Patch is in the future relative to current
+    meta.set("1.1-balance", makeVersionMeta({
+      version: "1.1-balance",
+      released_at: daysAgo(5),
+      is_major_balance_patch: true,
+    }));
+    // Patch at daysAgo(5) > current at daysAgo(10) → not between list and current
+    expect(classifyByVersion(["0.9"], "1.0", meta)).toBe("aging");
+  });
+
+  it("list version has no metadata → newestListDate stays 0 → 'fresh'", () => {
+    const meta = new Map<string, GameVersionMeta>();
+    meta.set("1.0", makeVersionMeta({ version: "1.0", released_at: daysAgo(10) }));
+    // "0.9" not in meta at all
+    expect(classifyByVersion(["0.9"], "1.0", meta)).toBe("fresh");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildSignal
+// ---------------------------------------------------------------------------
+
+describe("buildSignal", () => {
+  const emptyVersionMeta = new Map<string, GameVersionMeta>();
+
+  it("returns null when rows is empty", () => {
+    expect(buildSignal([], null, null, emptyVersionMeta)).toBeNull();
+  });
+
+  it("returns null when source_count is 0", () => {
+    const row = makeRow({ source_count: 0 });
+    expect(buildSignal([row], null, null, emptyVersionMeta)).toBeNull();
+  });
+
+  it("returns null when source_count is null", () => {
+    const row = makeRow({ source_count: null });
+    expect(buildSignal([row], null, null, emptyVersionMeta)).toBeNull();
+  });
+
+  it("returns null when staleness is 'excluded'", () => {
+    // published 400 days ago → classifyByTime returns 'excluded'
+    const row = makeRow({ most_recent_published: daysAgo(400) });
+    expect(buildSignal([row], null, null, emptyVersionMeta)).toBeNull();
+  });
+
+  it("uses 'any' scope row when no character given", () => {
+    const anyRow = makeRow({ character_scope: "any", weighted_tier: 5 });
+    const charRow = makeRow({ character_scope: "the ironclad", weighted_tier: 2 });
+    const signal = buildSignal([anyRow, charRow], null, null, emptyVersionMeta);
+    expect(signal?.consensusTier).toBe(5);
+  });
+
+  it("character-specific row takes precedence over 'any'", () => {
+    const anyRow = makeRow({ character_scope: "any", weighted_tier: 3 });
+    const charRow = makeRow({ character_scope: "the ironclad", weighted_tier: 6 });
+    const signal = buildSignal(
+      [anyRow, charRow],
+      "The Ironclad", // uppercase — should be lowercased for matching
+      null,
+      emptyVersionMeta,
+    );
+    expect(signal?.consensusTier).toBe(6);
+  });
+
+  it("falls back to 'any' when character row absent", () => {
+    const anyRow = makeRow({ character_scope: "any", weighted_tier: 4 });
+    const signal = buildSignal([anyRow], "the silent", null, emptyVersionMeta);
+    expect(signal?.consensusTier).toBe(4);
+  });
+
+  it("stddev < 0.5 → agreement 'strong'", () => {
+    const row = makeRow({ tier_stddev: 0.4 });
+    const signal = buildSignal([row], null, null, emptyVersionMeta);
+    expect(signal?.agreement).toBe("strong");
+  });
+
+  it("stddev === 0.5 → agreement 'mixed'", () => {
+    const row = makeRow({ tier_stddev: 0.5 });
+    const signal = buildSignal([row], null, null, emptyVersionMeta);
+    expect(signal?.agreement).toBe("mixed");
+  });
+
+  it("stddev 0.8 → agreement 'mixed'", () => {
+    const row = makeRow({ tier_stddev: 0.8 });
+    const signal = buildSignal([row], null, null, emptyVersionMeta);
+    expect(signal?.agreement).toBe("mixed");
+  });
+
+  it("stddev > 1.2 → agreement 'split'", () => {
+    const row = makeRow({ tier_stddev: 1.5 });
+    const signal = buildSignal([row], null, null, emptyVersionMeta);
+    expect(signal?.agreement).toBe("split");
+  });
+
+  it("stddev === 1.2 → agreement 'mixed'", () => {
+    const row = makeRow({ tier_stddev: 1.2 });
+    const signal = buildSignal([row], null, null, emptyVersionMeta);
+    expect(signal?.agreement).toBe("mixed");
+  });
+
+  it("consensusTierLetter maps correctly: tier 4 → B", () => {
+    const row = makeRow({ weighted_tier: 4 });
+    const signal = buildSignal([row], null, null, emptyVersionMeta);
+    expect(signal?.consensusTierLetter).toBe("B");
+  });
+
+  it("consensusTierLetter maps correctly: tier 6 → S", () => {
+    const row = makeRow({ weighted_tier: 6 });
+    const signal = buildSignal([row], null, null, emptyVersionMeta);
+    expect(signal?.consensusTierLetter).toBe("S");
+  });
+
+  it("consensusTierLetter maps correctly: tier 1 → F", () => {
+    const row = makeRow({ weighted_tier: 1 });
+    const signal = buildSignal([row], null, null, emptyVersionMeta);
+    expect(signal?.consensusTierLetter).toBe("F");
+  });
+
+  it("clamps fractional weighted_tier for letter: 4.7 rounds to 5 → A", () => {
+    const row = makeRow({ weighted_tier: 4.7 });
+    const signal = buildSignal([row], null, null, emptyVersionMeta);
+    expect(signal?.consensusTierLetter).toBe("A");
+    expect(signal?.consensusTier).toBeCloseTo(4.7); // raw value preserved
+  });
+
+  it("passes through mostRecentPublished", () => {
+    const date = daysAgo(5);
+    const row = makeRow({ most_recent_published: date });
+    const signal = buildSignal([row], null, null, emptyVersionMeta);
+    expect(signal?.mostRecentPublished).toBe(date);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeStaleness
+// ---------------------------------------------------------------------------
+
+describe("computeStaleness", () => {
+  const emptyMeta = new Map<string, GameVersionMeta>();
+
+  it("time excluded → 'excluded'", () => {
+    const row = makeRow({ most_recent_published: daysAgo(400) });
+    expect(computeStaleness(row, null, emptyMeta)).toBe("excluded");
+  });
+
+  it("time stale + version fresh → 'stale'", () => {
+    // 200 days old → aging from time, but let's use version stale instead
+    const meta = new Map<string, GameVersionMeta>();
+    meta.set("0.9", makeVersionMeta({ version: "0.9", released_at: daysAgo(60) }));
+    meta.set("1.0-balance", makeVersionMeta({
+      version: "1.0-balance",
+      released_at: daysAgo(30),
+      is_major_balance_patch: true,
+    }));
+    meta.set("1.0", makeVersionMeta({ version: "1.0", released_at: daysAgo(10) }));
+
+    const row = makeRow({
+      most_recent_published: daysAgo(10),
+      game_versions: ["0.9"],
+    });
+    // version stale (balance patch between), time fresh → combined: stale
+    expect(computeStaleness(row, "1.0", meta)).toBe("stale");
+  });
+
+  it("time aging + version fresh → 'aging'", () => {
+    const row = makeRow({ most_recent_published: daysAgo(200) });
+    expect(computeStaleness(row, null, emptyMeta)).toBe("aging");
+  });
+
+  it("both fresh → 'fresh'", () => {
+    const row = makeRow({ most_recent_published: daysAgo(10) });
+    expect(computeStaleness(row, null, emptyMeta)).toBe("fresh");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// End-to-end with mocked Supabase
+// ---------------------------------------------------------------------------
+
+describe("getCommunityTierSignals – end-to-end", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("full flow: character-specific wins, version-aware staleness applied", async () => {
+    const versionDate = daysAgo(10);
+    const listDate = daysAgo(90);
+
+    const supabase = makeSupabaseMock({
+      consensusRows: [
+        // 'any' fallback
+        {
+          card_id: "STRIKE",
+          character_scope: "any",
+          source_count: 5,
+          weighted_tier: 3,
+          tier_stddev: 0.4,
+          most_recent_published: listDate,
+          game_versions: ["1.0"],
+        },
+        // character-specific — should win
+        {
+          card_id: "STRIKE",
+          character_scope: "the ironclad",
+          source_count: 10,
+          weighted_tier: 5,
+          tier_stddev: 0.2,
+          most_recent_published: listDate,
+          game_versions: ["1.0"],
+        },
+      ],
+      gameVersionRows: [
+        { version: "1.0", released_at: versionDate, is_major_balance_patch: false },
+      ],
+    });
+
+    const result = await getCommunityTierSignals(
+      supabase,
+      ["STRIKE"],
+      "The Ironclad",
+      "1.0",
+    );
+
+    expect(result.size).toBe(1);
+    const signal = result.get("STRIKE")!;
+    expect(signal.sourceCount).toBe(10); // character-specific row
+    expect(signal.consensusTier).toBe(5);
+    expect(signal.consensusTierLetter).toBe("A");
+    expect(signal.agreement).toBe("strong"); // stddev 0.2
+    expect(signal.staleness).toBe("fresh"); // version matches current, recent date
+  });
+
+  it("excludes card when time-based staleness is excluded (>365 days)", async () => {
+    const supabase = makeSupabaseMock({
+      consensusRows: [
+        {
+          card_id: "DEFEND",
+          character_scope: "any",
+          source_count: 5,
+          weighted_tier: 4,
+          tier_stddev: 0.3,
+          most_recent_published: daysAgo(400),
+          game_versions: [],
+        },
+      ],
+      gameVersionRows: [],
+    });
+
+    const result = await getCommunityTierSignals(
+      supabase,
+      ["DEFEND"],
+      null,
+      null,
+    );
+    expect(result.size).toBe(0);
+  });
+
+  it("returns 'stale' when balance patch exists between list version and current", async () => {
+    const supabase = makeSupabaseMock({
+      consensusRows: [
+        {
+          card_id: "BASH",
+          character_scope: "any",
+          source_count: 3,
+          weighted_tier: 4,
+          tier_stddev: 0.5,
+          most_recent_published: daysAgo(30),
+          game_versions: ["0.9"],
+        },
+      ],
+      gameVersionRows: [
+        { version: "0.9", released_at: daysAgo(90), is_major_balance_patch: false },
+        { version: "1.0-balance", released_at: daysAgo(45), is_major_balance_patch: true },
+        { version: "1.0", released_at: daysAgo(10), is_major_balance_patch: false },
+      ],
+    });
+
+    const result = await getCommunityTierSignals(supabase, ["BASH"], null, "1.0");
+    expect(result.size).toBe(1);
+    expect(result.get("BASH")?.staleness).toBe("stale");
+  });
+});

--- a/packages/shared/evaluation/community-tier.test.ts
+++ b/packages/shared/evaluation/community-tier.test.ts
@@ -7,6 +7,7 @@ import {
   classifyByVersion,
   buildSignal,
   computeStaleness,
+  normalizeCharacter,
   type ConsensusRow,
   type GameVersionMeta,
 } from "./community-tier";
@@ -337,10 +338,12 @@ describe("buildSignal", () => {
 
   it("character-specific row takes precedence over 'any'", () => {
     const anyRow = makeRow({ character_scope: "any", weighted_tier: 3 });
-    const charRow = makeRow({ character_scope: "the ironclad", weighted_tier: 6 });
+    // Tier lists store the short form ("ironclad"); game state sends
+    // "The Ironclad" which the query normalizes before matching.
+    const charRow = makeRow({ character_scope: "ironclad", weighted_tier: 6 });
     const signal = buildSignal(
       [anyRow, charRow],
-      "The Ironclad", // uppercase — should be lowercased for matching
+      "The Ironclad",
       null,
       emptyVersionMeta,
     );
@@ -483,10 +486,11 @@ describe("getCommunityTierSignals – end-to-end", () => {
           most_recent_published: listDate,
           game_versions: ["1.0"],
         },
-        // character-specific — should win
+        // character-specific — should win. Tier lists store "ironclad"
+        // (short form); the query normalizes "The Ironclad" → "ironclad".
         {
           card_id: "STRIKE",
-          character_scope: "the ironclad",
+          character_scope: "ironclad",
           source_count: 10,
           weighted_tier: 5,
           tier_stddev: 0.2,
@@ -513,6 +517,30 @@ describe("getCommunityTierSignals – end-to-end", () => {
     expect(signal.consensusTierLetter).toBe("A");
     expect(signal.agreement).toBe("strong"); // stddev 0.2
     expect(signal.staleness).toBe("fresh"); // version matches current, recent date
+  });
+});
+
+describe("normalizeCharacter", () => {
+  it("strips 'The ' prefix and lowercases", () => {
+    expect(normalizeCharacter("The Ironclad")).toBe("ironclad");
+    expect(normalizeCharacter("THE SILENT")).toBe("silent");
+    expect(normalizeCharacter("Defect")).toBe("defect");
+  });
+
+  it("handles already-normalized input", () => {
+    expect(normalizeCharacter("ironclad")).toBe("ironclad");
+    expect(normalizeCharacter("silent")).toBe("silent");
+  });
+
+  it("returns null for null, empty, or 'unknown'", () => {
+    expect(normalizeCharacter(null)).toBeNull();
+    expect(normalizeCharacter("")).toBeNull();
+    expect(normalizeCharacter("Unknown")).toBeNull();
+    expect(normalizeCharacter("   ")).toBeNull();
+  });
+
+  it("trims whitespace", () => {
+    expect(normalizeCharacter("  The Ironclad  ")).toBe("ironclad");
   });
 
   it("excludes card when time-based staleness is excluded (>365 days)", async () => {

--- a/packages/shared/evaluation/community-tier.ts
+++ b/packages/shared/evaluation/community-tier.ts
@@ -41,8 +41,12 @@ export async function getCommunityTierSignals(
   const result = new Map<string, CommunityTierSignal>();
   if (cardIds.length === 0) return result;
 
-  // Fetch character-specific entries + 'any' fallback entries in one query
-  const scopes = character ? [character.toLowerCase(), "any"] : ["any"];
+  // Fetch character-specific entries + 'any' fallback entries in one query.
+  // The game client sends "The Ironclad" style names (lowercased to "the
+  // ironclad"); tier list admins enter "ironclad". Normalize both to the
+  // short form so the scope matches.
+  const normalized = normalizeCharacter(character);
+  const scopes = normalized ? [normalized, "any"] : ["any"];
 
   const { data: rows, error } = await supabase
     .from("community_tier_consensus")
@@ -116,6 +120,20 @@ export type ConsensusRow = {
   game_versions: string[] | null;
 };
 
+/**
+ * Normalize a character name to the short canonical form used by tier list
+ * `character_scope` ("ironclad", "silent", etc.). The game client sends
+ * "The Ironclad" while admins enter "ironclad" — strip the "the " prefix
+ * and lowercase so the scope matches either way.
+ * Returns null when the input is null/unknown.
+ */
+export function normalizeCharacter(character: string | null): string | null {
+  if (!character) return null;
+  const trimmed = character.trim().toLowerCase();
+  if (!trimmed || trimmed === "unknown") return null;
+  return trimmed.replace(/^the\s+/, "");
+}
+
 export function buildSignal(
   rows: ConsensusRow[],
   character: string | null,
@@ -124,7 +142,7 @@ export function buildSignal(
 ): CommunityTierSignal | null {
   // Prefer character-specific row when available; fall back to 'any'
   const characterRow = character
-    ? rows.find((r) => r.character_scope === character.toLowerCase())
+    ? rows.find((r) => r.character_scope === normalizeCharacter(character))
     : null;
   const anyRow = rows.find((r) => r.character_scope === "any");
   const chosen = characterRow ?? anyRow;

--- a/packages/shared/evaluation/community-tier.ts
+++ b/packages/shared/evaluation/community-tier.ts
@@ -1,0 +1,228 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "../types/database.types";
+import { valueToTier, type TierLetter } from "./tier-utils";
+
+/**
+ * Per-card community tier signal derived from aggregated tier lists.
+ * Used to inject a prior into LLM evaluations.
+ */
+export interface CommunityTierSignal {
+  consensusTier: number; // 1-6 weighted avg
+  consensusTierLetter: TierLetter;
+  sourceCount: number;
+  stddev: number;
+  agreement: "strong" | "mixed" | "split";
+  staleness: "fresh" | "aging" | "stale";
+  mostRecentPublished: string | null;
+}
+
+export interface GameVersionMeta {
+  version: string;
+  released_at: string | null; // ISO date
+  is_major_balance_patch: boolean;
+}
+
+const DAY_MS = 1000 * 60 * 60 * 24;
+const AGING_DAYS = 180;
+const STALE_DAYS = 365;
+
+/**
+ * Load community tier signals for the given card IDs and character.
+ * Applies staleness rules based on game version + publish date.
+ *
+ * Returns a Map<cardId, CommunityTierSignal>. Cards without data are absent.
+ */
+export async function getCommunityTierSignals(
+  supabase: SupabaseClient<Database>,
+  cardIds: string[],
+  character: string | null,
+  currentGameVersion: string | null,
+): Promise<Map<string, CommunityTierSignal>> {
+  const result = new Map<string, CommunityTierSignal>();
+  if (cardIds.length === 0) return result;
+
+  // Fetch character-specific entries + 'any' fallback entries in one query
+  const scopes = character ? [character.toLowerCase(), "any"] : ["any"];
+
+  const { data: rows, error } = await supabase
+    .from("community_tier_consensus")
+    .select(
+      "card_id, character_scope, source_count, weighted_tier, tier_stddev, most_recent_published, game_versions",
+    )
+    .in("card_id", cardIds)
+    .in("character_scope", scopes);
+
+  if (error || !rows) return result;
+
+  // Load game_versions metadata needed for staleness detection
+  const versions = new Set<string>();
+  for (const r of rows) {
+    for (const v of r.game_versions ?? []) versions.add(v);
+  }
+  if (currentGameVersion) versions.add(currentGameVersion);
+
+  const versionMeta = await loadGameVersionMeta(supabase, Array.from(versions));
+
+  // Group rows by card_id, merging character-specific + any-scope entries
+  // Character-specific takes precedence when both exist
+  const byCard = new Map<string, typeof rows>();
+  for (const r of rows) {
+    if (!r.card_id) continue;
+    const existing = byCard.get(r.card_id);
+    if (!existing) {
+      byCard.set(r.card_id, [r]);
+    } else {
+      existing.push(r);
+    }
+  }
+
+  for (const [cardId, cardRows] of byCard.entries()) {
+    const signal = buildSignal(cardRows, character, currentGameVersion, versionMeta);
+    if (signal) result.set(cardId, signal);
+  }
+
+  return result;
+}
+
+export async function loadGameVersionMeta(
+  supabase: SupabaseClient<Database>,
+  versions: string[],
+): Promise<Map<string, GameVersionMeta>> {
+  const result = new Map<string, GameVersionMeta>();
+  if (versions.length === 0) return result;
+
+  const { data: rows } = await supabase
+    .from("game_versions")
+    .select("version, released_at, is_major_balance_patch")
+    .in("version", versions);
+
+  for (const r of rows ?? []) {
+    result.set(r.version, {
+      version: r.version,
+      released_at: r.released_at,
+      is_major_balance_patch: r.is_major_balance_patch,
+    });
+  }
+  return result;
+}
+
+export type ConsensusRow = {
+  card_id: string | null;
+  character_scope: string | null;
+  source_count: number | null;
+  weighted_tier: number | null;
+  tier_stddev: number | null;
+  most_recent_published: string | null;
+  game_versions: string[] | null;
+};
+
+export function buildSignal(
+  rows: ConsensusRow[],
+  character: string | null,
+  currentGameVersion: string | null,
+  versionMeta: Map<string, GameVersionMeta>,
+): CommunityTierSignal | null {
+  // Prefer character-specific row when available; fall back to 'any'
+  const characterRow = character
+    ? rows.find((r) => r.character_scope === character.toLowerCase())
+    : null;
+  const anyRow = rows.find((r) => r.character_scope === "any");
+  const chosen = characterRow ?? anyRow;
+  if (!chosen) return null;
+
+  const consensusTier = chosen.weighted_tier ?? 3;
+  const sourceCount = chosen.source_count ?? 0;
+  const stddev = chosen.tier_stddev ?? 0;
+  if (sourceCount === 0) return null;
+
+  const agreement: CommunityTierSignal["agreement"] =
+    stddev < 0.5 ? "strong" : stddev > 1.2 ? "split" : "mixed";
+
+  const staleness = computeStaleness(chosen, currentGameVersion, versionMeta);
+  if (staleness === "excluded") return null;
+
+  const roundedTier = Math.round(consensusTier);
+  const clampedTier = Math.max(1, Math.min(6, roundedTier));
+
+  return {
+    consensusTier,
+    consensusTierLetter: valueToTier(clampedTier),
+    sourceCount,
+    stddev,
+    agreement,
+    staleness,
+    mostRecentPublished: chosen.most_recent_published,
+  };
+}
+
+export function computeStaleness(
+  row: ConsensusRow,
+  currentGameVersion: string | null,
+  versionMeta: Map<string, GameVersionMeta>,
+): "fresh" | "aging" | "stale" | "excluded" {
+  const timeBucket = classifyByTime(row.most_recent_published);
+  if (timeBucket === "excluded") return "excluded";
+
+  const versionBucket = classifyByVersion(
+    row.game_versions,
+    currentGameVersion,
+    versionMeta,
+  );
+  if (versionBucket === "excluded") return "excluded";
+
+  // Combine: take the worse of the two
+  if (timeBucket === "stale" || versionBucket === "stale") return "stale";
+  if (timeBucket === "aging" || versionBucket === "aging") return "aging";
+  return "fresh";
+}
+
+export function classifyByTime(
+  publishedAt: string | null,
+): "fresh" | "aging" | "stale" | "excluded" {
+  if (!publishedAt) return "fresh"; // no date info, don't penalize
+  const now = Date.now();
+  const published = new Date(publishedAt).getTime();
+  if (Number.isNaN(published)) return "fresh";
+  const ageDays = (now - published) / DAY_MS;
+  if (ageDays < AGING_DAYS) return "fresh";
+  if (ageDays < STALE_DAYS) return "aging";
+  return "excluded"; // > 365 days: excluded
+}
+
+export function classifyByVersion(
+  listVersions: string[] | null,
+  currentGameVersion: string | null,
+  versionMeta: Map<string, GameVersionMeta>,
+): "fresh" | "aging" | "stale" | "excluded" {
+  if (!currentGameVersion || !listVersions || listVersions.length === 0)
+    return "fresh";
+
+  const current = versionMeta.get(currentGameVersion);
+  if (!current?.released_at) return "fresh"; // no metadata — can't classify, trust time-based
+
+  const currentDate = new Date(current.released_at).getTime();
+  let hasBalancePatchBetween = false;
+  let newestListDate = 0;
+
+  for (const v of listVersions) {
+    const meta = versionMeta.get(v);
+    if (!meta?.released_at) continue;
+    const listDate = new Date(meta.released_at).getTime();
+    if (listDate > newestListDate) newestListDate = listDate;
+
+    // Any balance patch strictly between this list's version and current?
+    for (const other of versionMeta.values()) {
+      if (!other.is_major_balance_patch || !other.released_at) continue;
+      const otherDate = new Date(other.released_at).getTime();
+      if (otherDate > listDate && otherDate <= currentDate) {
+        hasBalancePatchBetween = true;
+      }
+    }
+  }
+
+  if (hasBalancePatchBetween) return "stale";
+  if (newestListDate === 0) return "fresh";
+  // If list version is current, fresh; if not current but no balance patch between, aging
+  if (currentDate === newestListDate) return "fresh";
+  return "aging";
+}

--- a/packages/shared/evaluation/eval-schemas.test.ts
+++ b/packages/shared/evaluation/eval-schemas.test.ts
@@ -222,6 +222,11 @@ describe("eval-schemas", () => {
   //           Anthropic: "For 'array' type, 'minItems' values other than 0
   //                       or 1 are not supported"
   //           (minItems of 0 or 1 is fine — same for maxItems.)
+  //   • #68  number type with `minimum` or `maximum`
+  //           zod: `z.number().min(X)` / `.max(X)` / `.gte(X)` / `.lte(X)`
+  //           Anthropic: "For 'number' type, properties maximum, minimum
+  //                       are not supported"
+  //           Enforce via prompt + post-parse clamping in caller instead.
   //
   // The Phase 4.5 smoke test (route.test.ts) uses MockLanguageModelV3 so it
   // never round-trips through Anthropic's validator. This guard closes that
@@ -248,6 +253,14 @@ describe("eval-schemas", () => {
           throw new Error(
             `[${schemaName}] integer schema at ${where} carries minimum/maximum, which Anthropic structured-output rejects (#48). ` +
               `Use plain z.number() instead of z.number().int() or z.int(). Node: ${JSON.stringify(node)}`,
+          );
+        }
+
+        // #68 — number min/max
+        if (node.type === "number" && ("minimum" in node || "maximum" in node)) {
+          throw new Error(
+            `[${schemaName}] number schema at ${where} carries minimum/maximum, which Anthropic structured-output rejects (#68). ` +
+              `Use plain z.number() and clamp post-parse in the caller. Node: ${JSON.stringify(node)}`,
           );
         }
 
@@ -297,6 +310,20 @@ describe("eval-schemas", () => {
         expect(() =>
           assertAnthropicCompatible(z.toJSONSchema(bad), "bad-int"),
         ).toThrow(/integer schema at .* carries minimum\/maximum/);
+      });
+
+      it("catches number .min() (#68)", () => {
+        const bad = z.object({ confidence: z.number().min(0) });
+        expect(() =>
+          assertAnthropicCompatible(z.toJSONSchema(bad), "bad-num-min"),
+        ).toThrow(/number schema at .* carries minimum\/maximum/);
+      });
+
+      it("catches number .max() (#68)", () => {
+        const bad = z.object({ confidence: z.number().max(1) });
+        expect(() =>
+          assertAnthropicCompatible(z.toJSONSchema(bad), "bad-num-max"),
+        ).toThrow(/number schema at .* carries minimum\/maximum/);
       });
 
       it("catches array .length(N) where N > 1 (#52)", () => {

--- a/packages/shared/evaluation/eval-schemas.test.ts
+++ b/packages/shared/evaluation/eval-schemas.test.ts
@@ -8,6 +8,7 @@ import {
   simpleEvalSchema,
   buildCardRewardSchema,
 } from "./eval-schemas";
+import { tierExtractionSchema } from "./tier-extraction";
 
 describe("eval-schemas", () => {
   describe("bossBriefingSchema", () => {
@@ -279,6 +280,7 @@ describe("eval-schemas", () => {
         [{ name: "Strike" }, { name: "Defend" }, { name: "Bash" }],
         true,
       )],
+      ["tierExtractionSchema", tierExtractionSchema],
     ];
 
     it.each(cases)("%s is Anthropic-compatible", (name, schema) => {

--- a/packages/shared/evaluation/models.ts
+++ b/packages/shared/evaluation/models.ts
@@ -19,6 +19,7 @@
 export const EVAL_MODELS = {
   default: "claude-haiku-4-5",
   boss: "claude-haiku-4-5",
+  vision: "claude-sonnet-4-5",
 } as const;
 
 export type EvalModelId = (typeof EVAL_MODELS)[keyof typeof EVAL_MODELS];

--- a/packages/shared/evaluation/models.ts
+++ b/packages/shared/evaluation/models.ts
@@ -19,7 +19,6 @@
 export const EVAL_MODELS = {
   default: "claude-haiku-4-5",
   boss: "claude-haiku-4-5",
-  vision: "claude-opus-4-5",
 } as const;
 
 export type EvalModelId = (typeof EVAL_MODELS)[keyof typeof EVAL_MODELS];

--- a/packages/shared/evaluation/models.ts
+++ b/packages/shared/evaluation/models.ts
@@ -19,7 +19,7 @@
 export const EVAL_MODELS = {
   default: "claude-haiku-4-5",
   boss: "claude-haiku-4-5",
-  vision: "claude-sonnet-4-5",
+  vision: "claude-opus-4-5",
 } as const;
 
 export type EvalModelId = (typeof EVAL_MODELS)[keyof typeof EVAL_MODELS];

--- a/packages/shared/evaluation/tier-extraction.ts
+++ b/packages/shared/evaluation/tier-extraction.ts
@@ -54,20 +54,45 @@ export function buildTierExtractionSystemPrompt(cardNames: string[]): string {
   const nameList = cardNames.slice().sort().join(", ");
   return `You are extracting a Slay the Spire 2 tier list from an image.
 
-The user will provide an image showing STS2 cards organized in tiers (S/A/B/C/D/F, 1-10, good/bad, etc.).
+## Image layout
 
-For each tier section visible in the image, identify the cards in that tier.
-Match card names against this authoritative list of STS2 cards:
+The image is a horizontal-row tier list, cascading vertically:
+
+    S  | [card] [card] [card] [card] [card] ...
+    A  | [card] [card] [card] ...
+    B  | [card] [card] ...
+    C  | [card] ...
+    D  | [card] [card] ...
+
+Each row is one tier. The tier label (S, A, B, C, D, F, 1–10, etc.) is at the LEFT edge of the row. Cards belonging to that tier extend horizontally to the RIGHT of the label, arranged left-to-right.
+
+A card's tier is determined by which ROW it sits in. Horizontal position within a row carries no meaning — a card on the left of the S row is equally S-tier to one on the right.
+
+## Process
+
+1. Identify the tier labels (the leftmost column) and their vertical bands.
+2. For each tier row, scan left-to-right and identify every card visible in that horizontal band.
+3. A card belongs to a row if its vertical center is within that row's band. If a card straddles two bands, note it in warnings and assign to the row containing most of its area.
+4. Do NOT assign cards from outside the tier-list grid (e.g., labels, icons, thumbnails in sidebars, or cards shown in legends/examples).
+
+## Card identification
+
+Match each card against this authoritative list of STS2 cards. Use BOTH the card name text and the card art to match:
+
 ${nameList}
 
-Output structured JSON per the schema. Follow these rules:
+Return the EXACT canonical name from the list above. Case-sensitive. Do not abbreviate or paraphrase.
+
+## Output rules
 
 1. If the image is NOT an STS2 tier list, return { "error": "not_a_tier_list" } and empty tiers array.
-2. detected_scale: infer from the tier labels present. If labels are S/A/B/C/D/F → "letter_6". If S/A/B/C/D (no F) → "letter_5". If numeric 1-10 → "numeric_10". If 1-5 → "numeric_5". If only "good"/"bad" or "pick"/"skip" → "binary".
-3. detected_character: if the image targets one character (e.g. "Ironclad Tier List"), return that character name lowercase. If no character specified or cross-character, return null.
-4. For each card, return the exact canonical name from the authoritative list. Do NOT invent card names.
-5. confidence: 0.9+ when you clearly recognize the card art and name. 0.7-0.9 when reasonably confident. Below 0.7 means uncertain — prefer to omit the card rather than guess.
-6. warnings: include notes about ambiguous sections, cards you couldn't identify, unusual tier scales, or anything the admin should review.
+2. detected_scale: infer from the tier labels present. S/A/B/C/D/F → "letter_6". S/A/B/C/D (no F) → "letter_5". 1–10 → "numeric_10". 1–5 → "numeric_5". good/bad or pick/skip → "binary".
+3. detected_character: if the image targets one character (e.g., "Ironclad Tier List" in the header), return that character name lowercase. If no character specified or cross-character, return null.
+4. Every card must appear in the authoritative list above. Do NOT invent names.
+5. confidence: 0.9+ = clearly recognize both art and name. 0.7–0.9 = reasonably confident from context. Below 0.7 = uncertain — prefer to omit rather than guess.
+6. warnings: list any cards you couldn't identify (describe their position), unusual tier scales, cards that straddle rows, duplicate cards, or anything the admin should review.
 
-Be thorough but accurate. Omitting a card is better than guessing wrong.`;
+Be thorough: scan every row completely before moving on. A missing card is worse than no output — if the image is clear and you skip cards, you've done the task poorly.
+
+Omitting an uncertain card is better than fabricating a match.`;
 }

--- a/packages/shared/evaluation/tier-extraction.ts
+++ b/packages/shared/evaluation/tier-extraction.ts
@@ -48,51 +48,19 @@ export type TierExtractionResult = z.infer<typeof tierExtractionSchema>;
 
 /**
  * Build the system prompt for tier list extraction.
- * Takes the authoritative list of STS2 card names so the model can match reliably.
+ * Intentionally minimal — Gemini 2.5 Pro one-shots this task with a short prompt
+ * and degrades under verbose instructions (thinking-token burn). The
+ * authoritative card list is the only load-bearing anti-hallucination lever;
+ * everything else is a hint.
  */
 export function buildTierExtractionSystemPrompt(cardNames: string[]): string {
   const nameList = cardNames.slice().sort().join(", ");
-  return `You are extracting a Slay the Spire 2 tier list from an image.
+  return `This is a Slay the Spire 2 card tier list. Extract every card into the JSON schema.
 
-## Image layout
+Layout: tier labels in the leftmost column, cards arranged horizontally in each row. Card names appear at the top-center of each card sprite.
 
-The image is a horizontal-row tier list, cascading vertically:
-
-    S  | [card] [card] [card] [card] [card] ...
-    A  | [card] [card] [card] ...
-    B  | [card] [card] ...
-    C  | [card] ...
-    D  | [card] [card] ...
-
-Each row is one tier. The tier label (S, A, B, C, D, F, 1–10, etc.) is at the LEFT edge of the row. Cards belonging to that tier extend horizontally to the RIGHT of the label, arranged left-to-right.
-
-A card's tier is determined by which ROW it sits in. Horizontal position within a row carries no meaning — a card on the left of the S row is equally S-tier to one on the right.
-
-## Process
-
-1. Identify the tier labels (the leftmost column) and their vertical bands.
-2. For each tier row, scan left-to-right and identify every card visible in that horizontal band.
-3. A card belongs to a row if its vertical center is within that row's band. If a card straddles two bands, note it in warnings and assign to the row containing most of its area.
-4. Do NOT assign cards from outside the tier-list grid (e.g., labels, icons, thumbnails in sidebars, or cards shown in legends/examples).
-
-## Card identification
-
-Match each card against this authoritative list of STS2 cards. Use BOTH the card name text and the card art to match:
-
+Card names must match this canonical list exactly (case-sensitive):
 ${nameList}
 
-Return the EXACT canonical name from the list above. Case-sensitive. Do not abbreviate or paraphrase.
-
-## Output rules
-
-1. If the image is NOT an STS2 tier list, return { "error": "not_a_tier_list" } and empty tiers array.
-2. detected_scale: infer from the tier labels present. S/A/B/C/D/F → "letter_6". S/A/B/C/D (no F) → "letter_5". 1–10 → "numeric_10". 1–5 → "numeric_5". good/bad or pick/skip → "binary".
-3. detected_character: if the image targets one character (e.g., "Ironclad Tier List" in the header), return that character name lowercase. If no character specified or cross-character, return null.
-4. Every card must appear in the authoritative list above. Do NOT invent names.
-5. confidence: 0.9+ = clearly recognize both art and name. 0.7–0.9 = reasonably confident from context. Below 0.7 = uncertain — prefer to omit rather than guess.
-6. warnings: list any cards you couldn't identify (describe their position), unusual tier scales, cards that straddle rows, duplicate cards, or anything the admin should review.
-
-Be thorough: scan every row completely before moving on. A missing card is worse than no output — if the image is clear and you skip cards, you've done the task poorly.
-
-Omitting an uncertain card is better than fabricating a match.`;
+Every card visible in the image must appear in the output. If a name isn't in the canonical list, omit it and note the read text in warnings.`;
 }

--- a/packages/shared/evaluation/tier-extraction.ts
+++ b/packages/shared/evaluation/tier-extraction.ts
@@ -6,7 +6,9 @@ import { z } from "zod";
  *
  * ⚠️ Avoid zod constraints that emit JSON Schema features rejected by
  * Anthropic's structured-output endpoint — see the notes in eval-schemas.ts.
- * In particular: no z.number().int(), no z.array().min/max/length().
+ * In particular: no z.number().int(), no z.array().min/max/length(),
+ * no z.number().min/max() — numeric bounds are also rejected. Enforce
+ * via prompt instructions + post-parse clamping in the caller instead.
  */
 
 export const tierExtractionSchema = z.object({
@@ -31,7 +33,9 @@ export const tierExtractionSchema = z.object({
             name: z
               .string()
               .describe("Canonical card name from the provided authoritative list"),
-            confidence: z.number().min(0).max(1),
+            confidence: z
+              .number()
+              .describe("0.0–1.0 — how confident the match is. Clamped server-side."),
           }),
         ),
       }),

--- a/packages/shared/evaluation/tier-extraction.ts
+++ b/packages/shared/evaluation/tier-extraction.ts
@@ -48,19 +48,13 @@ export type TierExtractionResult = z.infer<typeof tierExtractionSchema>;
 
 /**
  * Build the system prompt for tier list extraction.
- * Intentionally minimal — Gemini 2.5 Pro one-shots this task with a short prompt
- * and degrades under verbose instructions (thinking-token burn). The
- * authoritative card list is the only load-bearing anti-hallucination lever;
- * everything else is a hint.
+ * Intentionally minimal. Matching to canonical card names happens client-side —
+ * the model's job is to read whatever text is on each card and return it.
  */
-export function buildTierExtractionSystemPrompt(cardNames: string[]): string {
-  const nameList = cardNames.slice().sort().join(", ");
+export function buildTierExtractionSystemPrompt(): string {
   return `This is a Slay the Spire 2 card tier list. Extract every card into the JSON schema.
 
-Layout: tier labels in the leftmost column, cards arranged horizontally in each row. Card names appear at the top-center of each card sprite.
+Layout: tier labels in the leftmost column, cards arranged horizontally in each row. Card names appear at the top-center of each card sprite — read the name text directly from there.
 
-Card names must match this canonical list exactly (case-sensitive):
-${nameList}
-
-Every card visible in the image must appear in the output. If a name isn't in the canonical list, omit it and note the read text in warnings.`;
+Every card visible in the image must appear in the output. Return the name exactly as printed on the card, including any "+" for upgraded variants. Do not omit cards whose names look unfamiliar — extract them as-is.`;
 }

--- a/packages/shared/evaluation/tier-extraction.ts
+++ b/packages/shared/evaluation/tier-extraction.ts
@@ -1,0 +1,69 @@
+import { z } from "zod";
+
+/**
+ * Claude Sonnet extracts tier list data from uploaded images.
+ * Returns structured JSON matching this schema, or an error marker.
+ *
+ * ⚠️ Avoid zod constraints that emit JSON Schema features rejected by
+ * Anthropic's structured-output endpoint — see the notes in eval-schemas.ts.
+ * In particular: no z.number().int(), no z.array().min/max/length().
+ */
+
+export const tierExtractionSchema = z.object({
+  error: z.string().nullable().optional(),
+  detected_scale: z
+    .enum(["letter_6", "letter_5", "numeric_10", "numeric_5", "binary"])
+    .nullable()
+    .optional(),
+  detected_character: z
+    .string()
+    .nullable()
+    .optional()
+    .describe("Ironclad|Silent|Defect|Regent|Necrobinder, or null if cross-character"),
+  tiers: z
+    .array(
+      z.object({
+        label: z
+          .string()
+          .describe("The tier label from the image (e.g. 'S', 'A', '9', 'good')"),
+        cards: z.array(
+          z.object({
+            name: z
+              .string()
+              .describe("Canonical card name from the provided authoritative list"),
+            confidence: z.number().min(0).max(1),
+          }),
+        ),
+      }),
+    )
+    .default([]),
+  warnings: z.array(z.string()).default([]),
+});
+
+export type TierExtractionResult = z.infer<typeof tierExtractionSchema>;
+
+/**
+ * Build the system prompt for tier list extraction.
+ * Takes the authoritative list of STS2 card names so the model can match reliably.
+ */
+export function buildTierExtractionSystemPrompt(cardNames: string[]): string {
+  const nameList = cardNames.slice().sort().join(", ");
+  return `You are extracting a Slay the Spire 2 tier list from an image.
+
+The user will provide an image showing STS2 cards organized in tiers (S/A/B/C/D/F, 1-10, good/bad, etc.).
+
+For each tier section visible in the image, identify the cards in that tier.
+Match card names against this authoritative list of STS2 cards:
+${nameList}
+
+Output structured JSON per the schema. Follow these rules:
+
+1. If the image is NOT an STS2 tier list, return { "error": "not_a_tier_list" } and empty tiers array.
+2. detected_scale: infer from the tier labels present. If labels are S/A/B/C/D/F → "letter_6". If S/A/B/C/D (no F) → "letter_5". If numeric 1-10 → "numeric_10". If 1-5 → "numeric_5". If only "good"/"bad" or "pick"/"skip" → "binary".
+3. detected_character: if the image targets one character (e.g. "Ironclad Tier List"), return that character name lowercase. If no character specified or cross-character, return null.
+4. For each card, return the exact canonical name from the authoritative list. Do NOT invent card names.
+5. confidence: 0.9+ when you clearly recognize the card art and name. 0.7-0.9 when reasonably confident. Below 0.7 means uncertain — prefer to omit the card rather than guess.
+6. warnings: include notes about ambiguous sections, cards you couldn't identify, unusual tier scales, or anything the admin should review.
+
+Be thorough but accurate. Omitting a card is better than guessing wrong.`;
+}

--- a/packages/shared/evaluation/tier-normalize.test.ts
+++ b/packages/shared/evaluation/tier-normalize.test.ts
@@ -1,0 +1,230 @@
+import { describe, it, expect } from "vitest";
+import { normalizeTier } from "./tier-normalize";
+import type { TierNormalizationSource } from "./tier-normalize";
+
+function src(scale_type: TierNormalizationSource["scale_type"], map?: Record<string, number>): TierNormalizationSource {
+  return { scale_type, scale_config: map ? { map } : null };
+}
+
+describe("normalizeTier – letter_6 scale", () => {
+  const source = src("letter_6");
+
+  it.each([
+    ["S", 6],
+    ["A", 5],
+    ["B", 4],
+    ["C", 3],
+    ["D", 2],
+    ["F", 1],
+  ])('"%s" → %d, matched: true', (raw, expected) => {
+    const result = normalizeTier(raw, source);
+    expect(result.normalizedTier).toBe(expected);
+    expect(result.matched).toBe(true);
+  });
+
+  it("is case-insensitive: 's' → 6", () => {
+    const result = normalizeTier("s", source);
+    expect(result.normalizedTier).toBe(6);
+    expect(result.matched).toBe(true);
+  });
+
+  it('"S-tier" → 6', () => {
+    const result = normalizeTier("S-tier", source);
+    expect(result.normalizedTier).toBe(6);
+    expect(result.matched).toBe(true);
+  });
+
+  it('"Tier A" → 5', () => {
+    const result = normalizeTier("Tier A", source);
+    expect(result.normalizedTier).toBe(5);
+    expect(result.matched).toBe(true);
+  });
+
+  it('"b" → 4', () => {
+    const result = normalizeTier("b", source);
+    expect(result.normalizedTier).toBe(4);
+    expect(result.matched).toBe(true);
+  });
+
+  it('"S+" clamps to 6 (cannot exceed max)', () => {
+    const result = normalizeTier("S+", source);
+    expect(result.normalizedTier).toBe(6);
+    expect(result.matched).toBe(true);
+  });
+
+  it('"A+" → 5.5', () => {
+    const result = normalizeTier("A+", source);
+    expect(result.normalizedTier).toBe(5.5);
+    expect(result.matched).toBe(true);
+  });
+
+  it('"A-" → 4.5', () => {
+    const result = normalizeTier("A-", source);
+    expect(result.normalizedTier).toBe(4.5);
+    expect(result.matched).toBe(true);
+  });
+
+  it('"Z" → 3, matched: false (unknown letter)', () => {
+    const result = normalizeTier("Z", source);
+    expect(result.normalizedTier).toBe(3);
+    expect(result.matched).toBe(false);
+  });
+
+  it('"" → 3, matched: false (empty string)', () => {
+    const result = normalizeTier("", source);
+    expect(result.normalizedTier).toBe(3);
+    expect(result.matched).toBe(false);
+  });
+});
+
+describe("normalizeTier – letter_5 scale", () => {
+  const source = src("letter_5");
+
+  it('"D" → 2, matched: true (D is lowest in letter_5)', () => {
+    const result = normalizeTier("D", source);
+    expect(result.normalizedTier).toBe(2);
+    expect(result.matched).toBe(true);
+  });
+
+  it('"F" → 3, matched: false (F not in letter_5 map)', () => {
+    // F matches the letter regex but is not in the letter_5 map → base undefined → fallback
+    const result = normalizeTier("F", source);
+    expect(result.normalizedTier).toBe(3);
+    expect(result.matched).toBe(false);
+  });
+
+  it('"S" → 6, matched: true', () => {
+    const result = normalizeTier("S", source);
+    expect(result.normalizedTier).toBe(6);
+    expect(result.matched).toBe(true);
+  });
+});
+
+describe("normalizeTier – numeric_10 scale", () => {
+  const source = src("numeric_10");
+
+  it('"1" → 1', () => {
+    const result = normalizeTier("1", source);
+    expect(result.normalizedTier).toBe(1);
+    expect(result.matched).toBe(true);
+  });
+
+  it('"10" → 6', () => {
+    const result = normalizeTier("10", source);
+    expect(result.normalizedTier).toBe(6);
+    expect(result.matched).toBe(true);
+  });
+
+  it('"5.5" → 3.5', () => {
+    const result = normalizeTier("5.5", source);
+    expect(result.normalizedTier).toBe(3.5);
+    expect(result.matched).toBe(true);
+  });
+
+  it('"Tier 7" → 4.3 (1 + (7-1)/9 * 5, rounded to 1dp)', () => {
+    const result = normalizeTier("Tier 7", source);
+    expect(result.normalizedTier).toBe(4.3);
+    expect(result.matched).toBe(true);
+  });
+
+  it('"11" → 3, matched: false (out of range)', () => {
+    const result = normalizeTier("11", source);
+    expect(result.normalizedTier).toBe(3);
+    expect(result.matched).toBe(false);
+  });
+
+  it('"0" → 3, matched: false (out of range)', () => {
+    const result = normalizeTier("0", source);
+    expect(result.normalizedTier).toBe(3);
+    expect(result.matched).toBe(false);
+  });
+});
+
+describe("normalizeTier – numeric_5 scale", () => {
+  const source = src("numeric_5");
+
+  it('"1" → 1', () => {
+    const result = normalizeTier("1", source);
+    expect(result.normalizedTier).toBe(1);
+    expect(result.matched).toBe(true);
+  });
+
+  it('"5" → 6', () => {
+    const result = normalizeTier("5", source);
+    expect(result.normalizedTier).toBe(6);
+    expect(result.matched).toBe(true);
+  });
+
+  it('"3" → 3.5', () => {
+    const result = normalizeTier("3", source);
+    expect(result.normalizedTier).toBe(3.5);
+    expect(result.matched).toBe(true);
+  });
+});
+
+describe("normalizeTier – binary scale", () => {
+  const source = src("binary");
+
+  it.each(["good", "pick", "yes", "take", "strong"])('"%s" → 5, matched: true', (raw) => {
+    const result = normalizeTier(raw, source);
+    expect(result.normalizedTier).toBe(5);
+    expect(result.matched).toBe(true);
+  });
+
+  it.each(["bad", "no", "skip", "avoid", "weak", "trash"])('"%s" → 2, matched: true', (raw) => {
+    const result = normalizeTier(raw, source);
+    expect(result.normalizedTier).toBe(2);
+    expect(result.matched).toBe(true);
+  });
+
+  it('"maybe" → 3, matched: false', () => {
+    const result = normalizeTier("maybe", source);
+    expect(result.normalizedTier).toBe(3);
+    expect(result.matched).toBe(false);
+  });
+});
+
+describe("normalizeTier – per-source overrides via scale_config.map", () => {
+  it("exact map match takes priority over scale_type logic", () => {
+    const source = src("letter_6", { "S+": 6, "S": 5, "A": 4 });
+    const result = normalizeTier("S+", source);
+    expect(result.normalizedTier).toBe(6);
+    expect(result.matched).toBe(true);
+  });
+
+  it("case-insensitive override: 's+' matches 'S+' in map", () => {
+    const source = src("letter_6", { "S+": 6, "S": 5, "A": 4 });
+    const result = normalizeTier("s+", source);
+    expect(result.normalizedTier).toBe(6);
+    expect(result.matched).toBe(true);
+  });
+
+  it("unknown tier falls through to base scale_type when not in override map", () => {
+    // Map only covers S+/S/A; "B" should fall through to letter_6 base logic
+    const source = src("letter_6", { "S+": 6, "S": 5, "A": 4 });
+    const result = normalizeTier("B", source);
+    expect(result.normalizedTier).toBe(4); // letter_6 default for B
+    expect(result.matched).toBe(true);
+  });
+
+  it("override map values are clamped to 1-6", () => {
+    const source = src("letter_6", { overpower: 10 });
+    const result = normalizeTier("overpower", source);
+    expect(result.normalizedTier).toBe(6);
+    expect(result.matched).toBe(true);
+  });
+});
+
+describe("normalizeTier – edge cases", () => {
+  it("empty raw string → 3, matched: false", () => {
+    const result = normalizeTier("", src("letter_6"));
+    expect(result.normalizedTier).toBe(3);
+    expect(result.matched).toBe(false);
+  });
+
+  it('whitespace-only "  S  " is trimmed → 6, matched: true', () => {
+    const result = normalizeTier("  S  ", src("letter_6"));
+    expect(result.normalizedTier).toBe(6);
+    expect(result.matched).toBe(true);
+  });
+});

--- a/packages/shared/evaluation/tier-normalize.ts
+++ b/packages/shared/evaluation/tier-normalize.ts
@@ -1,0 +1,117 @@
+/**
+ * Normalize tier labels from heterogeneous community tier list sources
+ * to a 1-6 internal scale (S=6, A=5, B=4, C=3, D=2, F=1).
+ */
+
+export type ScaleType = "letter_6" | "letter_5" | "numeric_10" | "numeric_5" | "binary";
+
+export interface TierNormalizationSource {
+  scale_type: ScaleType;
+  scale_config: { map?: Record<string, number> } | null;
+}
+
+export interface NormalizationResult {
+  normalizedTier: number; // 1-6
+  matched: boolean;       // true if we confidently matched the raw tier
+}
+
+const LETTER_6_MAP: Record<string, number> = {
+  S: 6, A: 5, B: 4, C: 3, D: 2, F: 1,
+};
+
+// Letter-5 scales typically omit F; D is the lowest tier
+const LETTER_5_MAP: Record<string, number> = {
+  S: 6, A: 5, B: 4, C: 3, D: 2,
+};
+
+/**
+ * Normalize a raw tier label to the 1-6 scale.
+ * Returns { normalizedTier, matched } where matched=false signals a fallback.
+ */
+export function normalizeTier(
+  raw: string,
+  source: TierNormalizationSource,
+): NormalizationResult {
+  const cleaned = raw.trim();
+  if (!cleaned) return { normalizedTier: 3, matched: false };
+
+  // Per-source overrides take priority
+  const overrideMap = source.scale_config?.map;
+  if (overrideMap) {
+    // Try exact match first
+    if (cleaned in overrideMap) {
+      return { normalizedTier: clamp(overrideMap[cleaned]), matched: true };
+    }
+    // Try case-insensitive match
+    const lowerKey = cleaned.toLowerCase();
+    for (const [key, value] of Object.entries(overrideMap)) {
+      if (key.toLowerCase() === lowerKey) {
+        return { normalizedTier: clamp(value), matched: true };
+      }
+    }
+  }
+
+  switch (source.scale_type) {
+    case "letter_6":
+      return normalizeLetter(cleaned, LETTER_6_MAP);
+    case "letter_5":
+      return normalizeLetter(cleaned, LETTER_5_MAP);
+    case "numeric_10":
+      return normalizeNumeric(cleaned, 1, 10);
+    case "numeric_5":
+      return normalizeNumeric(cleaned, 1, 5);
+    case "binary":
+      return normalizeBinary(cleaned);
+    default:
+      return { normalizedTier: 3, matched: false };
+  }
+}
+
+function clamp(n: number): number {
+  if (Number.isNaN(n)) return 3;
+  if (n < 1) return 1;
+  if (n > 6) return 6;
+  return n;
+}
+
+function normalizeLetter(raw: string, baseMap: Record<string, number>): NormalizationResult {
+  // Extract the letter: handle "S-tier", "Tier S", "S+", "A-", "s", etc.
+  const match = raw.match(/[SABCDF]/i);
+  if (!match) return { normalizedTier: 3, matched: false };
+  const letter = match[0].toUpperCase();
+  const base = baseMap[letter];
+  if (base === undefined) return { normalizedTier: 3, matched: false };
+
+  // Check for modifiers directly attached to the tier letter (e.g. "S+", "A-", "A+")
+  // + bumps up by 0.5, - bumps down by 0.5 (clamped to scale)
+  // We only apply a modifier when the +/- immediately follows the letter (letter+-suffix only).
+  // "S-tier" has a hyphen but it's a separator, not a grade modifier.
+  let modifier = 0;
+  if (/[SABCDF]\+/i.test(raw)) modifier = 0.5;
+  else if (/[SABCDF]-(?!tier)/i.test(raw)) modifier = -0.5;
+
+  return { normalizedTier: clamp(base + modifier), matched: true };
+}
+
+function normalizeNumeric(raw: string, min: number, max: number): NormalizationResult {
+  // Extract the first number from the string
+  const match = raw.match(/-?\d+(\.\d+)?/);
+  if (!match) return { normalizedTier: 3, matched: false };
+  const n = parseFloat(match[0]);
+  if (Number.isNaN(n)) return { normalizedTier: 3, matched: false };
+  if (n < min || n > max) return { normalizedTier: 3, matched: false };
+  // Linear map [min, max] → [1, 6]
+  const normalized = 1 + ((n - min) / (max - min)) * 5;
+  return { normalizedTier: clamp(Math.round(normalized * 10) / 10), matched: true };
+}
+
+function normalizeBinary(raw: string): NormalizationResult {
+  const lower = raw.toLowerCase();
+  if (/\b(good|yes|pick|take|strong|auto[- ]?pick)\b/.test(lower)) {
+    return { normalizedTier: 5, matched: true };
+  }
+  if (/\b(bad|no|skip|avoid|weak|trash)\b/.test(lower)) {
+    return { normalizedTier: 2, matched: true };
+  }
+  return { normalizedTier: 3, matched: false };
+}

--- a/packages/shared/supabase/helpers.ts
+++ b/packages/shared/supabase/helpers.ts
@@ -35,6 +35,16 @@ export type EncounterInsert = Database["public"]["Tables"]["encounters"]["Insert
 export type OrbInsert = Database["public"]["Tables"]["orbs"]["Insert"];
 export type AfflictionInsert = Database["public"]["Tables"]["afflictions"]["Insert"];
 
+export type TierListSource = Database["public"]["Tables"]["tier_list_sources"]["Row"];
+export type TierList = Database["public"]["Tables"]["tier_lists"]["Row"];
+export type TierListEntry = Database["public"]["Tables"]["tier_list_entries"]["Row"];
+export type CommunityTierConsensus = Database["public"]["Views"]["community_tier_consensus"]["Row"];
+
+// Insert types
+export type TierListSourceInsert = Database["public"]["Tables"]["tier_list_sources"]["Insert"];
+export type TierListInsert = Database["public"]["Tables"]["tier_lists"]["Insert"];
+export type TierListEntryInsert = Database["public"]["Tables"]["tier_list_entries"]["Insert"];
+
 // View types
 export type EvaluationStat = Database["public"]["Views"]["evaluation_stats"]["Row"];
 export type EvaluationStatV2 = Database["public"]["Views"]["evaluation_stats_v2"]["Row"];

--- a/packages/shared/types/database.types.ts
+++ b/packages/shared/types/database.types.ts
@@ -457,16 +457,28 @@ export type Database = {
       game_versions: {
         Row: {
           id: string
+          is_major_balance_patch: boolean
+          notes_url: string | null
+          release_notes: string | null
+          released_at: string | null
           synced_at: string | null
           version: string
         }
         Insert: {
           id?: string
+          is_major_balance_patch?: boolean
+          notes_url?: string | null
+          release_notes?: string | null
+          released_at?: string | null
           synced_at?: string | null
           version: string
         }
         Update: {
           id?: string
+          is_major_balance_patch?: boolean
+          notes_url?: string | null
+          release_notes?: string | null
+          released_at?: string | null
           synced_at?: string | null
           version?: string
         }
@@ -765,6 +777,147 @@ export type Database = {
         }
         Relationships: []
       }
+      tier_list_entries: {
+        Row: {
+          card_id: string
+          created_at: string
+          extraction_confidence: number | null
+          id: string
+          normalized_tier: number
+          note: string | null
+          raw_tier: string
+          tier_list_id: string
+        }
+        Insert: {
+          card_id: string
+          created_at?: string
+          extraction_confidence?: number | null
+          id?: string
+          normalized_tier: number
+          note?: string | null
+          raw_tier: string
+          tier_list_id: string
+        }
+        Update: {
+          card_id?: string
+          created_at?: string
+          extraction_confidence?: number | null
+          id?: string
+          normalized_tier?: number
+          note?: string | null
+          raw_tier?: string
+          tier_list_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "tier_list_entries_tier_list_id_fkey"
+            columns: ["tier_list_id"]
+            isOneToOne: false
+            referencedRelation: "tier_lists"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "tier_list_entries_card_id_fkey"
+            columns: ["card_id"]
+            isOneToOne: false
+            referencedRelation: "cards"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      tier_list_sources: {
+        Row: {
+          author: string
+          created_at: string
+          id: string
+          notes: string | null
+          scale_config: Json | null
+          scale_type: string
+          source_type: string
+          source_url: string | null
+          trust_weight: number
+          updated_at: string
+        }
+        Insert: {
+          author: string
+          created_at?: string
+          id: string
+          notes?: string | null
+          scale_config?: Json | null
+          scale_type: string
+          source_type: string
+          source_url?: string | null
+          trust_weight?: number
+          updated_at?: string
+        }
+        Update: {
+          author?: string
+          created_at?: string
+          id?: string
+          notes?: string | null
+          scale_config?: Json | null
+          scale_type?: string
+          source_type?: string
+          source_url?: string | null
+          trust_weight?: number
+          updated_at?: string
+        }
+        Relationships: []
+      }
+      tier_lists: {
+        Row: {
+          character: string | null
+          entry_count: number
+          game_version: string | null
+          id: string
+          ingested_at: string
+          ingestion_method: string
+          is_active: boolean
+          published_at: string
+          source_id: string
+          source_image_url: string | null
+        }
+        Insert: {
+          character?: string | null
+          entry_count?: number
+          game_version?: string | null
+          id?: string
+          ingested_at?: string
+          ingestion_method: string
+          is_active?: boolean
+          published_at: string
+          source_id: string
+          source_image_url?: string | null
+        }
+        Update: {
+          character?: string | null
+          entry_count?: number
+          game_version?: string | null
+          id?: string
+          ingested_at?: string
+          ingestion_method?: string
+          is_active?: boolean
+          published_at?: string
+          source_id?: string
+          source_image_url?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "tier_lists_source_id_fkey"
+            columns: ["source_id"]
+            isOneToOne: false
+            referencedRelation: "tier_list_sources"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "tier_lists_game_version_fkey"
+            columns: ["game_version"]
+            isOneToOne: false
+            referencedRelation: "game_versions"
+            referencedColumns: ["version"]
+          },
+        ]
+      }
       afflictions: {
         Row: {
           description: string
@@ -1046,6 +1199,19 @@ export type Database = {
       }
     }
     Views: {
+      community_tier_consensus: {
+        Row: {
+          card_id: string | null
+          character_scope: string | null
+          game_versions: string[] | null
+          most_recent_published: string | null
+          oldest_published: string | null
+          source_count: number | null
+          tier_stddev: number | null
+          weighted_tier: number | null
+        }
+        Relationships: []
+      }
       card_win_rates: {
         Row: {
           act: number | null

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,6 +102,9 @@ importers:
       '@ai-sdk/anthropic':
         specifier: ^3.0.67
         version: 3.0.67(zod@4.3.6)
+      '@ai-sdk/google':
+        specifier: ^3.0.63
+        version: 3.0.63(zod@4.3.6)
       '@sts2/shared':
         specifier: workspace:*
         version: link:../../packages/shared
@@ -116,7 +119,7 @@ importers:
         version: 6.0.148(zod@4.3.6)
       next:
         specifier: 16.2.1
-        version: 16.2.1(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 16.2.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react:
         specifier: 19.2.4
         version: 19.2.4
@@ -220,6 +223,12 @@ packages:
 
   '@ai-sdk/gateway@3.0.90':
     resolution: {integrity: sha512-vCzFx5E3SZWZN6ukRZzmX8yTSrx6FihDjm3yGI77POA4RPSF6tG88+CcU7o+Taa9fbY4qMcbKmcfCrt8ABqhYQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/google@3.0.63':
+    resolution: {integrity: sha512-RfOZWVMYSPu2sPRfGajrauWAZ9BSaRopSn+AszkKWQ1MFj8nhaXvCqRHB5pBQUaHTfZKagvOmMpNfa/s3gPLgQ==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -3379,6 +3388,12 @@ snapshots:
       '@vercel/oidc': 3.1.0
       zod: 4.3.6
 
+  '@ai-sdk/google@3.0.63(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.23(zod@4.3.6)
+      zod: 4.3.6
+
   '@ai-sdk/provider-utils@4.0.23(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
@@ -5050,8 +5065,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.2.1
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.4(jiti@2.6.1))
@@ -5073,7 +5088,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -5084,22 +5099,22 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -5110,7 +5125,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -5731,7 +5746,7 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  next@16.2.1(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  next@16.2.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@next/env': 16.2.1
       '@swc/helpers': 0.5.15
@@ -5740,7 +5755,7 @@ snapshots:
       postcss: 8.4.31
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      styled-jsx: 5.1.6(react@19.2.4)
+      styled-jsx: 5.1.6(@babel/core@7.29.0)(react@19.2.4)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.2.1
       '@next/swc-darwin-x64': 16.2.1
@@ -6189,10 +6204,12 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
-  styled-jsx@5.1.6(react@19.2.4):
+  styled-jsx@5.1.6(@babel/core@7.29.0)(react@19.2.4):
     dependencies:
       client-only: 0.0.1
       react: 19.2.4
+    optionalDependencies:
+      '@babel/core': 7.29.0
 
   supports-color@7.2.0:
     dependencies:

--- a/supabase/migrations/022_community_tier_lists.sql
+++ b/supabase/migrations/022_community_tier_lists.sql
@@ -1,0 +1,105 @@
+-- ============================================
+-- Community tier list aggregation signal
+-- Adds tier list sources, snapshots, per-card entries + consensus MV
+-- Extends game_versions with release metadata for staleness detection
+-- ============================================
+
+-- Extend game_versions with release metadata
+alter table game_versions
+  add column if not exists released_at date,
+  add column if not exists release_notes text,
+  add column if not exists is_major_balance_patch boolean not null default false,
+  add column if not exists notes_url text;
+
+-- Tier list sources — metadata about where a tier list came from
+create table tier_list_sources (
+  id text primary key,                    -- slug, e.g. 'baalorlord_2026q1'
+  author text not null,
+  source_type text not null check (source_type in ('image', 'spreadsheet', 'website', 'reddit', 'youtube')),
+  source_url text,
+  trust_weight real not null default 1.0 check (trust_weight >= 0 and trust_weight <= 2),
+  scale_type text not null check (scale_type in ('letter_6', 'letter_5', 'numeric_10', 'numeric_5', 'binary')),
+  scale_config jsonb,                     -- per-source tier overrides (e.g. S+/SS tiers)
+  notes text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+-- Tier lists — per-snapshot of a source (version/date-scoped)
+create table tier_lists (
+  id uuid primary key default gen_random_uuid(),
+  source_id text not null references tier_list_sources(id) on delete cascade,
+  game_version text references game_versions(version),
+  published_at date not null,
+  character text,                         -- null = cross-character
+  is_active boolean not null default true,
+  source_image_url text,                  -- Supabase Storage URL for original image
+  ingestion_method text not null check (ingestion_method in ('vision_llm', 'manual_confirm', 'scraped')),
+  ingested_at timestamptz not null default now(),
+  entry_count int not null default 0,
+  constraint tier_lists_unique unique (source_id, game_version, published_at, character)
+);
+
+create index idx_tier_lists_active on tier_lists (is_active, game_version) where is_active;
+create index idx_tier_lists_source on tier_lists (source_id);
+
+-- Tier list entries — per-card tier data
+create table tier_list_entries (
+  id uuid primary key default gen_random_uuid(),
+  tier_list_id uuid not null references tier_lists(id) on delete cascade,
+  card_id text not null references cards(id) on delete cascade,
+  raw_tier text not null,                 -- source's original label (e.g. 'S', '9', 'good')
+  normalized_tier real not null check (normalized_tier >= 1 and normalized_tier <= 6),
+  note text,
+  extraction_confidence real check (extraction_confidence >= 0 and extraction_confidence <= 1),
+  created_at timestamptz not null default now(),
+  constraint tier_list_entries_unique unique (tier_list_id, card_id)
+);
+
+create index idx_tier_list_entries_card on tier_list_entries (card_id);
+create index idx_tier_list_entries_list on tier_list_entries (tier_list_id);
+
+-- Materialized view: aggregated consensus across active tier lists
+create materialized view community_tier_consensus as
+with active as (
+  select
+    tle.card_id,
+    tle.normalized_tier,
+    tls.trust_weight,
+    coalesce(tl.character, 'any') as character_scope,
+    tl.game_version,
+    tl.published_at
+  from tier_list_entries tle
+  join tier_lists tl on tl.id = tle.tier_list_id
+  join tier_list_sources tls on tls.id = tl.source_id
+  where tl.is_active = true
+)
+select
+  card_id,
+  character_scope,
+  count(*)::int as source_count,
+  round(
+    (sum(normalized_tier * trust_weight) / nullif(sum(trust_weight), 0))::numeric,
+    2
+  )::real as weighted_tier,
+  coalesce(stddev(normalized_tier)::real, 0) as tier_stddev,
+  max(published_at) as most_recent_published,
+  min(published_at) as oldest_published,
+  array_agg(distinct game_version) filter (where game_version is not null) as game_versions
+from active
+group by card_id, character_scope;
+
+create unique index idx_ctc_pk on community_tier_consensus (card_id, character_scope);
+
+-- ============================================
+-- RLS policies (public read, same as other reference tables)
+-- ============================================
+
+alter table tier_list_sources enable row level security;
+create policy "Public read" on tier_list_sources for select using (true);
+
+alter table tier_lists enable row level security;
+create policy "Public read" on tier_lists for select using (true);
+
+alter table tier_list_entries enable row level security;
+create policy "Public read" on tier_list_entries for select using (true);

--- a/supabase/migrations/022_community_tier_lists.sql
+++ b/supabase/migrations/022_community_tier_lists.sql
@@ -31,7 +31,7 @@ create table tier_lists (
   source_id text not null references tier_list_sources(id) on delete cascade,
   game_version text references game_versions(version),
   published_at date not null,
-  character text,                         -- null = cross-character
+  character text check (character is null or character = lower(character)),
   is_active boolean not null default true,
   source_image_url text,                  -- Supabase Storage URL for original image
   ingestion_method text not null check (ingestion_method in ('vision_llm', 'manual_confirm', 'scraped')),
@@ -59,14 +59,16 @@ create table tier_list_entries (
 create index idx_tier_list_entries_card on tier_list_entries (card_id);
 create index idx_tier_list_entries_list on tier_list_entries (tier_list_id);
 
--- Materialized view: aggregated consensus across active tier lists
+-- Materialized view: aggregated consensus across active tier lists.
+-- `character_scope` is lowercased so 'Ironclad' and 'ironclad' merge into
+-- a single group regardless of how source rows are stored.
 create materialized view community_tier_consensus as
 with active as (
   select
     tle.card_id,
     tle.normalized_tier,
     tls.trust_weight,
-    coalesce(tl.character, 'any') as character_scope,
+    coalesce(lower(tl.character), 'any') as character_scope,
     tl.game_version,
     tl.published_at
   from tier_list_entries tle

--- a/supabase/migrations/023_tier_list_storage.sql
+++ b/supabase/migrations/023_tier_list_storage.sql
@@ -10,7 +10,7 @@ values (
   'tier-list-images',
   'tier-list-images',
   true,
-  10485760,  -- 10 MB
+  26214400,  -- 25 MB — matches next.config proxyClientMaxBodySize + route limit
   array['image/png', 'image/jpeg', 'image/webp']
 )
 on conflict (id) do update set

--- a/supabase/migrations/023_tier_list_storage.sql
+++ b/supabase/migrations/023_tier_list_storage.sql
@@ -1,0 +1,14 @@
+-- ============================================
+-- Supabase Storage bucket for tier list images
+-- ============================================
+
+-- Public read bucket for admin-uploaded tier list images
+insert into storage.buckets (id, name, public)
+values ('tier-list-images', 'tier-list-images', true)
+on conflict (id) do nothing;
+
+-- Allow public read access
+create policy "Public read tier list images" on storage.objects
+  for select using (bucket_id = 'tier-list-images');
+
+-- Only service role writes (handled via RLS bypass — no policy needed)

--- a/supabase/migrations/023_tier_list_storage.sql
+++ b/supabase/migrations/023_tier_list_storage.sql
@@ -2,10 +2,20 @@
 -- Supabase Storage bucket for tier list images
 -- ============================================
 
--- Public read bucket for admin-uploaded tier list images
-insert into storage.buckets (id, name, public)
-values ('tier-list-images', 'tier-list-images', true)
-on conflict (id) do nothing;
+-- Public read bucket for admin-uploaded tier list images.
+-- MIME allowlist prevents attacker-controlled content-types (e.g. HTML) from
+-- being served through the public URL. Keep in sync with extract/route.ts.
+insert into storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+values (
+  'tier-list-images',
+  'tier-list-images',
+  true,
+  10485760,  -- 10 MB
+  array['image/png', 'image/jpeg', 'image/webp']
+)
+on conflict (id) do update set
+  file_size_limit = excluded.file_size_limit,
+  allowed_mime_types = excluded.allowed_mime_types;
 
 -- Allow public read access
 create policy "Public read tier list images" on storage.objects

--- a/supabase/migrations/024_refresh_consensus_rpc.sql
+++ b/supabase/migrations/024_refresh_consensus_rpc.sql
@@ -1,0 +1,11 @@
+create or replace function refresh_community_tier_consensus()
+returns void
+language plpgsql
+security definer
+as $$
+begin
+  refresh materialized view concurrently community_tier_consensus;
+end;
+$$;
+
+revoke all on function refresh_community_tier_consensus() from public;

--- a/supabase/migrations/025_tier_list_bucket_size.sql
+++ b/supabase/migrations/025_tier_list_bucket_size.sql
@@ -1,0 +1,8 @@
+-- Bump tier-list-images bucket size limit from 10MB to 25MB.
+-- Matches the next.config proxyClientMaxBodySize and extract route
+-- MAX_IMAGE_BYTES so large full-page tier list screenshots (typically
+-- 10-20MB as uncompressed PNG) can be uploaded without re-encoding.
+
+update storage.buckets
+set file_size_limit = 26214400  -- 25 MB
+where id = 'tier-list-images';


### PR DESCRIPTION
## Summary
- New schema: \`tier_list_sources\`, \`tier_lists\`, \`tier_list_entries\` + \`community_tier_consensus\` materialized view
- Extended \`game_versions\` with \`released_at\`, \`release_notes\`, \`is_major_balance_patch\`, \`notes_url\` for version-aware staleness
- Vision LLM ingestion: admin uploads tier list image → Claude Sonnet extracts tiers → admin confirms → persisted
- Community consensus injected into card/shop eval prompts with agreement (consensus/split) and staleness (aging) tags
- 94 new tests, all 488 passing; all 3 packages type-check clean

Closes #67

## Test plan
- [ ] Apply migrations 022, 023, 024
- [ ] Create test admin user (set \`profiles.role = 'admin'\`)
- [ ] Upload sample tier list image (e.g. https://i.imgur.com/kwWeG1b.jpeg) at \`/admin/tier-lists\`
- [ ] Verify extraction returns reasonable tiers with confidence scores
- [ ] Confirm → verify rows appear in DB, MV refreshes
- [ ] Trigger a card reward eval for a card in the seeded list — verify prompt contains \`[Community tier lists]\` section
- [ ] Test staleness: set \`game_versions.is_major_balance_patch = true\` for a version between the tier list's version and current → entries should be excluded

🤖 Generated with [Claude Code](https://claude.com/claude-code)