### PR TITLE
feat: map coach compliance phase 2

### DIFF
--- a/apps/desktop/src/components/swap-badge.test.tsx
+++ b/apps/desktop/src/components/swap-badge.test.tsx
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { SwapBadge } from "./swap-badge";
+
+describe("SwapBadge", () => {
+  it("renders SWAPPED label and reason as tooltip", () => {
+    render(<SwapBadge reason="dominated_by_path_B" />);
+    expect(screen.getByText(/swapped/i)).toBeInTheDocument();
+    const el = screen.getByText(/swapped/i);
+    expect(el.getAttribute("title")).toBe("dominated_by_path_B");
+  });
+
+  it("uses amber color tokens for visibility", () => {
+    const { container } = render(<SwapBadge reason="x" />);
+    expect(container.firstChild).toHaveClass("text-amber-400");
+  });
+
+  it("falls back to generic label when reason is null", () => {
+    render(<SwapBadge reason={null} />);
+    expect(screen.getByText(/swapped/i)).toBeInTheDocument();
+  });
+});

--- a/apps/desktop/src/components/swap-badge.tsx
+++ b/apps/desktop/src/components/swap-badge.tsx
@@ -1,0 +1,14 @@
+interface SwapBadgeProps {
+  reason: string | null;
+}
+
+export function SwapBadge({ reason }: SwapBadgeProps) {
+  return (
+    <span
+      title={reason ?? "server-side swap"}
+      className="text-[10px] font-semibold uppercase tracking-wider px-1.5 py-0.5 rounded border text-amber-400 bg-amber-500/10 border-amber-500/25"
+    >
+      ↻ Swapped
+    </span>
+  );
+}

--- a/apps/desktop/src/features/map/mapListeners.ts
+++ b/apps/desktop/src/features/map/mapListeners.ts
@@ -407,7 +407,7 @@ export function setupMapEvalListener() {
       listenerApi.dispatch(mapEvalUpdated({ ...preEval, bestPathNodes: preEval.recommendedNodes }));
 
       try {
-        const { prompt: mapPrompt, runState } = buildMapPrompt({
+        const { prompt: mapPrompt, runState, compliance: mapCompliance } = buildMapPrompt({
           context: ctx,
           state: mapState,
           cardRemovalCost: player?.cardRemovalCost ?? null,
@@ -437,6 +437,7 @@ export function setupMapEvalListener() {
               runId: null,
               gameVersion: null,
               runStateSnapshot: runState,
+              mapCompliance,
             })
           )
           .unwrap();

--- a/apps/desktop/src/lib/eval-inputs/map.ts
+++ b/apps/desktop/src/lib/eval-inputs/map.ts
@@ -13,8 +13,25 @@ import {
 import {
   enrichPaths,
   type CandidatePath,
+  type EnrichedPath,
 } from "@sts2/shared/evaluation/map/enrich-paths";
 import { formatFactsBlock } from "@sts2/shared/evaluation/map/format-facts-block";
+import type {
+  RepairMapNode,
+  RepairNextOption,
+} from "@sts2/shared/evaluation/map/repair-macro-path";
+
+/**
+ * Inputs for the phase-2 compliance pipeline, projected from desktop map state
+ * so the server can run repair + rerank without recomputing.
+ */
+export interface MapComplianceInputs {
+  nodes: RepairMapNode[];
+  nextOptions: RepairNextOption[];
+  boss: { col: number; row: number };
+  currentPosition: { col: number; row: number } | null;
+  enrichedPaths: EnrichedPath[];
+}
 
 export interface NodePreferences {
   monster: number;
@@ -111,7 +128,11 @@ export function buildMapPrompt(params: {
   context: EvaluationContext;
   state: MapState;
   cardRemovalCost: number | null;
-}): { prompt: string; runState: RunState } {
+}): {
+  prompt: string;
+  runState: RunState;
+  compliance: MapComplianceInputs;
+} {
   const { context, state, cardRemovalCost } = params;
   const contextStr = buildCompactContext(context);
   const options = state.map.next_options;
@@ -185,5 +206,27 @@ ${factsBlock}
 
 ${MAP_PATHING_SCAFFOLD}`;
 
-  return { prompt, runState };
+  const compliance: MapComplianceInputs = {
+    nodes: allNodes.map((n) => ({
+      col: n.col,
+      row: n.row,
+      type: n.type,
+      children: n.children,
+    })),
+    nextOptions: options.map((o) => ({
+      col: o.col,
+      row: o.row,
+      type: o.type,
+    })),
+    boss: { col: state.map.boss.col, row: state.map.boss.row },
+    currentPosition: state.map.current_position
+      ? {
+          col: state.map.current_position.col,
+          row: state.map.current_position.row,
+        }
+      : null,
+    enrichedPaths: enriched,
+  };
+
+  return { prompt, runState, compliance };
 }

--- a/apps/desktop/src/lib/eval-inputs/map.ts
+++ b/apps/desktop/src/lib/eval-inputs/map.ts
@@ -41,6 +41,12 @@ export interface MapCoachEvaluation {
     closeCall: boolean;
   }[];
   teachingCallouts: { pattern: string; floors: number[]; explanation: string }[];
+  compliance?: {
+    repaired: boolean;
+    reranked: boolean;
+    rerankReason: string | null;
+    repairReasons: { kind: string; detail?: string }[];
+  };
 }
 
 /**

--- a/apps/desktop/src/services/evaluationApi.ts
+++ b/apps/desktop/src/services/evaluationApi.ts
@@ -9,7 +9,10 @@ import {
   mapCoachOutputSchema,
   type MapCoachOutputRaw,
 } from "@sts2/shared/evaluation/map-coach-schema";
-import type { MapCoachEvaluation } from "../lib/eval-inputs/map";
+import type {
+  MapCoachEvaluation,
+  MapComplianceInputs,
+} from "../lib/eval-inputs/map";
 
 // --- Request types ---
 
@@ -55,6 +58,12 @@ interface MapPromptRequest extends EvalRequestBase {
    * Echoed by the server and forwarded to `/api/choice` for persistence.
    */
   runStateSnapshot?: unknown;
+  /**
+   * Optional inputs for the server-side phase-2 compliance pipeline (repair +
+   * rerank). When omitted, the server ships the LLM output without a
+   * `compliance` field. Only populated for the map coach eval.
+   */
+  mapCompliance?: MapComplianceInputs;
 }
 
 /** Convert snake_case server output to camelCase client shape. */
@@ -82,6 +91,17 @@ function adaptMapCoach(raw: MapCoachOutputRaw): MapCoachEvaluation {
       closeCall: b.close_call,
     })),
     teachingCallouts: raw.teaching_callouts,
+    compliance: raw.compliance
+      ? {
+          repaired: raw.compliance.repaired,
+          reranked: raw.compliance.reranked,
+          rerankReason: raw.compliance.rerank_reason,
+          repairReasons: raw.compliance.repair_reasons.map((r) => ({
+            kind: r.kind,
+            detail: r.detail,
+          })),
+        }
+      : undefined,
   };
 }
 
@@ -205,6 +225,7 @@ export const evaluationApi = createApi({
             runId: args.runId,
             gameVersion: args.gameVersion,
             runStateSnapshot: args.runStateSnapshot,
+            mapCompliance: args.mapCompliance,
           });
           // Server response is map-coach output + optional `runStateSnapshot`
           // echo. Strip the echo before zod-parsing since the schema is strict.

--- a/apps/desktop/src/views/map/map-view.tsx
+++ b/apps/desktop/src/views/map/map-view.tsx
@@ -12,6 +12,7 @@ import { EvalError } from "../../components/eval-error";
 import { BranchCard } from "../../components/branch-card";
 import { TeachingCallouts } from "../../components/teaching-callouts";
 import { ConfidencePill } from "../../components/confidence-pill";
+import { SwapBadge } from "../../components/swap-badge";
 
 
 interface MapViewProps {
@@ -313,7 +314,12 @@ export function MapView({ state }: MapViewProps) {
                 <h3 className="text-sm font-semibold leading-snug text-zinc-100">
                   {evaluation.headline}
                 </h3>
-                <ConfidencePill confidence={evaluation.confidence} />
+                <div className="flex flex-col items-end gap-1 shrink-0">
+                  {evaluation.compliance?.reranked && (
+                    <SwapBadge reason={evaluation.compliance.rerankReason} />
+                  )}
+                  <ConfidencePill confidence={evaluation.confidence} />
+                </div>
               </div>
             </div>
 

--- a/apps/web/src/app/api/evaluate/route.test.ts
+++ b/apps/web/src/app/api/evaluate/route.test.ts
@@ -38,8 +38,17 @@ import {
   mapCoachOutputSchema,
   sanitizeMapCoachOutput,
   MAP_COACH_LIMITS,
+  type MapCoachOutputRaw,
 } from "@sts2/shared/evaluation/map-coach-schema";
 import { toCardRewardEvaluation } from "@sts2/shared/evaluation/parse-tool-response";
+import { repairMacroPath } from "@sts2/shared/evaluation/map/repair-macro-path";
+import type {
+  RepairMapNode,
+  RepairNextOption,
+} from "@sts2/shared/evaluation/map/repair-macro-path";
+import { rerankIfDominated } from "@sts2/shared/evaluation/map/rerank-if-dominated";
+import type { EnrichedPath } from "@sts2/shared/evaluation/map/enrich-paths";
+import { buildComplianceReport } from "@sts2/shared/evaluation/map/compliance-report";
 
 // Minimal usage object matching LanguageModelV3Usage shape. The AI SDK
 // middleware flattens this to `{ inputTokens: number, outputTokens: number }`
@@ -311,6 +320,196 @@ describe("AI SDK + zod integration (Phase 4.5 smoke)", () => {
       // Schema keys and `runStateSnapshot` must not alias.
       expect(Object.keys(body)).toContain("reasoning");
       expect(Object.keys(body)).toContain("runStateSnapshot");
+    });
+  });
+
+  // Phase 2 integration: the route handler calls the compliance pipeline
+  // (repair → rerank → attach compliance) immediately after
+  // `sanitizeMapCoachOutput`. These tests drive the identical call sequence
+  // against a MockLanguageModelV3 so the end-to-end contract is covered
+  // without booting Next / Supabase / auth.
+  describe("map coach compliance pipeline", () => {
+    // Shared graph: f0 (start) → two next options at f1, each leading to boss
+    // at f2. Path 1 = monster@1,1 → boss@1,2. Path 2 = monster@2,1 → boss@1,2.
+    const nodes: RepairMapNode[] = [
+      { col: 0, row: 0, type: "Unknown", children: [[1, 1], [2, 1]] },
+      { col: 1, row: 1, type: "Monster", children: [[1, 2]] },
+      { col: 2, row: 1, type: "Monster", children: [[1, 2]] },
+      { col: 1, row: 2, type: "Boss", children: [] },
+    ];
+    const nextOptions: RepairNextOption[] = [
+      { col: 1, row: 1, type: "Monster" },
+      { col: 2, row: 1, type: "Monster" },
+    ];
+    const boss = { col: 1, row: 2 };
+    const currentPosition = { col: 0, row: 0 };
+
+    function enrichedPath(
+      id: string,
+      firstNodeId: string,
+      hpVerdict: EnrichedPath["aggregates"]["hpProjectionVerdict"],
+      budget: EnrichedPath["aggregates"]["fightBudgetStatus"],
+    ): EnrichedPath {
+      const [, rowStr] = firstNodeId.split(",");
+      const row = Number(rowStr);
+      return {
+        id,
+        nodes: [
+          { floor: row, type: "monster", nodeId: firstNodeId },
+          { floor: row + 1, type: "boss", nodeId: "1,2" },
+        ],
+        patterns: [],
+        aggregates: {
+          elitesTaken: 0,
+          monstersTaken: 1,
+          restsTaken: 0,
+          shopsTaken: 0,
+          hardPoolFightsOnPath: 0,
+          totalFights: 1,
+          projectedHpEnteringPreBossRest: 50,
+          fightBudgetStatus: budget,
+          hpProjectionVerdict: hpVerdict,
+        },
+      };
+    }
+
+    /**
+     * Runs the exact pipeline wired into `route.ts`:
+     *   sanitize → repair → rerank → buildComplianceReport → re-sanitize.
+     */
+    function runPipeline(
+      raw: MapCoachOutputRaw,
+      enrichedPaths: EnrichedPath[],
+    ): MapCoachOutputRaw {
+      const sanitized = sanitizeMapCoachOutput(raw);
+      const repair = repairMacroPath({
+        output: sanitized,
+        nodes,
+        nextOptions,
+        boss,
+        currentPosition,
+      });
+      const rerank = rerankIfDominated({
+        output: repair.output,
+        candidates: enrichedPaths,
+      });
+      const compliance = buildComplianceReport(repair, rerank);
+      const recapped = sanitizeMapCoachOutput(rerank.output);
+      return { ...recapped, compliance };
+    }
+
+    const validLlmOutput = {
+      reasoning: { risk_capacity: "Tight.", act_goal: "Consolidate." },
+      headline: "Take monster cluster via 1,1.",
+      confidence: 0.82,
+      macro_path: {
+        floors: [
+          { floor: 1, node_type: "monster" as const, node_id: "1,1" },
+          { floor: 2, node_type: "boss" as const, node_id: "1,2" },
+        ],
+        summary: "Monster then boss.",
+      },
+      key_branches: [
+        {
+          floor: 1,
+          decision: "Path 1 or 2?",
+          recommended: "Path 1",
+          alternatives: [{ option: "Path 2", tradeoff: "Safer." }],
+          close_call: false,
+        },
+      ],
+      teaching_callouts: [
+        {
+          pattern: "monster_chain",
+          floors: [1],
+          explanation: "Reliable gold.",
+        },
+      ],
+    };
+
+    it("reranks a dominated LLM pick and attaches compliance", async () => {
+      // LLM picks path 1 (node 1,1). Enrichment scores it as
+      // (exceeds_budget, critical). Path 2 (node 2,1) is (within_budget, safe)
+      // — strictly dominates path 1 on both axes.
+      const enrichedPaths: EnrichedPath[] = [
+        enrichedPath("1", "1,1", "critical", "exceeds_budget"),
+        enrichedPath("2", "2,1", "safe", "within_budget"),
+      ];
+      const model = mockModelWithText(JSON.stringify(validLlmOutput));
+      const result = await generateText({
+        model,
+        prompt: "evaluate these paths",
+        output: Output.object({ schema: mapCoachOutputSchema }),
+      });
+
+      const originalHeadline = validLlmOutput.headline;
+      const finalOutput = runPipeline(result.output, enrichedPaths);
+
+      expect(finalOutput.compliance).toBeDefined();
+      expect(finalOutput.compliance!.reranked).toBe(true);
+      expect(finalOutput.compliance!.rerank_reason).toMatch(
+        /^dominated_by_path_/,
+      );
+      expect(finalOutput.headline).not.toBe(originalHeadline);
+      expect(finalOutput.headline).toContain("Safer alternative");
+      expect(finalOutput.macro_path.floors[0].node_id).toBe("2,1");
+      // Synthetic branch is always floor-indexed to the new path; at minimum
+      // one key_branch (the synthetic swap entry) survives the cap.
+      expect(finalOutput.key_branches.length).toBeGreaterThanOrEqual(1);
+      expect(finalOutput.key_branches[0].decision).toContain(
+        "Coach initially picked",
+      );
+    });
+
+    it("passes compliance.repaired=false and reranked=false on a clean response", async () => {
+      // Path 1 is already (within_budget, safe) — not dominated. Path is
+      // well-formed (monster@1,1 → boss@1,2), so repair is also a no-op.
+      const enrichedPaths: EnrichedPath[] = [
+        enrichedPath("1", "1,1", "safe", "within_budget"),
+        enrichedPath("2", "2,1", "risky", "tight"),
+      ];
+      const model = mockModelWithText(JSON.stringify(validLlmOutput));
+      const result = await generateText({
+        model,
+        prompt: "evaluate these paths",
+        output: Output.object({ schema: mapCoachOutputSchema }),
+      });
+
+      const finalOutput = runPipeline(result.output, enrichedPaths);
+
+      expect(finalOutput.compliance).toBeDefined();
+      expect(finalOutput.compliance!.repaired).toBe(false);
+      expect(finalOutput.compliance!.reranked).toBe(false);
+      expect(finalOutput.compliance!.rerank_reason).toBeNull();
+      expect(finalOutput.compliance!.repair_reasons).toEqual([]);
+      // Output is otherwise untouched.
+      expect(finalOutput.headline).toBe(validLlmOutput.headline);
+      expect(finalOutput.macro_path.floors[0].node_id).toBe("1,1");
+    });
+
+    it("does not rerank when no alternative dominates", async () => {
+      // Path 1 is (tight, risky). Path 2 is (tight, safe) — ties on budget,
+      // so does NOT strictly dominate. Path 3 is (exceeds_budget, safe) —
+      // strictly worse on budget. No alternative wins on BOTH axes.
+      const enrichedPaths: EnrichedPath[] = [
+        enrichedPath("1", "1,1", "risky", "tight"),
+        enrichedPath("2", "2,1", "safe", "tight"),
+      ];
+      const model = mockModelWithText(JSON.stringify(validLlmOutput));
+      const result = await generateText({
+        model,
+        prompt: "evaluate these paths",
+        output: Output.object({ schema: mapCoachOutputSchema }),
+      });
+
+      const finalOutput = runPipeline(result.output, enrichedPaths);
+
+      expect(finalOutput.compliance).toBeDefined();
+      expect(finalOutput.compliance!.reranked).toBe(false);
+      expect(finalOutput.compliance!.rerank_reason).toBeNull();
+      // Headline + macro_path stay on the LLM's pick.
+      expect(finalOutput.headline).toBe(validLlmOutput.headline);
+      expect(finalOutput.macro_path.floors[0].node_id).toBe("1,1");
     });
   });
 });

--- a/apps/web/src/app/api/evaluate/route.ts
+++ b/apps/web/src/app/api/evaluate/route.ts
@@ -19,7 +19,16 @@ import {
 import {
   mapCoachOutputSchema,
   sanitizeMapCoachOutput,
+  type MapCoachOutputRaw,
 } from "@sts2/shared/evaluation/map-coach-schema";
+import { repairMacroPath } from "@sts2/shared/evaluation/map/repair-macro-path";
+import type {
+  RepairMapNode,
+  RepairNextOption,
+} from "@sts2/shared/evaluation/map/repair-macro-path";
+import { rerankIfDominated } from "@sts2/shared/evaluation/map/rerank-if-dominated";
+import type { EnrichedPath } from "@sts2/shared/evaluation/map/enrich-paths";
+import { buildComplianceReport } from "@sts2/shared/evaluation/map/compliance-report";
 import { EVAL_MODELS } from "@sts2/shared/evaluation/models";
 import { toCardRewardEvaluation } from "@sts2/shared/evaluation/parse-tool-response";
 import { sanitizeRankings } from "@sts2/shared/evaluation/sanitize-rankings";
@@ -36,6 +45,45 @@ import { getCharacterStrategy } from "@/evaluation/strategy/character-strategies
 // ─── Trailing-comma repair for LLM-generated JSON ───
 function repairJson(text: string): string {
   return text.replace(/,(\s*[}\]])/g, "$1");
+}
+
+/**
+ * Run the phase-2 compliance pipeline on a sanitized map-coach output and
+ * attach the resulting `compliance` field. When inputs are absent (older
+ * clients that haven't migrated), the output is returned unchanged.
+ *
+ * Runs repair → rerank → re-sanitize so the synthetic `key_branch` the rerank
+ * prepends (and any preserved teaching callouts) respect the same soft caps
+ * `sanitizeMapCoachOutput` enforces on the LLM's raw output.
+ */
+function applyMapCompliance(
+  sanitized: MapCoachOutputRaw,
+  inputs: EvaluateRequest["mapCompliance"],
+): MapCoachOutputRaw {
+  if (!inputs) return sanitized;
+
+  const repair = repairMacroPath({
+    output: sanitized,
+    nodes: inputs.nodes,
+    nextOptions: inputs.nextOptions,
+    boss: inputs.boss,
+    currentPosition: inputs.currentPosition,
+  });
+  const rerank = rerankIfDominated({
+    output: repair.output,
+    candidates: inputs.enrichedPaths,
+  });
+  const compliance = buildComplianceReport(repair, rerank);
+
+  // Re-apply soft caps — rerank prepends a synthetic branch and may preserve
+  // callouts that together exceed the post-parse cap.
+  const recapped = sanitizeMapCoachOutput(rerank.output);
+
+  if (process.env.EVAL_DEBUG === "1") {
+    console.log("[Evaluate map compliance]", compliance);
+  }
+
+  return { ...recapped, compliance };
 }
 
 // ─── Cached game data (loaded once per cold start, ~30min TTL on Vercel) ───
@@ -210,6 +258,21 @@ interface EvaluateRequest {
    * for the duplication trade-off.
    */
   runStateSnapshot?: unknown;
+  /**
+   * Optional inputs for the phase-2 compliance pipeline (repair + rerank).
+   * Populated by the desktop map-coach call path — absent for callers that
+   * haven't migrated yet, in which case the route ships the LLM output
+   * without a `compliance` field. See
+   * `packages/shared/evaluation/map/repair-macro-path.ts` and
+   * `packages/shared/evaluation/map/rerank-if-dominated.ts`.
+   */
+  mapCompliance?: {
+    nodes: RepairMapNode[];
+    nextOptions: RepairNextOption[];
+    boss: { col: number; row: number };
+    currentPosition: { col: number; row: number } | null;
+    enrichedPaths: EnrichedPath[];
+  };
 }
 
 export async function POST(request: Request) {
@@ -511,6 +574,7 @@ export async function POST(request: Request) {
         // structured-output endpoint rejects the resulting JSON Schema
         // constraints (#52, #68). See `map-coach-schema.ts`.
         const sanitized = sanitizeMapCoachOutput(mapResult.output);
+        const finalOutput = applyMapCompliance(sanitized, body.mapCompliance);
         // Echo the desktop-provided run-state snapshot back so the caller can
         // forward it to `/api/choice` for persistence. This route does not
         // write to the `choices` table itself; see `apps/web/src/app/api/
@@ -520,7 +584,7 @@ export async function POST(request: Request) {
         // (without raw state in the request body) would add surface area
         // without value. Noted as a known follow-up.
         return NextResponse.json({
-          ...sanitized,
+          ...finalOutput,
           runStateSnapshot: body.runStateSnapshot ?? null,
         });
       }
@@ -572,8 +636,9 @@ export async function POST(request: Request) {
                   }).catch(console.error);
                 }
                 const sanitized = sanitizeMapCoachOutput(parsed);
+                const finalOutput = applyMapCompliance(sanitized, body.mapCompliance);
                 return NextResponse.json({
-                  ...sanitized,
+                  ...finalOutput,
                   runStateSnapshot: body.runStateSnapshot ?? null,
                 });
               }

--- a/packages/shared/evaluation/map-coach-schema.test.ts
+++ b/packages/shared/evaluation/map-coach-schema.test.ts
@@ -105,6 +105,53 @@ describe("mapCoachOutputSchema", () => {
   });
 });
 
+describe("mapCoachOutputSchema.compliance", () => {
+  const valid = {
+    reasoning: { risk_capacity: "m", act_goal: "g" },
+    headline: "h",
+    confidence: 0.5,
+    macro_path: {
+      floors: [{ floor: 1, node_type: "monster", node_id: "1,1" }],
+      summary: "s",
+    },
+    key_branches: [],
+    teaching_callouts: [],
+  };
+
+  it("accepts payload without compliance (backwards compatible)", () => {
+    expect(mapCoachOutputSchema.safeParse(valid).success).toBe(true);
+  });
+
+  it("accepts a full compliance object", () => {
+    const full = {
+      ...valid,
+      compliance: {
+        repaired: true,
+        reranked: true,
+        rerank_reason: "dominated_by_path_B",
+        repair_reasons: [
+          { kind: "empty_macro_path" as const },
+          { kind: "contiguity_gap" as const, detail: "f8" },
+        ],
+      },
+    };
+    expect(mapCoachOutputSchema.safeParse(full).success).toBe(true);
+  });
+
+  it("rejects invalid repair_reason kind", () => {
+    const bad = {
+      ...valid,
+      compliance: {
+        repaired: true,
+        reranked: false,
+        rerank_reason: null,
+        repair_reasons: [{ kind: "bogus" }],
+      },
+    };
+    expect(mapCoachOutputSchema.safeParse(bad).success).toBe(false);
+  });
+});
+
 describe("sanitizeMapCoachOutput", () => {
   it("passes through a valid within-caps payload unchanged in shape", () => {
     const sanitized = sanitizeMapCoachOutput(valid);

--- a/packages/shared/evaluation/map-coach-schema.ts
+++ b/packages/shared/evaluation/map-coach-schema.ts
@@ -25,6 +25,16 @@ const nodeTypeEnum = z.enum([
 
 export type MapNodeType = z.infer<typeof nodeTypeEnum>;
 
+const repairReasonKindEnum = z.enum([
+  "empty_macro_path",
+  "unknown_node_id",
+  "first_floor_mismatch",
+  "contiguity_gap",
+  "missing_boss",
+  "walk_dead_end",
+  "starts_at_current_position",
+]);
+
 /**
  * Soft caps applied post-parse. Hard limits (number range, array length) are
  * NOT in the zod schema because `z.toJSONSchema` emits them as JSON Schema
@@ -89,6 +99,19 @@ export const mapCoachOutputSchema = z.object({
     .describe(
       `At most ${MAP_COACH_LIMITS.maxTeachingCallouts} entries — only pedagogically useful patterns. Truncated post-parse if exceeded.`,
     ),
+  compliance: z
+    .object({
+      repaired: z.boolean(),
+      reranked: z.boolean(),
+      rerank_reason: z.string().nullable(),
+      repair_reasons: z.array(
+        z.object({
+          kind: repairReasonKindEnum,
+          detail: z.string().optional(),
+        }),
+      ),
+    })
+    .optional(),
 });
 
 export type MapCoachOutputRaw = z.infer<typeof mapCoachOutputSchema>;

--- a/packages/shared/evaluation/map-coach-schema.ts
+++ b/packages/shared/evaluation/map-coach-schema.ts
@@ -20,6 +20,7 @@ const nodeTypeEnum = z.enum([
   "shop",
   "treasure",
   "event",
+  "boss",
   "unknown",
 ]);
 

--- a/packages/shared/evaluation/map/compliance-report.test.ts
+++ b/packages/shared/evaluation/map/compliance-report.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { buildComplianceReport } from "./compliance-report";
+import type { MapCoachOutputRaw } from "../map-coach-schema";
+
+const stubOutput: MapCoachOutputRaw = {
+  reasoning: { risk_capacity: "moderate", act_goal: "heal" },
+  headline: "take elite",
+  confidence: 0.75,
+  macro_path: { floors: [], summary: "path" },
+  key_branches: [],
+  teaching_callouts: [],
+};
+
+describe("buildComplianceReport", () => {
+  it("reflects both fired", () => {
+    const report = buildComplianceReport(
+      {
+        output: stubOutput,
+        repaired: true,
+        repair_reasons: [{ kind: "empty_macro_path" }],
+      },
+      { output: stubOutput, reranked: true, rerank_reason: "dominated_by_path_B" },
+    );
+    expect(report).toEqual({
+      repaired: true,
+      reranked: true,
+      rerank_reason: "dominated_by_path_B",
+      repair_reasons: [{ kind: "empty_macro_path" }],
+    });
+  });
+
+  it("reflects neither fired", () => {
+    const report = buildComplianceReport(
+      { output: stubOutput, repaired: false, repair_reasons: [] },
+      { output: stubOutput, reranked: false, rerank_reason: null },
+    );
+    expect(report).toEqual({
+      repaired: false,
+      reranked: false,
+      rerank_reason: null,
+      repair_reasons: [],
+    });
+  });
+
+  it("reflects only repair fired", () => {
+    const report = buildComplianceReport(
+      {
+        output: stubOutput,
+        repaired: true,
+        repair_reasons: [{ kind: "missing_boss" }, { kind: "contiguity_gap", detail: "f8" }],
+      },
+      { output: stubOutput, reranked: false, rerank_reason: null },
+    );
+    expect(report.repaired).toBe(true);
+    expect(report.reranked).toBe(false);
+    expect(report.repair_reasons).toHaveLength(2);
+  });
+});

--- a/packages/shared/evaluation/map/compliance-report.ts
+++ b/packages/shared/evaluation/map/compliance-report.ts
@@ -1,0 +1,56 @@
+import type { MapCoachOutputRaw } from "../map-coach-schema";
+
+/**
+ * Types for phase-2 compliance pipeline: structural repair + judgment rerank.
+ * These are pure types — no runtime logic. Consumers: repair-macro-path,
+ * rerank-if-dominated, and the evaluate route handler.
+ */
+
+export type RepairReasonKind =
+  | "empty_macro_path"
+  | "unknown_node_id"
+  | "first_floor_mismatch"
+  | "contiguity_gap"
+  | "missing_boss"
+  | "walk_dead_end"
+  | "starts_at_current_position";
+
+export interface RepairReason {
+  kind: RepairReasonKind;
+  detail?: string;
+}
+
+export interface RepairResult {
+  output: MapCoachOutputRaw;
+  repaired: boolean;
+  repair_reasons: RepairReason[];
+}
+
+export interface RerankResult {
+  output: MapCoachOutputRaw;
+  reranked: boolean;
+  rerank_reason: string | null;
+}
+
+export interface ComplianceReport {
+  repaired: boolean;
+  reranked: boolean;
+  rerank_reason: string | null;
+  repair_reasons: RepairReason[];
+}
+
+/**
+ * Combine a RepairResult + RerankResult into a ComplianceReport suitable
+ * for attaching to the response payload.
+ */
+export function buildComplianceReport(
+  repair: RepairResult,
+  rerank: RerankResult,
+): ComplianceReport {
+  return {
+    repaired: repair.repaired,
+    reranked: rerank.reranked,
+    rerank_reason: rerank.rerank_reason,
+    repair_reasons: repair.repair_reasons,
+  };
+}

--- a/packages/shared/evaluation/map/repair-macro-path.test.ts
+++ b/packages/shared/evaluation/map/repair-macro-path.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect } from "vitest";
+import { repairMacroPath } from "./repair-macro-path";
+import type { RepairInputs, RepairMapNode } from "./repair-macro-path";
+import type { MapCoachOutputRaw } from "../map-coach-schema";
+
+// Simple vertical chain: f1 -> f2 -> f3 (boss)
+const simpleNodes: RepairMapNode[] = [
+  { col: 1, row: 1, type: "Monster", children: [[1, 2]] },
+  { col: 1, row: 2, type: "Elite", children: [[1, 3]] },
+  { col: 1, row: 3, type: "Boss", children: [] },
+];
+
+// Forked graph: f1 branches to either an elite or a shop, both rejoin at boss.
+const forkedNodes: RepairMapNode[] = [
+  { col: 1, row: 1, type: "Monster", children: [[1, 2], [2, 2]] },
+  { col: 1, row: 2, type: "Elite", children: [[1, 3]] },
+  { col: 2, row: 2, type: "Shop", children: [[1, 3]] },
+  { col: 1, row: 3, type: "Boss", children: [] },
+];
+
+function makeInputs(
+  output: MapCoachOutputRaw,
+  overrides?: Partial<RepairInputs>,
+): RepairInputs {
+  return {
+    output,
+    nodes: simpleNodes,
+    nextOptions: [{ col: 1, row: 1, type: "Monster" }],
+    boss: { col: 1, row: 3 },
+    currentPosition: { col: 0, row: 0 },
+    ...overrides,
+  };
+}
+
+function baseOutput(
+  floors: { floor: number; node_type: string; node_id: string }[],
+): MapCoachOutputRaw {
+  return {
+    reasoning: { risk_capacity: "m", act_goal: "g" },
+    headline: "h",
+    confidence: 0.8,
+    macro_path: {
+      floors: floors as MapCoachOutputRaw["macro_path"]["floors"],
+      summary: "s",
+    },
+    key_branches: [],
+    teaching_callouts: [],
+  };
+}
+
+describe("repairMacroPath", () => {
+  it("passes valid path through unchanged", () => {
+    const output = baseOutput([
+      { floor: 1, node_type: "monster", node_id: "1,1" },
+      { floor: 2, node_type: "elite", node_id: "1,2" },
+      { floor: 3, node_type: "boss", node_id: "1,3" },
+    ]);
+    const result = repairMacroPath(makeInputs(output));
+    expect(result.repaired).toBe(false);
+    expect(result.repair_reasons).toEqual([]);
+    expect(result.output.macro_path.floors).toEqual(output.macro_path.floors);
+  });
+
+  it("synthesizes macro_path from the chosen next_option when empty", () => {
+    const output = baseOutput([]);
+    const result = repairMacroPath(makeInputs(output));
+    expect(result.repaired).toBe(true);
+    expect(result.repair_reasons.map((r) => r.kind)).toContain(
+      "empty_macro_path",
+    );
+    expect(result.output.macro_path.floors).toEqual([
+      { floor: 1, node_type: "monster", node_id: "1,1" },
+      { floor: 2, node_type: "elite", node_id: "1,2" },
+      { floor: 3, node_type: "boss", node_id: "1,3" },
+    ]);
+  });
+
+  it("drops an unknown node_id and walks from the last valid node", () => {
+    const output = baseOutput([
+      { floor: 1, node_type: "monster", node_id: "1,1" },
+      { floor: 2, node_type: "elite", node_id: "9,9" },
+      { floor: 3, node_type: "boss", node_id: "1,3" },
+    ]);
+    const result = repairMacroPath(
+      makeInputs(output, {
+        nodes: forkedNodes,
+        nextOptions: [{ col: 1, row: 1, type: "Monster" }],
+      }),
+    );
+    expect(result.repaired).toBe(true);
+    expect(result.repair_reasons.map((r) => r.kind)).toContain(
+      "unknown_node_id",
+    );
+    expect(result.output.macro_path.floors[0].node_id).toBe("1,1");
+    expect(
+      result.output.macro_path.floors[
+        result.output.macro_path.floors.length - 1
+      ].node_id,
+    ).toBe("1,3");
+  });
+
+  it("appends a walk to boss when final floor is missing", () => {
+    const output = baseOutput([
+      { floor: 1, node_type: "monster", node_id: "1,1" },
+      { floor: 2, node_type: "elite", node_id: "1,2" },
+    ]);
+    const result = repairMacroPath(makeInputs(output));
+    expect(result.repaired).toBe(true);
+    expect(result.repair_reasons.map((r) => r.kind)).toContain("missing_boss");
+    expect(
+      result.output.macro_path.floors[
+        result.output.macro_path.floors.length - 1
+      ].node_id,
+    ).toBe("1,3");
+  });
+
+  it("stitches through a contiguity gap using the smart walker", () => {
+    const output = baseOutput([
+      { floor: 1, node_type: "monster", node_id: "1,1" },
+      { floor: 3, node_type: "boss", node_id: "1,3" },
+    ]);
+    const result = repairMacroPath(
+      makeInputs(output, {
+        nodes: forkedNodes,
+        nextOptions: [{ col: 1, row: 1, type: "Monster" }],
+      }),
+    );
+    expect(result.repaired).toBe(true);
+    expect(result.repair_reasons.map((r) => r.kind)).toContain(
+      "contiguity_gap",
+    );
+    const ids = result.output.macro_path.floors.map((f) => f.node_id);
+    expect(ids).toEqual(["1,1", "1,2", "1,3"]);
+  });
+
+  it("swaps first floor when it doesn't match any next_option", () => {
+    const output = baseOutput([
+      { floor: 0, node_type: "unknown", node_id: "0,0" },
+      { floor: 1, node_type: "monster", node_id: "1,1" },
+      { floor: 2, node_type: "elite", node_id: "1,2" },
+      { floor: 3, node_type: "boss", node_id: "1,3" },
+    ]);
+    const result = repairMacroPath(
+      makeInputs(output, {
+        currentPosition: { col: 0, row: 0 },
+        nodes: [
+          { col: 0, row: 0, type: "Unknown", children: [[1, 1]] },
+          ...simpleNodes,
+        ],
+      }),
+    );
+    expect(result.repaired).toBe(true);
+    expect(result.repair_reasons.map((r) => r.kind)).toContain(
+      "starts_at_current_position",
+    );
+    expect(result.output.macro_path.floors[0].node_id).toBe("1,1");
+  });
+
+  it("emits walk_dead_end when the walker cannot reach boss", () => {
+    const deadEndNodes: RepairMapNode[] = [
+      { col: 1, row: 1, type: "Monster", children: [] },
+    ];
+    const output = baseOutput([]);
+    const result = repairMacroPath(
+      makeInputs(output, {
+        nodes: deadEndNodes,
+        nextOptions: [{ col: 1, row: 1, type: "Monster" }],
+        boss: { col: 9, row: 9 },
+      }),
+    );
+    expect(result.repair_reasons.map((r) => r.kind)).toContain(
+      "empty_macro_path",
+    );
+    expect(result.repair_reasons.map((r) => r.kind)).toContain("walk_dead_end");
+  });
+});

--- a/packages/shared/evaluation/map/repair-macro-path.test.ts
+++ b/packages/shared/evaluation/map/repair-macro-path.test.ts
@@ -33,16 +33,13 @@ function makeInputs(
 }
 
 function baseOutput(
-  floors: { floor: number; node_type: string; node_id: string }[],
+  floors: MapCoachOutputRaw["macro_path"]["floors"],
 ): MapCoachOutputRaw {
   return {
     reasoning: { risk_capacity: "m", act_goal: "g" },
     headline: "h",
     confidence: 0.8,
-    macro_path: {
-      floors: floors as MapCoachOutputRaw["macro_path"]["floors"],
-      summary: "s",
-    },
+    macro_path: { floors, summary: "s" },
     key_branches: [],
     teaching_callouts: [],
   };

--- a/packages/shared/evaluation/map/repair-macro-path.ts
+++ b/packages/shared/evaluation/map/repair-macro-path.ts
@@ -1,0 +1,341 @@
+import type { MapCoachOutputRaw } from "../map-coach-schema";
+import type { RepairReason, RepairResult } from "./compliance-report";
+
+/**
+ * Structural auto-repair for the map coach's macro_path. Runs seven validators
+ * in order; any that fires contributes a typed RepairReason and triggers
+ * best-effort re-stitching using a smart child walk that biases toward stated
+ * next floors on branching forks. Pure function — no IO.
+ *
+ * Callers project their game-state nodes into RepairMapNode (col/row/type +
+ * [col,row] children) rather than importing game-state types directly.
+ */
+
+export interface RepairMapNode {
+  col: number;
+  row: number;
+  type: string;
+  children: [col: number, row: number][];
+}
+
+export interface RepairNextOption {
+  col: number;
+  row: number;
+  type: string;
+}
+
+export interface RepairInputs {
+  output: MapCoachOutputRaw;
+  nodes: RepairMapNode[];
+  nextOptions: RepairNextOption[];
+  boss: { col: number; row: number };
+  currentPosition: { col: number; row: number } | null;
+}
+
+function nodeKey(col: number, row: number): string {
+  return `${col},${row}`;
+}
+
+function buildNodeMap(nodes: RepairMapNode[]): Map<string, RepairMapNode> {
+  const map = new Map<string, RepairMapNode>();
+  for (const n of nodes) map.set(nodeKey(n.col, n.row), n);
+  return map;
+}
+
+/**
+ * Precompute reachable node set per node (BFS over children). Used by
+ * smartWalk to steer forks toward a target node id.
+ */
+function buildReachable(nodes: RepairMapNode[]): Map<string, Set<string>> {
+  const nodeMap = buildNodeMap(nodes);
+  const reachable = new Map<string, Set<string>>();
+  function visit(nodeId: string): Set<string> {
+    const cached = reachable.get(nodeId);
+    if (cached) return cached;
+    const acc = new Set<string>([nodeId]);
+    reachable.set(nodeId, acc);
+    const node = nodeMap.get(nodeId);
+    if (node) {
+      for (const [cc, cr] of node.children) {
+        const childKey = nodeKey(cc, cr);
+        for (const r of visit(childKey)) acc.add(r);
+      }
+    }
+    return acc;
+  }
+  for (const n of nodes) visit(nodeKey(n.col, n.row));
+  return reachable;
+}
+
+function nodeTypeToken(type: string): string {
+  switch (type) {
+    case "Monster":
+      return "monster";
+    case "Elite":
+      return "elite";
+    case "RestSite":
+      return "rest";
+    case "Shop":
+      return "shop";
+    case "Treasure":
+      return "treasure";
+    case "Event":
+      return "event";
+    case "Boss":
+      return "boss";
+    default:
+      return "unknown";
+  }
+}
+
+function floorsContiguous(
+  floors: MapCoachOutputRaw["macro_path"]["floors"],
+  nodeMap: Map<string, RepairMapNode>,
+): boolean {
+  for (let i = 0; i < floors.length - 1; i++) {
+    const cur = nodeMap.get(floors[i].node_id);
+    if (!cur) return false;
+    const next = floors[i + 1];
+    const childMatch = cur.children.some(
+      ([cc, cr]) => nodeKey(cc, cr) === next.node_id,
+    );
+    if (!childMatch) return false;
+  }
+  return true;
+}
+
+/**
+ * Walk from startKey toward bossKey, steering children toward a target when
+ * provided. Returns the visited chain including startKey. Stops early (deadEnd)
+ * on a leaf that isn't the boss or on a cycle.
+ */
+function smartWalk(
+  startKey: string,
+  bossKey: string,
+  nodeMap: Map<string, RepairMapNode>,
+  reachable: Map<string, Set<string>>,
+  steerToKey?: string,
+): { visited: RepairMapNode[]; deadEnd: boolean } {
+  const visited: RepairMapNode[] = [];
+  let cursorKey: string | undefined = startKey;
+  const guard = new Set<string>();
+  while (cursorKey && !guard.has(cursorKey)) {
+    guard.add(cursorKey);
+    const node = nodeMap.get(cursorKey);
+    if (!node) return { visited, deadEnd: true };
+    visited.push(node);
+    if (cursorKey === bossKey) return { visited, deadEnd: false };
+    if (node.children.length === 0) return { visited, deadEnd: true };
+
+    let nextKey: string | undefined;
+    if (steerToKey) {
+      for (const [cc, cr] of node.children) {
+        const childKey = nodeKey(cc, cr);
+        if (reachable.get(childKey)?.has(steerToKey)) {
+          nextKey = childKey;
+          break;
+        }
+      }
+    }
+    if (!nextKey) {
+      const [cc, cr] = node.children[0];
+      nextKey = nodeKey(cc, cr);
+    }
+    cursorKey = nextKey;
+  }
+  return { visited, deadEnd: true };
+}
+
+function visitedToFloors(
+  visited: RepairMapNode[],
+): MapCoachOutputRaw["macro_path"]["floors"] {
+  return visited.map((n) => ({
+    floor: n.row,
+    node_type: nodeTypeToken(n.type) as MapCoachOutputRaw["macro_path"]["floors"][number]["node_type"],
+    node_id: nodeKey(n.col, n.row),
+  }));
+}
+
+function synthesizeFromNextOption(
+  inputs: RepairInputs,
+  reasons: RepairReason[],
+): MapCoachOutputRaw["macro_path"]["floors"] {
+  const bossKey = nodeKey(inputs.boss.col, inputs.boss.row);
+  const nodeMap = buildNodeMap(inputs.nodes);
+  const reachable = buildReachable(inputs.nodes);
+
+  const chosen = inputs.nextOptions[0];
+  if (!chosen) return [];
+  const startKey = nodeKey(chosen.col, chosen.row);
+
+  const { visited, deadEnd } = smartWalk(startKey, bossKey, nodeMap, reachable);
+  if (deadEnd && visited[visited.length - 1]?.type !== "Boss") {
+    reasons.push({ kind: "walk_dead_end" });
+  }
+  return visitedToFloors(visited);
+}
+
+export function repairMacroPath(inputs: RepairInputs): RepairResult {
+  const { output, nodes, boss, currentPosition, nextOptions } = inputs;
+  const nodeMap = buildNodeMap(nodes);
+  const reachable = buildReachable(nodes);
+  const floors = output.macro_path.floors;
+  const bossKey = nodeKey(boss.col, boss.row);
+  const reasons: RepairReason[] = [];
+
+  // Case 1: empty macro_path.
+  if (floors.length === 0) {
+    reasons.push({ kind: "empty_macro_path" });
+    const repairedFloors = synthesizeFromNextOption(inputs, reasons);
+    return {
+      output: {
+        ...output,
+        macro_path: { ...output.macro_path, floors: repairedFloors },
+      },
+      repaired: true,
+      repair_reasons: reasons,
+    };
+  }
+
+  // Case 2: first floor equals current_position — drop it.
+  let working = floors;
+  if (
+    currentPosition &&
+    working[0].node_id === nodeKey(currentPosition.col, currentPosition.row)
+  ) {
+    reasons.push({ kind: "starts_at_current_position" });
+    working = working.slice(1);
+    if (working.length === 0) {
+      const repairedFloors = synthesizeFromNextOption(inputs, reasons);
+      return {
+        output: {
+          ...output,
+          macro_path: { ...output.macro_path, floors: repairedFloors },
+        },
+        repaired: true,
+        repair_reasons: reasons,
+      };
+    }
+  }
+
+  // Case 3: drop unknown node_ids, recording each.
+  const knownFloors: typeof working = [];
+  for (const f of working) {
+    if (nodeMap.has(f.node_id)) {
+      knownFloors.push(f);
+    } else {
+      reasons.push({ kind: "unknown_node_id", detail: f.node_id });
+    }
+  }
+  working = knownFloors;
+  if (working.length === 0) {
+    const repairedFloors = synthesizeFromNextOption(inputs, reasons);
+    return {
+      output: {
+        ...output,
+        macro_path: { ...output.macro_path, floors: repairedFloors },
+      },
+      repaired: reasons.length > 0 || repairedFloors.length !== floors.length,
+      repair_reasons: reasons,
+    };
+  }
+
+  // Case 4: first floor must match a next_option.
+  const firstOnNextOption = nextOptions.some(
+    (o) => nodeKey(o.col, o.row) === working[0].node_id,
+  );
+  if (!firstOnNextOption) {
+    reasons.push({ kind: "first_floor_mismatch", detail: working[0].node_id });
+    const matchIdx = working.findIndex((f) =>
+      nextOptions.some((o) => nodeKey(o.col, o.row) === f.node_id),
+    );
+    if (matchIdx > 0) {
+      working = working.slice(matchIdx);
+    } else {
+      const repairedFloors = synthesizeFromNextOption(inputs, reasons);
+      return {
+        output: {
+          ...output,
+          macro_path: { ...output.macro_path, floors: repairedFloors },
+        },
+        repaired: true,
+        repair_reasons: reasons,
+      };
+    }
+  }
+
+  // Case 5: contiguity. Walk `working`; on first break, stitch via smart walk.
+  const stitched: RepairMapNode[] = [];
+  for (let i = 0; i < working.length; i++) {
+    const curNode = nodeMap.get(working[i].node_id);
+    if (!curNode) break;
+    if (stitched.length === 0) {
+      stitched.push(curNode);
+      continue;
+    }
+    const prev = stitched[stitched.length - 1];
+    const isChild = prev.children.some(
+      ([cc, cr]) => nodeKey(cc, cr) === working[i].node_id,
+    );
+    if (isChild) {
+      stitched.push(curNode);
+    } else {
+      reasons.push({
+        kind: "contiguity_gap",
+        detail: `before_${working[i].node_id}`,
+      });
+      const walk = smartWalk(
+        nodeKey(prev.col, prev.row),
+        bossKey,
+        nodeMap,
+        reachable,
+        working[i].node_id,
+      );
+      for (const step of walk.visited.slice(1)) {
+        stitched.push(step);
+        if (nodeKey(step.col, step.row) === working[i].node_id) break;
+      }
+      const landed = stitched[stitched.length - 1];
+      if (nodeKey(landed.col, landed.row) !== working[i].node_id) {
+        break;
+      }
+    }
+  }
+
+  // Case 6: ensure final floor is boss.
+  const last = stitched[stitched.length - 1];
+  if (!last || nodeKey(last.col, last.row) !== bossKey) {
+    reasons.push({ kind: "missing_boss" });
+    if (last) {
+      const walk = smartWalk(
+        nodeKey(last.col, last.row),
+        bossKey,
+        nodeMap,
+        reachable,
+      );
+      if (
+        walk.deadEnd &&
+        walk.visited[walk.visited.length - 1]?.type !== "Boss"
+      ) {
+        reasons.push({ kind: "walk_dead_end" });
+      }
+      for (const step of walk.visited.slice(1)) stitched.push(step);
+    }
+  }
+
+  if (reasons.length === 0) {
+    return { output, repaired: false, repair_reasons: [] };
+  }
+
+  return {
+    output: {
+      ...output,
+      macro_path: {
+        ...output.macro_path,
+        floors: visitedToFloors(stitched),
+      },
+    },
+    repaired: true,
+    repair_reasons: reasons,
+  };
+}

--- a/packages/shared/evaluation/map/rerank-if-dominated.test.ts
+++ b/packages/shared/evaluation/map/rerank-if-dominated.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect } from "vitest";
+import { rerankIfDominated } from "./rerank-if-dominated";
+import type { RerankInputs } from "./rerank-if-dominated";
+import type { MapCoachOutputRaw } from "../map-coach-schema";
+import type { EnrichedPath } from "./enrich-paths";
+
+function path(
+  id: string,
+  firstNodeId: string,
+  hpVerdict: EnrichedPath["aggregates"]["hpProjectionVerdict"],
+  budget: EnrichedPath["aggregates"]["fightBudgetStatus"],
+): EnrichedPath {
+  const [, rowStr] = firstNodeId.split(",");
+  const row = Number(rowStr);
+  return {
+    id,
+    nodes: [{ floor: row, type: "monster", nodeId: firstNodeId }],
+    patterns: [],
+    aggregates: {
+      elitesTaken: 0,
+      monstersTaken: 0,
+      restsTaken: 0,
+      shopsTaken: 0,
+      hardPoolFightsOnPath: 0,
+      totalFights: 0,
+      projectedHpEnteringPreBossRest: 50,
+      fightBudgetStatus: budget,
+      hpProjectionVerdict: hpVerdict,
+    },
+  };
+}
+
+function output(firstNodeId: string): MapCoachOutputRaw {
+  return {
+    reasoning: { risk_capacity: "m", act_goal: "g" },
+    headline: "original",
+    confidence: 0.8,
+    macro_path: {
+      floors: [{ floor: 1, node_type: "monster", node_id: firstNodeId }],
+      summary: "s",
+    },
+    key_branches: [
+      {
+        floor: 1,
+        decision: "take this?",
+        recommended: "yes",
+        alternatives: [],
+        close_call: false,
+      },
+    ],
+    teaching_callouts: [
+      { pattern: "rest_after_elite", floors: [1], explanation: "..." },
+    ],
+  };
+}
+
+describe("rerankIfDominated", () => {
+  it("passes through when LLM pick is not dominated", () => {
+    const candidates = [
+      path("A", "1,1", "safe", "exceeds_budget"),
+      path("B", "2,1", "risky", "within_budget"),
+    ];
+    const inputs: RerankInputs = {
+      output: output("1,1"),
+      candidates,
+    };
+    const result = rerankIfDominated(inputs);
+    expect(result.reranked).toBe(false);
+    expect(result.rerank_reason).toBeNull();
+    expect(result.output.headline).toBe("original");
+  });
+
+  it("swaps to the dominator when LLM pick is dominated", () => {
+    const candidates = [
+      path("A", "1,1", "critical", "exceeds_budget"),
+      path("B", "2,1", "safe", "within_budget"),
+    ];
+    const inputs: RerankInputs = {
+      output: output("1,1"),
+      candidates,
+    };
+    const result = rerankIfDominated(inputs);
+    expect(result.reranked).toBe(true);
+    expect(result.rerank_reason).toBe("dominated_by_path_B");
+    expect(result.output.macro_path.floors[0].node_id).toBe("2,1");
+    expect(result.output.headline).toContain("Safer alternative");
+    expect(result.output.confidence).toBeCloseTo(0.65, 2);
+  });
+
+  it("picks the strictly-best dominator among multiple", () => {
+    const candidates = [
+      path("A", "1,1", "critical", "exceeds_budget"),
+      path("B", "2,1", "risky", "tight"),
+      path("C", "3,1", "safe", "within_budget"),
+    ];
+    const inputs: RerankInputs = { output: output("1,1"), candidates };
+    const result = rerankIfDominated(inputs);
+    expect(result.reranked).toBe(true);
+    expect(result.rerank_reason).toBe("dominated_by_path_C");
+  });
+
+  it("does not swap when LLM pick is already best possible", () => {
+    const candidates = [
+      path("A", "1,1", "safe", "within_budget"),
+      path("B", "2,1", "risky", "tight"),
+    ];
+    const inputs: RerankInputs = { output: output("1,1"), candidates };
+    const result = rerankIfDominated(inputs);
+    expect(result.reranked).toBe(false);
+  });
+
+  it("does not swap when all paths are equally bad", () => {
+    const candidates = [
+      path("A", "1,1", "critical", "exceeds_budget"),
+      path("B", "2,1", "critical", "exceeds_budget"),
+    ];
+    const inputs: RerankInputs = { output: output("1,1"), candidates };
+    const result = rerankIfDominated(inputs);
+    expect(result.reranked).toBe(false);
+  });
+
+  it("filters key_branches + teaching_callouts to new path's floors", () => {
+    const candidates = [
+      path("A", "1,1", "critical", "exceeds_budget"),
+      path("B", "2,1", "safe", "within_budget"),
+    ];
+    const llmOutput = output("1,1");
+    llmOutput.key_branches = [
+      {
+        floor: 1,
+        decision: "d1",
+        recommended: "r1",
+        alternatives: [],
+        close_call: false,
+      },
+      {
+        floor: 5,
+        decision: "d5",
+        recommended: "r5",
+        alternatives: [],
+        close_call: false,
+      },
+    ];
+    llmOutput.teaching_callouts = [
+      { pattern: "x", floors: [1], explanation: "a" },
+      { pattern: "y", floors: [99], explanation: "b" },
+    ];
+    const inputs: RerankInputs = { output: llmOutput, candidates };
+    const result = rerankIfDominated(inputs);
+    expect(result.reranked).toBe(true);
+    expect(result.output.key_branches.length).toBeGreaterThanOrEqual(1);
+    expect(result.output.key_branches[0].decision).toContain(
+      "Coach initially picked",
+    );
+    expect(result.output.teaching_callouts).toHaveLength(1);
+    expect(result.output.teaching_callouts[0].floors).toEqual([1]);
+  });
+});

--- a/packages/shared/evaluation/map/rerank-if-dominated.ts
+++ b/packages/shared/evaluation/map/rerank-if-dominated.ts
@@ -1,0 +1,127 @@
+import type { MapCoachOutputRaw } from "../map-coach-schema";
+import type { EnrichedPath } from "./enrich-paths";
+import type { RerankResult } from "./compliance-report";
+
+export interface RerankInputs {
+  output: MapCoachOutputRaw;
+  candidates: EnrichedPath[];
+}
+
+const HP_ORDER = { safe: 0, risky: 1, critical: 2 } as const;
+const BUDGET_ORDER = {
+  within_budget: 0,
+  tight: 1,
+  exceeds_budget: 2,
+} as const;
+
+/** True iff x is strictly better on BOTH axes. */
+function dominates(x: EnrichedPath, y: EnrichedPath): boolean {
+  const hpStrictlyBetter =
+    HP_ORDER[x.aggregates.hpProjectionVerdict] <
+    HP_ORDER[y.aggregates.hpProjectionVerdict];
+  const budgetStrictlyBetter =
+    BUDGET_ORDER[x.aggregates.fightBudgetStatus] <
+    BUDGET_ORDER[y.aggregates.fightBudgetStatus];
+  return hpStrictlyBetter && budgetStrictlyBetter;
+}
+
+function findLlmPick(
+  output: MapCoachOutputRaw,
+  candidates: EnrichedPath[],
+): EnrichedPath | null {
+  const firstNodeId = output.macro_path.floors[0]?.node_id;
+  if (!firstNodeId) return null;
+  return candidates.find((c) => c.nodes[0]?.nodeId === firstNodeId) ?? null;
+}
+
+function shortSummary(path: EnrichedPath): string {
+  const parts = path.nodes.slice(0, 4).map((n) => n.type);
+  return parts.join(" → ");
+}
+
+function applySwap(
+  output: MapCoachOutputRaw,
+  llmPick: EnrichedPath,
+  winner: EnrichedPath,
+): MapCoachOutputRaw {
+  const winnerFloors = winner.nodes.map((n) => ({
+    floor: n.floor,
+    node_type: n.type,
+    node_id: n.nodeId ?? "",
+  }));
+  const winnerFloorSet = new Set(winnerFloors.map((f) => f.floor));
+
+  // Filter key_branches to entries whose floor is still on the new path.
+  const preservedBranches = output.key_branches.filter((b) =>
+    winnerFloorSet.has(b.floor),
+  );
+
+  // Prepend synthetic swap branch at the first floor of the new path.
+  const syntheticBranch = {
+    floor: winnerFloors[0]?.floor ?? 0,
+    decision:
+      "Coach initially picked a path that exceeded fight budget or HP risk.",
+    recommended: `Swap to path ${winner.id} — strictly safer.`,
+    alternatives: [
+      {
+        option: `LLM's original pick (${shortSummary(llmPick)})`,
+        tradeoff: `HP ${llmPick.aggregates.hpProjectionVerdict}, budget ${llmPick.aggregates.fightBudgetStatus}.`,
+      },
+    ],
+    close_call: false,
+  };
+
+  // Filter teaching_callouts to those that still reference a floor on the
+  // new path.
+  const preservedCallouts = output.teaching_callouts.filter((c) =>
+    c.floors.some((f) => winnerFloorSet.has(f)),
+  );
+
+  return {
+    ...output,
+    macro_path: {
+      floors: winnerFloors,
+      summary: `Swapped: ${shortSummary(winner)}`,
+    },
+    headline: `Safer alternative: ${shortSummary(winner)}`,
+    confidence: Math.max(0, output.confidence - 0.15),
+    key_branches: [syntheticBranch, ...preservedBranches],
+    teaching_callouts: preservedCallouts,
+  };
+}
+
+export function rerankIfDominated(inputs: RerankInputs): RerankResult {
+  const { output, candidates } = inputs;
+  const llmPick = findLlmPick(output, candidates);
+  if (!llmPick) {
+    return { output, reranked: false, rerank_reason: null };
+  }
+
+  const dominators = candidates.filter(
+    (c) => c.id !== llmPick.id && dominates(c, llmPick),
+  );
+  if (dominators.length === 0) {
+    return { output, reranked: false, rerank_reason: null };
+  }
+
+  // Tiebreak: lowest HP risk → best fight budget → candidates order as a
+  // stable fallback.
+  const candidateOrder = new Map(candidates.map((c, i) => [c.id, i]));
+  const winner = [...dominators].sort((a, b) => {
+    const hpDiff =
+      HP_ORDER[a.aggregates.hpProjectionVerdict] -
+      HP_ORDER[b.aggregates.hpProjectionVerdict];
+    if (hpDiff !== 0) return hpDiff;
+    const budgetDiff =
+      BUDGET_ORDER[a.aggregates.fightBudgetStatus] -
+      BUDGET_ORDER[b.aggregates.fightBudgetStatus];
+    if (budgetDiff !== 0) return budgetDiff;
+    return (candidateOrder.get(a.id) ?? 0) - (candidateOrder.get(b.id) ?? 0);
+  })[0];
+
+  return {
+    output: applySwap(output, llmPick, winner),
+    reranked: true,
+    rerank_reason: `dominated_by_path_${winner.id}`,
+  };
+}


### PR DESCRIPTION
Phase 2 of the map pathing coach. Adds two post-parse layers to the map eval pipeline so the LLM's output respects the structured facts phase 1 already surfaces.

Closes #82

## What ships

- **`repairMacroPath`** (`packages/shared/evaluation/map/repair-macro-path.ts`) — structural auto-repair. Seven validators run in order (empty, starts-at-current-position, unknown-node-id, first-floor-mismatch, contiguity-gap, missing-boss, walk-dead-end). Smart child walk biases toward the LLM's stated next floor on branching forks via precomputed reachability sets.
- **`rerankIfDominated`** (`packages/shared/evaluation/map/rerank-if-dominated.ts`) — judgment rerank. Swaps the LLM's pick to a strictly-dominating alternative (better on BOTH HP risk AND fight budget). Partial filter preserves `key_branches` and `teaching_callouts` for floors still on the new path; synthetic swap entry prepended. Confidence dampened by 0.15. `reasoning.risk_capacity` + `reasoning.act_goal` preserved.
- **`buildComplianceReport`** — combines repair + rerank results into a single `{repaired, reranked, rerank_reason, repair_reasons}` object attached to the response.
- **Schema** — `mapCoachOutputSchema` gains optional `compliance` field; `nodeTypeEnum` widened to include `"boss"` (closes a latent phase-1 gap).
- **Route wiring** — `/api/evaluate` map branch runs repair → rerank → build-report → re-sanitize → attach, gated on an optional `mapCompliance` field on the request body.
- **Desktop** — `buildMapPrompt` returns compliance inputs alongside prompt + runState; `mapListeners` + `evaluationApi` forward them; `adaptMapCoach` passes compliance through snake→camel; `SwapBadge` renders in `MapView` when a rerank fires.
- **Tests** — 35 new tests (7 repair + 6 rerank + 3 compliance-report + 3 schema + 3 SwapBadge + 3 route integration + regression guards). Full suite: 378 web + 238 desktop, all green.

## Architectural pivot from the plan

Plan's Task 4 assumed `body.state.map` carried raw map state — it doesn't (phase-1 sends only the formatted prompt + `runStateSnapshot`). Added optional `mapCompliance: {nodes, nextOptions, boss, currentPosition, enrichedPaths}` on the eval request body, populated by the desktop. Absent → compliance skipped (backwards compatible).

## UX

- `[↻ Swapped]` amber badge appears next to the confidence pill when a rerank fires. Tooltip exposes `rerank_reason`.
- Repair-only events are silent — the map already renders correctly thanks to the repaired path.
- Confidence pill naturally surfaces the 0.15 dampen.

## Known softnesses

- Strict dominance is conservative by design. If the LLM picks `(exceeds_budget, safe)` and an alternative is `(within_budget, risky)`, neither dominates — no swap. Accept; tune thresholds or loosen to partial-dominance later (phase 2.5).
- Compliance telemetry lives in `choices.rankings_snapshot->'compliance'` — no dashboard yet. Raw SQL for now.
- Repair's smart walker falls back to `children[0]` when steering can't help — deterministic but not always what the LLM meant on complex forks.

## Out of scope

- Phase 3: deviation-aware prompting (personal history injection). Now unblocked by compliance telemetry.
- Phase 4+: extend the repair + rerank pattern to card/shop/ancient eval types.

## Test plan

- [x] `pnpm turbo test` all workspaces green (616/616)
- [x] `pnpm -r exec tsc --noEmit` clean
- [x] `pnpm turbo lint` at phase-1 baseline (4 pre-existing errors, unchanged)
- [x] `pnpm turbo build` web + desktop both succeed
- [ ] Manual smoke: trigger a map eval that historically got a bad pick; verify SwapBadge appears and headline changes
- [ ] SQL check: `choices.rankings_snapshot->'compliance'` populated after eval

## Related

- Spec: `docs/superpowers/specs/2026-04-18-map-coach-compliance-design.md`
- Plan: `docs/superpowers/plans/2026-04-18-map-coach-compliance.md`