### PR TITLE
feat(desktop): save-file-derived canonical runId (Phase 1+2)

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -1224,6 +1224,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2055,12 +2064,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd168d97690d0b8c412d6b6c10360277f4d7ee495c5d0d5d5fe0854923255cc"
+dependencies = [
+ "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -2224,6 +2262,26 @@ dependencies = [
  "bitflags 2.11.0",
  "serde",
  "unicode-segmentation",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
 ]
 
 [[package]]
@@ -2457,6 +2515,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
+ "log",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
 ]
@@ -2540,6 +2599,34 @@ name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
+
+[[package]]
+name = "notify"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c533b4c39709f9ba5005d8002048266593c1cfaf3c5f0739d5b8ab0c6c504009"
+dependencies = [
+ "bitflags 2.11.0",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "notify-types"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "585d3cb5e12e01aed9e8a1f70d5c6b5e86fe2a6e48fc8cd0b3e0b8df6f6eb174"
+dependencies = [
+ "instant",
+]
 
 [[package]]
 name = "ntapi"
@@ -4442,6 +4529,7 @@ version = "0.1.0"
 dependencies = [
  "dirs",
  "log",
+ "notify",
  "reqwest 0.12.28",
  "serde",
  "serde_json",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -34,6 +34,7 @@ dirs = "6.0"
 thiserror = "2"
 tempfile = "3"
 sysinfo = "0.33"
+notify = "7"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winreg = "0.55"

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1,5 +1,6 @@
 mod game_state_poller;
 mod mods;
+mod save_file;
 mod steam;
 
 use mods::{GameInfo, InstallOutcome, InstallResult, ModError, ModStatus};

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -2,6 +2,7 @@ mod game_state_poller;
 mod mods;
 mod save_dir;
 mod save_file;
+mod save_watcher;
 mod steam;
 
 use mods::{GameInfo, InstallOutcome, InstallResult, ModError, ModStatus};
@@ -129,6 +130,7 @@ pub fn run() {
             game_state_poller::get_latest_game_state,
             save_file::get_active_run_identifier,
             save_file::list_run_history,
+            save_watcher::start_run_history_watch,
         ])
         .setup(|app| {
             let handle = app.handle().clone();
@@ -136,6 +138,12 @@ pub fn run() {
                 handle,
                 "http://127.0.0.1:15526".to_string(),
             );
+            let app_for_watcher = app.handle().clone();
+            tauri::async_runtime::spawn(async move {
+                if let Err(e) = save_watcher::start_run_history_watch(app_for_watcher).await {
+                    log::info!("[save_watcher] skipped: {e}");
+                }
+            });
             Ok(())
         })
         .run(tauri::generate_context!())

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -127,6 +127,8 @@ pub fn run() {
             get_mod_status,
             install_required_mods,
             game_state_poller::get_latest_game_state,
+            save_file::get_active_run_identifier,
+            save_file::list_run_history,
         ])
         .setup(|app| {
             let handle = app.handle().clone();

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1,5 +1,6 @@
 mod game_state_poller;
 mod mods;
+mod save_dir;
 mod save_file;
 mod steam;
 

--- a/apps/desktop/src-tauri/src/save_dir.rs
+++ b/apps/desktop/src-tauri/src/save_dir.rs
@@ -1,0 +1,153 @@
+//! STS2 save directory resolution. On macOS, STS2 writes saves under
+//! `~/Library/Application Support/SlayTheSpire2/steam/<steam_user_id>/modded/profile1/saves`.
+//! On Windows, the parent is `%APPDATA%\SlayTheSpire2` instead.
+//!
+//! Tests inject a fake home directory via the `sts2_home` parameter; production
+//! callers pass `None` to use the real one.
+
+use std::path::{Path, PathBuf};
+
+use crate::save_file::SaveError;
+
+/// Returns the `saves/` directory inside the active (numeric) steam user
+/// subdirectory, choosing `modded/profile1/saves` first and falling back to
+/// `profile1/saves` if modded doesn't exist.
+pub fn resolve_saves_dir(home_override: Option<&Path>) -> Result<PathBuf, SaveError> {
+    let base = sts2_root(home_override)?;
+    let steam_dir = base.join("steam");
+    if !steam_dir.exists() {
+        return Err(SaveError::NotFound(format!(
+            "sts2 steam dir not found at {}",
+            steam_dir.display()
+        )));
+    }
+
+    // Pick the MOST-RECENTLY-MODIFIED subdirectory whose name is an all-digit
+    // steam user id. Users with alt accounts have multiple numeric dirs; the
+    // currently-active one will be freshest. Falling back to lowest-numeric
+    // would silently point at the wrong account.
+    let mut candidates: Vec<(PathBuf, std::time::SystemTime)> =
+        std::fs::read_dir(&steam_dir)?
+            .filter_map(|e| e.ok())
+            .map(|e| e.path())
+            .filter(|p| p.is_dir())
+            .filter(|p| {
+                p.file_name()
+                    .and_then(|n| n.to_str())
+                    .map(|n| !n.is_empty() && n.chars().all(|c| c.is_ascii_digit()))
+                    .unwrap_or(false)
+            })
+            .filter_map(|p| {
+                let mtime = std::fs::metadata(&p).ok()?.modified().ok()?;
+                Some((p, mtime))
+            })
+            .collect();
+    if candidates.len() > 1 {
+        log::warn!(
+            "[save_dir] {} candidate steam user dirs under {}; picking most recent",
+            candidates.len(),
+            steam_dir.display()
+        );
+    }
+    candidates.sort_by_key(|(_, t)| *t);
+    let user_dir = candidates.pop().map(|(p, _)| p).ok_or_else(|| {
+        SaveError::NotFound(format!(
+            "no numeric steam user id under {}",
+            steam_dir.display()
+        ))
+    })?;
+
+    let modded = user_dir.join("modded/profile1/saves");
+    if modded.exists() {
+        return Ok(modded);
+    }
+    let plain = user_dir.join("profile1/saves");
+    if plain.exists() {
+        return Ok(plain);
+    }
+    Err(SaveError::NotFound(format!(
+        "no saves directory under {}",
+        user_dir.display()
+    )))
+}
+
+fn sts2_root(home_override: Option<&Path>) -> Result<PathBuf, SaveError> {
+    let home = match home_override {
+        Some(p) => p.to_path_buf(),
+        None => dirs::home_dir()
+            .ok_or_else(|| SaveError::NotFound("home directory unavailable".into()))?,
+    };
+
+    #[cfg(target_os = "macos")]
+    {
+        Ok(home.join("Library/Application Support/SlayTheSpire2"))
+    }
+    #[cfg(target_os = "windows")]
+    {
+        // When home_override is provided, tests lay out AppData directly inside it.
+        if home_override.is_some() {
+            Ok(home.join("AppData/Roaming/SlayTheSpire2"))
+        } else {
+            Ok(home.join("AppData\\Roaming\\SlayTheSpire2"))
+        }
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    {
+        Err(SaveError::NotFound(format!(
+            "sts2 save dir not defined on this platform"
+        )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn make_layout(home: &Path) {
+        let base: PathBuf;
+        #[cfg(target_os = "macos")]
+        {
+            base = home.join("Library/Application Support/SlayTheSpire2/steam/987654321/modded/profile1/saves");
+        }
+        #[cfg(target_os = "windows")]
+        {
+            base = home.join("AppData/Roaming/SlayTheSpire2/steam/987654321/modded/profile1/saves");
+        }
+        std::fs::create_dir_all(&base).unwrap();
+        std::fs::create_dir_all(base.join("history")).unwrap();
+    }
+
+    #[test]
+    fn resolves_saves_dir_for_modded_layout() {
+        let tmp = TempDir::new().unwrap();
+        make_layout(tmp.path());
+        let dir = resolve_saves_dir(Some(tmp.path())).expect("resolve");
+        assert!(dir.ends_with("modded/profile1/saves") || dir.ends_with("modded\\profile1\\saves"));
+    }
+
+    #[test]
+    fn returns_not_found_when_no_steam_dir() {
+        let tmp = TempDir::new().unwrap();
+        let err = resolve_saves_dir(Some(tmp.path())).unwrap_err();
+        assert!(matches!(err, SaveError::NotFound(_)));
+    }
+
+    #[test]
+    fn picks_numeric_steam_user_dir_ignoring_others() {
+        let tmp = TempDir::new().unwrap();
+        make_layout(tmp.path());
+        // Add a non-numeric sibling that must be ignored
+        let extra;
+        #[cfg(target_os = "macos")]
+        {
+            extra = tmp.path().join("Library/Application Support/SlayTheSpire2/steam/not_numeric");
+        }
+        #[cfg(target_os = "windows")]
+        {
+            extra = tmp.path().join("AppData/Roaming/SlayTheSpire2/steam/not_numeric");
+        }
+        std::fs::create_dir_all(&extra).unwrap();
+        resolve_saves_dir(Some(tmp.path())).expect("resolve");
+    }
+}

--- a/apps/desktop/src-tauri/src/save_file.rs
+++ b/apps/desktop/src-tauri/src/save_file.rs
@@ -1,0 +1,164 @@
+//! Pure parsing for STS2 save files. No I/O beyond the file read for each
+//! path passed in. Tolerant of schema-version drift via `#[serde(default)]`
+//! on all optional fields.
+
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+use thiserror::Error;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct RunSummary {
+    pub start_time: i64,
+    pub seed: String,
+    pub ascension: u32,
+    pub character: String,
+    pub win: bool,
+    pub was_abandoned: bool,
+    pub killed_by_encounter: String,
+    pub run_time: u32,
+    pub build_id: String,
+    pub act_reached: u32,
+    pub players_count: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ActiveRun {
+    pub start_time: i64,
+    pub seed: String,
+    pub ascension: u32,
+    pub character: String,
+    pub is_mp: bool,
+}
+
+#[derive(Debug, Error)]
+pub enum SaveError {
+    #[error("save file not found: {0}")]
+    NotFound(String),
+    #[error("save file i/o: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("save file parse: schema_version={schema_version:?} path={path}: {source}")]
+    Parse {
+        path: String,
+        schema_version: Option<u32>,
+        #[source]
+        source: serde_json::Error,
+    },
+}
+
+/// Raw shape of a `history/<start_time>.run` file — only fields we need.
+/// Everything else is tolerated via `#[serde(default)]`.
+#[derive(Deserialize)]
+struct RawRunFile {
+    start_time: i64,
+    #[serde(default)]
+    seed: String,
+    #[serde(default)]
+    ascension: u32,
+    #[serde(default)]
+    win: bool,
+    #[serde(default)]
+    was_abandoned: bool,
+    #[serde(default)]
+    killed_by_encounter: String,
+    #[serde(default)]
+    run_time: u32,
+    #[serde(default)]
+    build_id: String,
+    #[serde(default)]
+    schema_version: Option<u32>,
+    #[serde(default)]
+    players: Vec<RawPlayer>,
+    #[serde(default)]
+    map_point_history: Vec<Vec<serde_json::Value>>,
+}
+
+#[derive(Deserialize, Default)]
+struct RawPlayer {
+    #[serde(default)]
+    character: String,
+}
+
+pub fn parse_run_file(path: &Path) -> Result<RunSummary, SaveError> {
+    let bytes = std::fs::read(path)?;
+    let path_str = path.to_string_lossy().to_string();
+
+    // Peek at schema_version even if the full parse fails, for better errors.
+    let peeked_version: Option<u32> = serde_json::from_slice::<serde_json::Value>(&bytes)
+        .ok()
+        .and_then(|v| v.get("schema_version").and_then(|x| x.as_u64()).map(|n| n as u32));
+
+    let raw: RawRunFile = serde_json::from_slice(&bytes).map_err(|e| SaveError::Parse {
+        path: path_str.clone(),
+        schema_version: peeked_version,
+        source: e,
+    })?;
+
+    let character = raw
+        .players
+        .first()
+        .map(|p| p.character.clone())
+        .unwrap_or_default();
+
+    let act_reached = raw.map_point_history.len() as u32;
+
+    Ok(RunSummary {
+        start_time: raw.start_time,
+        seed: raw.seed,
+        ascension: raw.ascension,
+        character,
+        win: raw.win,
+        was_abandoned: raw.was_abandoned,
+        killed_by_encounter: raw.killed_by_encounter,
+        run_time: raw.run_time,
+        build_id: raw.build_id,
+        act_reached,
+        players_count: raw.players.len() as u32,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn fixture(name: &str) -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tests")
+            .join("fixtures")
+            .join(name)
+    }
+
+    #[test]
+    fn parse_run_file_ok_for_sp_win() {
+        let summary = parse_run_file(&fixture("sp_win.run")).expect("parse");
+        assert_eq!(summary.win, true);
+        assert_eq!(summary.was_abandoned, false);
+        assert_eq!(summary.killed_by_encounter, "NONE.NONE");
+        assert_eq!(summary.players_count, 1);
+        assert!(summary.start_time > 0);
+        assert!(!summary.seed.is_empty());
+    }
+
+    #[test]
+    fn parse_run_file_ok_for_sp_death() {
+        let summary = parse_run_file(&fixture("sp_death.run")).expect("parse");
+        assert_eq!(summary.win, false);
+        assert_eq!(summary.was_abandoned, false);
+        assert_ne!(summary.killed_by_encounter, "NONE.NONE");
+        assert_eq!(summary.players_count, 1);
+    }
+
+    #[test]
+    fn parse_run_file_ok_for_sp_abandon() {
+        let summary = parse_run_file(&fixture("sp_abandon.run")).expect("parse");
+        assert_eq!(summary.win, false);
+        assert_eq!(summary.was_abandoned, true);
+        assert_eq!(summary.players_count, 1);
+    }
+
+    #[test]
+    fn parse_run_file_err_on_corrupt_json() {
+        let err = parse_run_file(&fixture("corrupt.run")).unwrap_err();
+        assert!(matches!(err, SaveError::Parse { .. }), "got {err:?}");
+    }
+}

--- a/apps/desktop/src-tauri/src/save_file.rs
+++ b/apps/desktop/src-tauri/src/save_file.rs
@@ -116,6 +116,34 @@ pub fn parse_run_file(path: &Path) -> Result<RunSummary, SaveError> {
     })
 }
 
+pub fn parse_active_save(path: &Path) -> Result<ActiveRun, SaveError> {
+    let bytes = std::fs::read(path)?;
+    let path_str = path.to_string_lossy().to_string();
+    let peeked_version: Option<u32> = serde_json::from_slice::<serde_json::Value>(&bytes)
+        .ok()
+        .and_then(|v| v.get("schema_version").and_then(|x| x.as_u64()).map(|n| n as u32));
+
+    let raw: RawRunFile = serde_json::from_slice(&bytes).map_err(|e| SaveError::Parse {
+        path: path_str.clone(),
+        schema_version: peeked_version,
+        source: e,
+    })?;
+
+    let character = raw
+        .players
+        .first()
+        .map(|p| p.character.clone())
+        .unwrap_or_default();
+
+    Ok(ActiveRun {
+        start_time: raw.start_time,
+        seed: raw.seed,
+        ascension: raw.ascension,
+        character,
+        is_mp: raw.players.len() > 1,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -160,5 +188,25 @@ mod tests {
     fn parse_run_file_err_on_corrupt_json() {
         let err = parse_run_file(&fixture("corrupt.run")).unwrap_err();
         assert!(matches!(err, SaveError::Parse { .. }), "got {err:?}");
+    }
+
+    #[test]
+    fn parse_active_save_detects_singleplayer() {
+        let active = parse_active_save(&fixture("sp_win.run")).expect("parse");
+        // Reusing sp_win.run as a stand-in for current_run.save shape.
+        assert_eq!(active.is_mp, false);
+        assert!(active.start_time > 0);
+    }
+
+    #[test]
+    fn parse_active_save_detects_multiplayer() {
+        let active = parse_active_save(&fixture("current_run_mp.save")).expect("parse");
+        assert_eq!(active.is_mp, true, "len(players) > 1 should imply MP");
+    }
+
+    #[test]
+    fn parse_active_save_err_on_corrupt() {
+        let err = parse_active_save(&fixture("corrupt.run")).unwrap_err();
+        assert!(matches!(err, SaveError::Parse { .. }));
     }
 }

--- a/apps/desktop/src-tauri/src/save_file.rs
+++ b/apps/desktop/src-tauri/src/save_file.rs
@@ -144,6 +144,101 @@ pub fn parse_active_save(path: &Path) -> Result<ActiveRun, SaveError> {
     })
 }
 
+#[derive(Debug, Clone, Serialize)]
+pub struct RunHistoryListing {
+    pub entries: Vec<RunSummary>,
+    pub skipped: u32,
+}
+
+#[tauri::command]
+pub async fn get_active_run_identifier() -> Result<Option<ActiveRun>, String> {
+    let saves_dir = match crate::save_dir::resolve_saves_dir(None) {
+        Ok(d) => d,
+        Err(e) => {
+            log::info!("[save_file] saves dir unavailable: {e}");
+            return Ok(None);
+        }
+    };
+
+    // Prefer current_run.save (SP); fall back to current_run_mp.save (MP).
+    for name in ["current_run.save", "current_run_mp.save"] {
+        let path = saves_dir.join(name);
+        if path.exists() {
+            match parse_active_save(&path) {
+                Ok(active) => return Ok(Some(active)),
+                Err(e) => {
+                    log::warn!("[save_file] parse {} failed: {e}", name);
+                    continue;
+                }
+            }
+        }
+    }
+    Ok(None)
+}
+
+#[tauri::command]
+pub async fn list_run_history(
+    after_start_time: Option<i64>,
+) -> Result<RunHistoryListing, String> {
+    let saves_dir = match crate::save_dir::resolve_saves_dir(None) {
+        Ok(d) => d,
+        Err(e) => {
+            log::info!("[save_file] saves dir unavailable: {e}");
+            return Ok(RunHistoryListing {
+                entries: vec![],
+                skipped: 0,
+            });
+        }
+    };
+    let history_dir = saves_dir.join("history");
+    if !history_dir.exists() {
+        return Ok(RunHistoryListing {
+            entries: vec![],
+            skipped: 0,
+        });
+    }
+
+    let threshold = after_start_time.unwrap_or(0);
+    let mut entries: Vec<RunSummary> = vec![];
+    let mut skipped: u32 = 0;
+
+    let dir_entries = match std::fs::read_dir(&history_dir) {
+        Ok(it) => it,
+        Err(e) => return Err(format!("read_dir {}: {e}", history_dir.display())),
+    };
+
+    for entry in dir_entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) != Some("run") {
+            continue;
+        }
+        // Filename is the start_time; use as a cheap pre-filter before parsing.
+        let stem: Option<i64> = path
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .and_then(|s| s.parse().ok());
+        if let Some(ts) = stem {
+            if ts <= threshold {
+                continue;
+            }
+        }
+        match parse_run_file(&path) {
+            Ok(summary) => {
+                if summary.start_time > threshold {
+                    entries.push(summary);
+                }
+            }
+            Err(e) => {
+                log::warn!("[save_file] skip {}: {e}", path.display());
+                skipped += 1;
+            }
+        }
+    }
+
+    entries.sort_by_key(|s| s.start_time);
+    Ok(RunHistoryListing { entries, skipped })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/apps/desktop/src-tauri/src/save_watcher.rs
+++ b/apps/desktop/src-tauri/src/save_watcher.rs
@@ -1,0 +1,138 @@
+//! `notify`-crate watcher that emits "run-completed" Tauri events when a
+//! new `history/<ts>.run` appears. Wrapped in a supervisor that respawns
+//! the inner task on panic/exit (same pattern as game_state_poller.rs).
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Duration;
+
+use notify::{Event, EventKind, RecursiveMode, Watcher};
+use tauri::{AppHandle, Emitter};
+
+use crate::save_file::{parse_run_file, RunSummary};
+
+/// Arms a watcher on `<saves_dir>/history`. Idempotent — re-arming is a no-op.
+pub async fn start_watch(app: AppHandle, saves_dir: PathBuf) -> Result<(), String> {
+    use std::sync::atomic::{AtomicBool, Ordering};
+    static ARMED: AtomicBool = AtomicBool::new(false);
+    if ARMED
+        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+        .is_err()
+    {
+        return Ok(());
+    }
+
+    let history_dir = saves_dir.join("history");
+    if !history_dir.exists() {
+        std::fs::create_dir_all(&history_dir)
+            .map_err(|e| format!("create history dir: {e}"))?;
+    }
+
+    tauri::async_runtime::spawn(async move {
+        loop {
+            let app_c = app.clone();
+            let dir_c = history_dir.clone();
+            let handle = tokio::spawn(async move {
+                run_watch_loop(app_c, dir_c).await;
+            });
+            match handle.await {
+                Ok(()) => log::error!("[save_watcher] exited; restarting in 1s"),
+                Err(e) if e.is_panic() => {
+                    log::error!("[save_watcher] panicked: {e}; restarting in 1s")
+                }
+                Err(e) => log::error!("[save_watcher] cancelled: {e}; restarting in 1s"),
+            }
+            tokio::time::sleep(Duration::from_secs(1)).await;
+        }
+    });
+
+    Ok(())
+}
+
+async fn run_watch_loop(app: AppHandle, history_dir: PathBuf) {
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<Event>();
+    let tx = Arc::new(tx);
+    let tx_clone = tx.clone();
+
+    let mut watcher = match notify::recommended_watcher(move |res: notify::Result<Event>| {
+        if let Ok(ev) = res {
+            let _ = tx_clone.send(ev);
+        }
+    }) {
+        Ok(w) => w,
+        Err(e) => {
+            log::error!("[save_watcher] create watcher failed: {e}");
+            return;
+        }
+    };
+
+    if let Err(e) = watcher.watch(&history_dir, RecursiveMode::NonRecursive) {
+        log::error!("[save_watcher] watch failed: {e}");
+        return;
+    }
+
+    log::info!("[save_watcher] watching {}", history_dir.display());
+
+    while let Some(ev) = rx.recv().await {
+        if !matches!(ev.kind, EventKind::Create(_) | EventKind::Modify(_)) {
+            continue;
+        }
+        for path in ev.paths {
+            if path.extension().and_then(|s| s.to_str()) != Some("run") {
+                continue;
+            }
+            handle_new_history_file(&app, &path).await;
+        }
+    }
+}
+
+async fn handle_new_history_file(app: &AppHandle, path: &Path) {
+    // Small debounce — the game can write the file in multiple passes.
+    tokio::time::sleep(Duration::from_millis(150)).await;
+    match parse_run_file(path) {
+        Ok(summary) => emit_run_completed(app, &summary),
+        Err(e) => log::warn!(
+            "[save_watcher] parse {} failed: {e}",
+            path.display()
+        ),
+    }
+}
+
+fn emit_run_completed(app: &AppHandle, summary: &RunSummary) {
+    if let Err(e) = app.emit("run-completed", summary) {
+        log::warn!("[save_watcher] emit run-completed failed: {e}");
+    }
+}
+
+#[tauri::command]
+pub async fn start_run_history_watch(app: AppHandle) -> Result<(), String> {
+    let saves_dir = crate::save_dir::resolve_saves_dir(None)
+        .map_err(|e| format!("resolve saves dir: {e}"))?;
+    start_watch(app, saves_dir).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    /// Verify the inner fs-watch → parse → handle pipeline. We bypass the
+    /// Tauri event emit (which requires an AppHandle) and instead assert
+    /// that `parse_run_file` returns Ok when given a file the watcher sees.
+    #[tokio::test]
+    async fn parses_new_history_file_when_dropped_into_dir() {
+        let tmp = TempDir::new().unwrap();
+        let history = tmp.path().join("history");
+        std::fs::create_dir_all(&history).unwrap();
+
+        // Drop a valid fixture
+        let fixture = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/fixtures/sp_win.run");
+        let target = history.join("1234567890.run");
+        std::fs::copy(&fixture, &target).unwrap();
+
+        let summary = parse_run_file(&target).expect("parse");
+        assert_eq!(summary.players_count, 1);
+        assert!(summary.win || !summary.win); // tautology — assert it parses without panic
+    }
+}

--- a/apps/desktop/src-tauri/tests/fixtures/corrupt.run
+++ b/apps/desktop/src-tauri/tests/fixtures/corrupt.run
@@ -1,0 +1,1 @@
+{"seed": "OOPS", "start_time": 1234567890, truncated here

--- a/apps/desktop/src-tauri/tests/fixtures/current_run_mp.save
+++ b/apps/desktop/src-tauri/tests/fixtures/current_run_mp.save
@@ -1,0 +1,5072 @@
+{
+  "acts": [
+    {
+      "id": "ACT.OVERGROWTH",
+      "rooms": {
+        "ancient_id": "EVENT.NEOW",
+        "boss_encounters_visited": 1,
+        "boss_id": "ENCOUNTER.THE_KIN_BOSS",
+        "elite_encounter_ids": [
+          "ENCOUNTER.BYGONE_EFFIGY_ELITE",
+          "ENCOUNTER.BYRDONIS_ELITE",
+          "ENCOUNTER.PHROG_PARASITE_ELITE",
+          "ENCOUNTER.BYRDONIS_ELITE",
+          "ENCOUNTER.BYGONE_EFFIGY_ELITE",
+          "ENCOUNTER.PHROG_PARASITE_ELITE",
+          "ENCOUNTER.BYRDONIS_ELITE",
+          "ENCOUNTER.BYGONE_EFFIGY_ELITE",
+          "ENCOUNTER.PHROG_PARASITE_ELITE",
+          "ENCOUNTER.BYRDONIS_ELITE",
+          "ENCOUNTER.PHROG_PARASITE_ELITE",
+          "ENCOUNTER.BYGONE_EFFIGY_ELITE",
+          "ENCOUNTER.BYRDONIS_ELITE",
+          "ENCOUNTER.PHROG_PARASITE_ELITE",
+          "ENCOUNTER.BYGONE_EFFIGY_ELITE"
+        ],
+        "elite_encounters_visited": 3,
+        "event_ids": [
+          "EVENT.RELIC_TRADER",
+          "EVENT.FAKE_MERCHANT",
+          "EVENT.WELLSPRING",
+          "EVENT.MORPHIC_GROVE",
+          "EVENT.DOLL_ROOM",
+          "EVENT.SELF_HELP_BOOK",
+          "EVENT.STONE_OF_ALL_TIME",
+          "EVENT.RANWID_THE_ELDER",
+          "EVENT.SAPPHIRE_SEED",
+          "EVENT.SYMBIOTE",
+          "EVENT.CRYSTAL_SPHERE",
+          "EVENT.POTION_COURIER",
+          "EVENT.AROMA_OF_CHAOS",
+          "EVENT.WELCOME_TO_WONGOS",
+          "EVENT.WHISPERING_HOLLOW",
+          "EVENT.TABLET_OF_TRUTH",
+          "EVENT.THIS_OR_THAT",
+          "EVENT.ROOM_FULL_OF_CHEESE",
+          "EVENT.BRAIN_LEECH",
+          "EVENT.WOOD_CARVINGS",
+          "EVENT.SUNKEN_STATUE",
+          "EVENT.THE_FUTURE_OF_POTIONS",
+          "EVENT.UNREST_SITE",
+          "EVENT.THE_LEGENDS_WERE_TRUE",
+          "EVENT.WAR_HISTORIAN_REPY",
+          "EVENT.BYRDONIS_NEST",
+          "EVENT.SLIPPERY_BRIDGE",
+          "EVENT.TEA_MASTER",
+          "EVENT.DENSE_VEGETATION",
+          "EVENT.LUMINOUS_CHOIR",
+          "EVENT.JUNGLE_MAZE_ADVENTURE"
+        ],
+        "events_visited": 1,
+        "normal_encounter_ids": [
+          "ENCOUNTER.FUZZY_WURM_CRAWLER_WEAK",
+          "ENCOUNTER.NIBBITS_WEAK",
+          "ENCOUNTER.SLIMES_WEAK",
+          "ENCOUNTER.FOGMOG_NORMAL",
+          "ENCOUNTER.SLIMES_NORMAL",
+          "ENCOUNTER.CUBEX_CONSTRUCT_NORMAL",
+          "ENCOUNTER.MAWLER_NORMAL",
+          "ENCOUNTER.SNAPPING_JAXFRUIT_NORMAL",
+          "ENCOUNTER.OVERGROWTH_CRAWLERS",
+          "ENCOUNTER.RUBY_RAIDERS_NORMAL",
+          "ENCOUNTER.SLITHERING_STRANGLER_NORMAL",
+          "ENCOUNTER.INKLETS_NORMAL",
+          "ENCOUNTER.NIBBITS_NORMAL",
+          "ENCOUNTER.VINE_SHAMBLER_NORMAL"
+        ],
+        "normal_encounters_visited": 5,
+        "second_boss_id": null
+      }
+    },
+    {
+      "id": "ACT.HIVE",
+      "rooms": {
+        "ancient_id": "EVENT.PAEL",
+        "boss_encounters_visited": 1,
+        "boss_id": "ENCOUNTER.THE_INSATIABLE_BOSS",
+        "elite_encounter_ids": [
+          "ENCOUNTER.DECIMILLIPEDE_ELITE",
+          "ENCOUNTER.ENTOMANCER_ELITE",
+          "ENCOUNTER.INFESTED_PRISMS_ELITE",
+          "ENCOUNTER.ENTOMANCER_ELITE",
+          "ENCOUNTER.DECIMILLIPEDE_ELITE",
+          "ENCOUNTER.INFESTED_PRISMS_ELITE",
+          "ENCOUNTER.ENTOMANCER_ELITE",
+          "ENCOUNTER.INFESTED_PRISMS_ELITE",
+          "ENCOUNTER.DECIMILLIPEDE_ELITE",
+          "ENCOUNTER.INFESTED_PRISMS_ELITE",
+          "ENCOUNTER.ENTOMANCER_ELITE",
+          "ENCOUNTER.DECIMILLIPEDE_ELITE",
+          "ENCOUNTER.ENTOMANCER_ELITE",
+          "ENCOUNTER.INFESTED_PRISMS_ELITE",
+          "ENCOUNTER.DECIMILLIPEDE_ELITE"
+        ],
+        "elite_encounters_visited": 2,
+        "event_ids": [
+          "EVENT.RELIC_TRADER",
+          "EVENT.DOLL_ROOM",
+          "EVENT.BUGSLAYER",
+          "EVENT.ROOM_FULL_OF_CHEESE",
+          "EVENT.THE_LEGENDS_WERE_TRUE",
+          "EVENT.INFESTED_AUTOMATON",
+          "EVENT.THE_FUTURE_OF_POTIONS",
+          "EVENT.CRYSTAL_SPHERE",
+          "EVENT.BRAIN_LEECH",
+          "EVENT.COLORFUL_PHILOSOPHERS",
+          "EVENT.POTION_COURIER",
+          "EVENT.SPIRIT_GRAFTER",
+          "EVENT.SYMBIOTE",
+          "EVENT.TEA_MASTER",
+          "EVENT.FAKE_MERCHANT",
+          "EVENT.RANWID_THE_ELDER",
+          "EVENT.WAR_HISTORIAN_REPY",
+          "EVENT.LOST_WISP",
+          "EVENT.ZEN_WEAVER",
+          "EVENT.STONE_OF_ALL_TIME",
+          "EVENT.THIS_OR_THAT",
+          "EVENT.FIELD_OF_MAN_SIZED_HOLES",
+          "EVENT.AMALGAMATOR",
+          "EVENT.WELCOME_TO_WONGOS",
+          "EVENT.COLOSSAL_FLOWER",
+          "EVENT.THE_LANTERN_KEY",
+          "EVENT.SELF_HELP_BOOK",
+          "EVENT.SLIPPERY_BRIDGE"
+        ],
+        "events_visited": 4,
+        "normal_encounter_ids": [
+          "ENCOUNTER.THIEVING_HOPPER_WEAK",
+          "ENCOUNTER.BOWLBUGS_WEAK",
+          "ENCOUNTER.LOUSE_PROGENITOR_NORMAL",
+          "ENCOUNTER.OVICOPTER_NORMAL",
+          "ENCOUNTER.SLUMBERING_BEETLE_NORMAL",
+          "ENCOUNTER.SPINY_TOAD_NORMAL",
+          "ENCOUNTER.THE_OBSCURA_NORMAL",
+          "ENCOUNTER.BOWLBUGS_NORMAL",
+          "ENCOUNTER.HUNTER_KILLER_NORMAL",
+          "ENCOUNTER.CHOMPERS_NORMAL",
+          "ENCOUNTER.MYTES_NORMAL",
+          "ENCOUNTER.EXOSKELETONS_NORMAL",
+          "ENCOUNTER.LOUSE_PROGENITOR_NORMAL"
+        ],
+        "normal_encounters_visited": 4,
+        "second_boss_id": null
+      }
+    },
+    {
+      "id": "ACT.GLORY",
+      "rooms": {
+        "ancient_id": "EVENT.VAKUU",
+        "boss_encounters_visited": 0,
+        "boss_id": "ENCOUNTER.QUEEN_BOSS",
+        "elite_encounter_ids": [
+          "ENCOUNTER.MECHA_KNIGHT_ELITE",
+          "ENCOUNTER.KNIGHTS_ELITE",
+          "ENCOUNTER.SOUL_NEXUS_ELITE",
+          "ENCOUNTER.MECHA_KNIGHT_ELITE",
+          "ENCOUNTER.KNIGHTS_ELITE",
+          "ENCOUNTER.SOUL_NEXUS_ELITE",
+          "ENCOUNTER.MECHA_KNIGHT_ELITE",
+          "ENCOUNTER.SOUL_NEXUS_ELITE",
+          "ENCOUNTER.KNIGHTS_ELITE",
+          "ENCOUNTER.SOUL_NEXUS_ELITE",
+          "ENCOUNTER.MECHA_KNIGHT_ELITE",
+          "ENCOUNTER.KNIGHTS_ELITE",
+          "ENCOUNTER.SOUL_NEXUS_ELITE",
+          "ENCOUNTER.KNIGHTS_ELITE",
+          "ENCOUNTER.MECHA_KNIGHT_ELITE"
+        ],
+        "elite_encounters_visited": 0,
+        "event_ids": [
+          "EVENT.DOLL_ROOM",
+          "EVENT.BATTLEWORN_DUMMY",
+          "EVENT.ROUND_TEA_PARTY",
+          "EVENT.RELIC_TRADER",
+          "EVENT.ROOM_FULL_OF_CHEESE",
+          "EVENT.THE_FUTURE_OF_POTIONS",
+          "EVENT.THE_LEGENDS_WERE_TRUE",
+          "EVENT.WELCOME_TO_WONGOS",
+          "EVENT.CRYSTAL_SPHERE",
+          "EVENT.BRAIN_LEECH",
+          "EVENT.TINKER_TIME",
+          "EVENT.STONE_OF_ALL_TIME",
+          "EVENT.REFLECTIONS",
+          "EVENT.TRIAL",
+          "EVENT.SYMBIOTE",
+          "EVENT.GRAVE_OF_THE_FORGOTTEN",
+          "EVENT.RANWID_THE_ELDER",
+          "EVENT.POTION_COURIER",
+          "EVENT.SLIPPERY_BRIDGE",
+          "EVENT.TEA_MASTER",
+          "EVENT.HUNGRY_FOR_MUSHROOMS",
+          "EVENT.SELF_HELP_BOOK",
+          "EVENT.THIS_OR_THAT",
+          "EVENT.FAKE_MERCHANT",
+          "EVENT.WAR_HISTORIAN_REPY"
+        ],
+        "events_visited": 1,
+        "normal_encounter_ids": [
+          "ENCOUNTER.TURRET_OPERATOR_WEAK",
+          "ENCOUNTER.DEVOTED_SCULPTOR_WEAK",
+          "ENCOUNTER.GLOBE_HEAD_NORMAL",
+          "ENCOUNTER.THE_LOST_AND_FORGOTTEN_NORMAL",
+          "ENCOUNTER.SLIMED_BERSERKER_NORMAL",
+          "ENCOUNTER.CONSTRUCT_MENAGERIE_NORMAL",
+          "ENCOUNTER.AXEBOTS_NORMAL",
+          "ENCOUNTER.FROG_KNIGHT_NORMAL",
+          "ENCOUNTER.SCROLLS_OF_BITING_NORMAL",
+          "ENCOUNTER.FABRICATOR_NORMAL",
+          "ENCOUNTER.OWL_MAGISTRATE_NORMAL",
+          "ENCOUNTER.THE_LOST_AND_FORGOTTEN_NORMAL"
+        ],
+        "normal_encounters_visited": 0,
+        "second_boss_id": null
+      },
+      "saved_map": {
+        "boss": {
+          "can_modify": true,
+          "coord": {
+            "col": 3,
+            "row": 13
+          },
+          "type": "boss"
+        },
+        "height": 13,
+        "points": [
+          {
+            "can_modify": true,
+            "children": [
+              {
+                "col": 1,
+                "row": 3
+              },
+              {
+                "col": 2,
+                "row": 3
+              }
+            ],
+            "coord": {
+              "col": 1,
+              "row": 2
+            },
+            "type": "unknown"
+          },
+          {
+            "can_modify": true,
+            "children": [
+              {
+                "col": 1,
+                "row": 4
+              }
+            ],
+            "coord": {
+              "col": 1,
+              "row": 3
+            },
+            "type": "monster"
+          },
+          {
+            "can_modify": true,
+            "children": [
+              {
+                "col": 1,
+                "row": 5
+              }
+            ],
+            "coord": {
+              "col": 1,
+              "row": 4
+            },
+            "type": "monster"
+          },
+          {
+            "can_modify": true,
+            "children": [
+              {
+                "col": 1,
+                "row": 6
+              }
+            ],
+            "coord": {
+              "col": 1,
+              "row": 5
+            },
+            "type": "monster"
+          },
+          {
+            "children": [
+              {
+                "col": 2,
+                "row": 7
+              }
+            ],
+            "coord": {
+              "col": 1,
+              "row": 6
+            },
+            "type": "treasure"
+          },
+          {
+            "can_modify": true,
+            "children": [
+              {
+                "col": 1,
+                "row": 9
+              },
+              {
+                "col": 2,
+                "row": 9
+              }
+            ],
+            "coord": {
+              "col": 1,
+              "row": 8
+            },
+            "type": "elite"
+          },
+          {
+            "can_modify": true,
+            "children": [
+              {
+                "col": 1,
+                "row": 10
+              }
+            ],
+            "coord": {
+              "col": 1,
+              "row": 9
+            },
+            "type": "unknown"
+          },
+          {
+            "can_modify": true,
+            "children": [
+              {
+                "col": 2,
+                "row": 11
+              }
+            ],
+            "coord": {
+              "col": 1,
+              "row": 10
+            },
+            "type": "elite"
+          },
+          {
+            "children": [
+              {
+                "col": 2,
+                "row": 2
+              },
+              {
+                "col": 1,
+                "row": 2
+              }
+            ],
+            "coord": {
+              "col": 2,
+              "row": 1
+            },
+            "type": "monster"
+          },
+          {
+            "can_modify": true,
+            "children": [
+              {
+                "col": 2,
+                "row": 3
+              }
+            ],
+            "coord": {
+              "col": 2,
+              "row": 2
+            },
+            "type": "monster"
+          },
+          {
+            "can_modify": true,
+            "children": [
+              {
+                "col": 2,
+                "row": 4
+              }
+            ],
+            "coord": {
+              "col": 2,
+              "row": 3
+            },
+            "type": "unknown"
+          },
+          {
+            "can_modify": true,
+            "children": [
+              {
+                "col": 2,
+                "row": 5
+              }
+            ],
+            "coord": {
+              "col": 2,
+              "row": 4
+            },
+            "type": "monster"
+          },
+          {
+            "can_modify": true,
+            "children": [
+              {
+                "col": 3,
+                "row": 6
+              }
+            ],
+            "coord": {
+              "col": 2,
+              "row": 5
+            },
+            "type": "unknown"
+          },
+          {
+            "can_modify": true,
+            "children": [
+              {
+                "col": 1,
+                "row": 8
+              }
+            ],
+            "coord": {
+              "col": 2,
+              "row": 7
+            },
+            "type": "rest_site"
+          },
+          {
+            "can_modify": true,
+            "children": [
+              {
+                "col": 1,
+                "row": 10
+              }
+            ],
+            "coord": {
+              "col": 2,
+              "row": 9
+            },
+            "type": "rest_site"
+          },
+          {
+            "can_modify": true,
+            "children": [
+              {
+                "col": 3,
+                "row": 12
+              }
+            ],
+            "coord": {
+              "col": 2,
+              "row": 11
+            },
+            "type": "unknown"
+          },
+          {
+            "children": [
+              {
+                "col": 4,
+                "row": 2
+              }
+            ],
+            "coord": {
+              "col": 3,
+              "row": 1
+            },
+            "type": "monster"
+          },
+          {
+            "children": [
+              {
+                "col": 2,
+                "row": 7
+              },
+              {
+                "col": 4,
+                "row": 7
+              },
+              {
+                "col": 3,
+                "row": 7
+              }
+            ],
+            "coord": {
+              "col": 3,
+              "row": 6
+            },
+            "type": "treasure"
+          },
+          {
+            "can_modify": true,
+            "children": [
+              {
+                "col": 3,
+                "row": 8
+              }
+            ],
+            "coord": {
+              "col": 3,
+              "row": 7
+            },
+            "type": "unknown"
+          },
+          {
+            "can_modify": true,
+            "children": [
+              {
+                "col": 3,
+                "row": 9
+              },
+              {
+                "col": 4,
+                "row": 9
+              }
+            ],
+            "coord": {
+              "col": 3,
+              "row": 8
+            },
+            "type": "elite"
+          },
+          {
+            "can_modify": true,
+            "children": [
+              {
+                "col": 3,
+                "row": 10
+              }
+            ],
+            "coord": {
+              "col": 3,
+              "row": 9
+            },
+            "type": "rest_site"
+          },
+          {
+            "can_modify": true,
+            "children": [
+              {
+                "col": 4,
+                "row": 11
+              },
+              {
+                "col": 3,
+                "row": 11
+              }
+            ],
+            "coord": {
+              "col": 3,
+              "row": 10
+            },
+            "type": "monster"
+          },
+          {
+            "can_modify": true,
+            "children": [
+              {
+                "col": 3,
+                "row": 12
+              }
+            ],
+            "coord": {
+              "col": 3,
+              "row": 11
+            },
+            "type": "unknown"
+          },
+          {
+            "children": [
+              {
+                "col": 3,
+                "row": 13
+              }
+            ],
+            "coord": {
+              "col": 3,
+              "row": 12
+            },
+            "type": "rest_site"
+          },
+          {
+            "can_modify": true,
+            "children": [
+              {
+                "col": 5,
+                "row": 3
+              }
+            ],
+            "coord": {
+              "col": 4,
+              "row": 2
+            },
+            "type": "shop"
+          },
+          {
+            "can_modify": true,
+            "children": [
+              {
+                "col": 4,
+                "row": 5
+              }
+            ],
+            "coord": {
+              "col": 4,
+              "row": 4
+            },
+            "type": "shop"
+          },
+          {
+            "can_modify": true,
+            "children": [
+              {
+                "col": 3,
+                "row": 6
+              }
+            ],
+            "coord": {
+              "col": 4,
+              "row": 5
+            },
+            "type": "monster"
+          },
+          {
+            "can_modify": true,
+            "children": [
+              {
+                "col": 5,
+                "row": 8
+              },
+              {
+                "col": 3,
+                "row": 8
+              }
+            ],
+            "coord": {
+              "col": 4,
+              "row": 7
+            },
+            "type": "monster"
+          },
+          {
+            "can_modify": true,
+            "children": [
+              {
+                "col": 3,
+                "row": 10
+              }
+            ],
+            "coord": {
+              "col": 4,
+              "row": 9
+            },
+            "type": "monster"
+          },
+          {
+            "can_modify": true,
+            "children": [
+              {
+                "col": 3,
+                "row": 12
+              }
+            ],
+            "coord": {
+              "col": 4,
+              "row": 11
+            },
+            "type": "elite"
+          },
+          {
+            "children": [
+              {
+                "col": 6,
+                "row": 2
+              }
+            ],
+            "coord": {
+              "col": 5,
+              "row": 1
+            },
+            "type": "monster"
+          },
+          {
+            "can_modify": true,
+            "children": [
+              {
+                "col": 4,
+                "row": 4
+              },
+              {
+                "col": 5,
+                "row": 4
+              }
+            ],
+            "coord": {
+              "col": 5,
+              "row": 3
+            },
+            "type": "monster"
+          },
+          {
+            "can_modify": true,
+            "children": [
+              {
+                "col": 6,
+                "row": 5
+              },
+              {
+                "col": 4,
+                "row": 5
+              }
+            ],
+            "coord": {
+              "col": 5,
+              "row": 4
+            },
+            "type": "unknown"
+          },
+          {
+            "can_modify": true,
+            "children": [
+              {
+                "col": 5,
+                "row": 8
+              }
+            ],
+            "coord": {
+              "col": 5,
+              "row": 7
+            },
+            "type": "elite"
+          },
+          {
+            "can_modify": true,
+            "children": [
+              {
+                "col": 4,
+                "row": 9
+              },
+              {
+                "col": 5,
+                "row": 9
+              }
+            ],
+            "coord": {
+              "col": 5,
+              "row": 8
+            },
+            "type": "unknown"
+          },
+          {
+            "can_modify": true,
+            "children": [
+              {
+                "col": 5,
+                "row": 10
+              }
+            ],
+            "coord": {
+              "col": 5,
+              "row": 9
+            },
+            "type": "unknown"
+          },
+          {
+            "can_modify": true,
+            "children": [
+              {
+                "col": 4,
+                "row": 11
+              }
+            ],
+            "coord": {
+              "col": 5,
+              "row": 10
+            },
+            "type": "shop"
+          },
+          {
+            "can_modify": true,
+            "children": [
+              {
+                "col": 6,
+                "row": 3
+              },
+              {
+                "col": 5,
+                "row": 3
+              }
+            ],
+            "coord": {
+              "col": 6,
+              "row": 2
+            },
+            "type": "unknown"
+          },
+          {
+            "can_modify": true,
+            "children": [
+              {
+                "col": 5,
+                "row": 4
+              },
+              {
+                "col": 6,
+                "row": 4
+              }
+            ],
+            "coord": {
+              "col": 6,
+              "row": 3
+            },
+            "type": "unknown"
+          },
+          {
+            "can_modify": true,
+            "children": [
+              {
+                "col": 6,
+                "row": 5
+              }
+            ],
+            "coord": {
+              "col": 6,
+              "row": 4
+            },
+            "type": "monster"
+          },
+          {
+            "can_modify": true,
+            "children": [
+              {
+                "col": 6,
+                "row": 6
+              }
+            ],
+            "coord": {
+              "col": 6,
+              "row": 5
+            },
+            "type": "unknown"
+          },
+          {
+            "children": [
+              {
+                "col": 5,
+                "row": 7
+              }
+            ],
+            "coord": {
+              "col": 6,
+              "row": 6
+            },
+            "type": "treasure"
+          }
+        ],
+        "start": {
+          "can_modify": true,
+          "children": [
+            {
+              "col": 2,
+              "row": 1
+            },
+            {
+              "col": 3,
+              "row": 1
+            },
+            {
+              "col": 5,
+              "row": 1
+            }
+          ],
+          "coord": {
+            "col": 3,
+            "row": 0
+          },
+          "type": "ancient"
+        },
+        "start_coords": [
+          {
+            "col": 2,
+            "row": 1
+          },
+          {
+            "col": 5,
+            "row": 1
+          },
+          {
+            "col": 3,
+            "row": 1
+          }
+        ],
+        "width": 7
+      }
+    }
+  ],
+  "ascension": 4,
+  "current_act_index": 2,
+  "events_seen": [
+    "EVENT.DOLL_ROOM",
+    "EVENT.BUGSLAYER",
+    "EVENT.ROOM_FULL_OF_CHEESE"
+  ],
+  "extra_fields": {
+    "started_with_neow": true
+  },
+  "game_mode": "standard",
+  "map_drawings": "H4sIAAAAAAAEE2NiYGB44LaMjZFBgJGBgYGhJKiCGcYGABk75VgcAAAA",
+  "map_point_history": [
+    [
+      {
+        "map_point_type": "ancient",
+        "player_stats": [
+          {
+            "ancient_choice": [
+              {
+                "TextKey": "LOST_COFFER",
+                "title": {
+                  "key": "LOST_COFFER.title",
+                  "table": "relics"
+                },
+                "was_chosen": true
+              },
+              {
+                "TextKey": "NEOWS_TORMENT",
+                "title": {
+                  "key": "NEOWS_TORMENT.title",
+                  "table": "relics"
+                },
+                "was_chosen": false
+              },
+              {
+                "TextKey": "LARGE_CAPSULE",
+                "title": {
+                  "key": "LARGE_CAPSULE.title",
+                  "table": "relics"
+                },
+                "was_chosen": false
+              }
+            ],
+            "card_choices": [
+              {
+                "card": {
+                  "floor_added_to_deck": 1,
+                  "id": "CARD.IRON_WAVE"
+                },
+                "was_picked": true
+              },
+              {
+                "card": {
+                  "id": "CARD.HAVOC"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "id": "CARD.SETUP_STRIKE"
+                },
+                "was_picked": false
+              }
+            ],
+            "cards_gained": [
+              {
+                "id": "CARD.IRON_WAVE"
+              }
+            ],
+            "current_gold": 99,
+            "current_hp": 64,
+            "damage_taken": 0,
+            "event_choices": [
+              {
+                "title": {
+                  "key": "LOST_COFFER.title",
+                  "table": "relics"
+                }
+              }
+            ],
+            "gold_gained": 0,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 64,
+            "max_hp": 80,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 76561198018482804,
+            "potion_choices": [
+              {
+                "choice": "POTION.POTION_OF_BINDING",
+                "was_picked": true
+              }
+            ],
+            "relic_choices": [
+              {
+                "choice": "RELIC.LOST_COFFER",
+                "was_picked": true
+              }
+            ]
+          },
+          {
+            "ancient_choice": [
+              {
+                "TextKey": "LEAD_PAPERWEIGHT",
+                "title": {
+                  "key": "LEAD_PAPERWEIGHT.title",
+                  "table": "relics"
+                },
+                "was_chosen": false
+              },
+              {
+                "TextKey": "PRECISE_SCISSORS",
+                "title": {
+                  "key": "PRECISE_SCISSORS.title",
+                  "table": "relics"
+                },
+                "was_chosen": true
+              },
+              {
+                "TextKey": "HEFTY_TABLET",
+                "title": {
+                  "key": "HEFTY_TABLET.title",
+                  "table": "relics"
+                },
+                "was_chosen": false
+              }
+            ],
+            "cards_removed": [
+              {
+                "floor_added_to_deck": 1,
+                "id": "CARD.DEFEND_SILENT"
+              }
+            ],
+            "current_gold": 99,
+            "current_hp": 56,
+            "damage_taken": 0,
+            "event_choices": [
+              {
+                "title": {
+                  "key": "PRECISE_SCISSORS.title",
+                  "table": "relics"
+                }
+              }
+            ],
+            "gold_gained": 0,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 56,
+            "max_hp": 70,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 76561198071826144,
+            "relic_choices": [
+              {
+                "choice": "RELIC.PRECISE_SCISSORS",
+                "was_picked": true
+              }
+            ]
+          }
+        ],
+        "rooms": [
+          {
+            "model_id": "EVENT.NEOW",
+            "room_type": "event",
+            "turns_taken": 0
+          }
+        ]
+      },
+      {
+        "map_point_type": "monster",
+        "player_stats": [
+          {
+            "card_choices": [
+              {
+                "card": {
+                  "floor_added_to_deck": 2,
+                  "id": "CARD.BODY_SLAM"
+                },
+                "was_picked": true
+              },
+              {
+                "card": {
+                  "id": "CARD.MOLTEN_FIST"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "id": "CARD.PERFECTED_STRIKE"
+                },
+                "was_picked": false
+              }
+            ],
+            "cards_gained": [
+              {
+                "id": "CARD.BODY_SLAM"
+              }
+            ],
+            "current_gold": 113,
+            "current_hp": 69,
+            "damage_taken": 1,
+            "gold_gained": 14,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 6,
+            "max_hp": 80,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 76561198018482804
+          },
+          {
+            "card_choices": [
+              {
+                "card": {
+                  "floor_added_to_deck": 2,
+                  "id": "CARD.MIRAGE"
+                },
+                "was_picked": true
+              },
+              {
+                "card": {
+                  "id": "CARD.OUTBREAK"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "id": "CARD.FLICK_FLACK"
+                },
+                "was_picked": false
+              }
+            ],
+            "cards_gained": [
+              {
+                "floor_added_to_deck": 2,
+                "id": "CARD.MIRAGE"
+              }
+            ],
+            "current_gold": 110,
+            "current_hp": 56,
+            "damage_taken": 0,
+            "gold_gained": 11,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 0,
+            "max_hp": 70,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 76561198071826144
+          }
+        ],
+        "rooms": [
+          {
+            "model_id": "ENCOUNTER.FUZZY_WURM_CRAWLER_WEAK",
+            "monster_ids": [
+              "MONSTER.FUZZY_WURM_CRAWLER"
+            ],
+            "room_type": "monster",
+            "turns_taken": 4
+          }
+        ]
+      },
+      {
+        "map_point_type": "monster",
+        "player_stats": [
+          {
+            "card_choices": [
+              {
+                "card": {
+                  "floor_added_to_deck": 3,
+                  "id": "CARD.BATTLE_TRANCE"
+                },
+                "was_picked": true
+              },
+              {
+                "card": {
+                  "id": "CARD.TRUE_GRIT"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "id": "CARD.TREMBLE"
+                },
+                "was_picked": false
+              }
+            ],
+            "cards_gained": [
+              {
+                "id": "CARD.BATTLE_TRANCE"
+              }
+            ],
+            "current_gold": 120,
+            "current_hp": 65,
+            "damage_taken": 10,
+            "gold_gained": 7,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 6,
+            "max_hp": 80,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 76561198018482804,
+            "potion_choices": [
+              {
+                "choice": "POTION.BLOCK_POTION",
+                "was_picked": true
+              }
+            ]
+          },
+          {
+            "card_choices": [
+              {
+                "card": {
+                  "floor_added_to_deck": 3,
+                  "id": "CARD.SLICE"
+                },
+                "was_picked": true
+              },
+              {
+                "card": {
+                  "id": "CARD.DEFLECT"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "id": "CARD.CLOAK_AND_DAGGER"
+                },
+                "was_picked": false
+              }
+            ],
+            "cards_gained": [
+              {
+                "floor_added_to_deck": 3,
+                "id": "CARD.SLICE"
+              }
+            ],
+            "current_gold": 120,
+            "current_hp": 52,
+            "damage_taken": 4,
+            "gold_gained": 10,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 0,
+            "max_hp": 70,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 76561198071826144,
+            "potion_choices": [
+              {
+                "choice": "POTION.STRENGTH_POTION",
+                "was_picked": true
+              }
+            ]
+          }
+        ],
+        "rooms": [
+          {
+            "model_id": "ENCOUNTER.NIBBITS_WEAK",
+            "monster_ids": [
+              "MONSTER.NIBBIT"
+            ],
+            "room_type": "monster",
+            "turns_taken": 5
+          }
+        ]
+      },
+      {
+        "map_point_type": "monster",
+        "player_stats": [
+          {
+            "card_choices": [
+              {
+                "card": {
+                  "floor_added_to_deck": 4,
+                  "id": "CARD.POMMEL_STRIKE"
+                },
+                "was_picked": true
+              },
+              {
+                "card": {
+                  "id": "CARD.HOWL_FROM_BEYOND"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "id": "CARD.TRUE_GRIT"
+                },
+                "was_picked": false
+              }
+            ],
+            "cards_gained": [
+              {
+                "id": "CARD.POMMEL_STRIKE"
+              }
+            ],
+            "current_gold": 129,
+            "current_hp": 71,
+            "damage_taken": 0,
+            "gold_gained": 9,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 6,
+            "max_hp": 80,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 76561198018482804
+          },
+          {
+            "card_choices": [
+              {
+                "card": {
+                  "floor_added_to_deck": 4,
+                  "id": "CARD.RICOCHET"
+                },
+                "was_picked": true
+              },
+              {
+                "card": {
+                  "id": "CARD.UNTOUCHABLE"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "id": "CARD.PINPOINT"
+                },
+                "was_picked": false
+              }
+            ],
+            "cards_gained": [
+              {
+                "floor_added_to_deck": 4,
+                "id": "CARD.RICOCHET"
+              }
+            ],
+            "current_gold": 128,
+            "current_hp": 52,
+            "damage_taken": 0,
+            "gold_gained": 8,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 0,
+            "max_hp": 70,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 76561198071826144
+          }
+        ],
+        "rooms": [
+          {
+            "model_id": "ENCOUNTER.SLIMES_WEAK",
+            "monster_ids": [
+              "MONSTER.TWIG_SLIME_S",
+              "MONSTER.LEAF_SLIME_M",
+              "MONSTER.LEAF_SLIME_S"
+            ],
+            "room_type": "monster",
+            "turns_taken": 5
+          }
+        ]
+      },
+      {
+        "map_point_type": "monster",
+        "player_stats": [
+          {
+            "card_choices": [
+              {
+                "card": {
+                  "floor_added_to_deck": 5,
+                  "id": "CARD.BURNING_PACT"
+                },
+                "was_picked": true
+              },
+              {
+                "card": {
+                  "id": "CARD.BLUDGEON"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "id": "CARD.TREMBLE"
+                },
+                "was_picked": false
+              }
+            ],
+            "cards_gained": [
+              {
+                "id": "CARD.BURNING_PACT"
+              }
+            ],
+            "current_gold": 144,
+            "current_hp": 72,
+            "damage_taken": 5,
+            "gold_gained": 15,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 6,
+            "max_hp": 80,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 76561198018482804,
+            "potion_used": [
+              "POTION.BLOCK_POTION"
+            ]
+          },
+          {
+            "card_choices": [
+              {
+                "card": {
+                  "floor_added_to_deck": 5,
+                  "id": "CARD.NOXIOUS_FUMES"
+                },
+                "was_picked": true
+              },
+              {
+                "card": {
+                  "id": "CARD.PHANTOM_BLADES"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "id": "CARD.BUBBLE_BUBBLE"
+                },
+                "was_picked": false
+              }
+            ],
+            "cards_gained": [
+              {
+                "floor_added_to_deck": 5,
+                "id": "CARD.NOXIOUS_FUMES"
+              }
+            ],
+            "current_gold": 143,
+            "current_hp": 36,
+            "damage_taken": 16,
+            "gold_gained": 15,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 0,
+            "max_hp": 70,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 76561198071826144,
+            "potion_choices": [
+              {
+                "choice": "POTION.DEXTERITY_POTION",
+                "was_picked": true
+              }
+            ]
+          }
+        ],
+        "rooms": [
+          {
+            "model_id": "ENCOUNTER.FOGMOG_NORMAL",
+            "monster_ids": [
+              "MONSTER.FOGMOG"
+            ],
+            "room_type": "monster",
+            "turns_taken": 6
+          }
+        ]
+      },
+      {
+        "map_point_type": "monster",
+        "player_stats": [
+          {
+            "card_choices": [
+              {
+                "card": {
+                  "id": "CARD.SWORD_BOOMERANG"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "id": "CARD.FIGHT_ME"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "id": "CARD.PERFECTED_STRIKE"
+                },
+                "was_picked": false
+              }
+            ],
+            "current_gold": 154,
+            "current_hp": 73,
+            "damage_taken": 5,
+            "gold_gained": 10,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 6,
+            "max_hp": 80,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 76561198018482804,
+            "potion_choices": [
+              {
+                "choice": "POTION.FYSH_OIL",
+                "was_picked": true
+              }
+            ],
+            "potion_used": [
+              "POTION.POTION_OF_BINDING"
+            ]
+          },
+          {
+            "card_choices": [
+              {
+                "card": {
+                  "floor_added_to_deck": 6,
+                  "id": "CARD.HAZE"
+                },
+                "was_picked": true
+              },
+              {
+                "card": {
+                  "id": "CARD.RICOCHET"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "id": "CARD.CLOAK_AND_DAGGER"
+                },
+                "was_picked": false
+              }
+            ],
+            "cards_gained": [
+              {
+                "floor_added_to_deck": 6,
+                "id": "CARD.HAZE"
+              }
+            ],
+            "current_gold": 157,
+            "current_hp": 22,
+            "damage_taken": 14,
+            "gold_gained": 14,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 0,
+            "max_hp": 70,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 76561198071826144,
+            "potion_used": [
+              "POTION.DEXTERITY_POTION"
+            ]
+          }
+        ],
+        "rooms": [
+          {
+            "model_id": "ENCOUNTER.SLIMES_NORMAL",
+            "monster_ids": [
+              "MONSTER.TWIG_SLIME_M",
+              "MONSTER.LEAF_SLIME_M",
+              "MONSTER.TWIG_SLIME_S",
+              "MONSTER.LEAF_SLIME_S"
+            ],
+            "room_type": "monster",
+            "turns_taken": 6
+          }
+        ]
+      },
+      {
+        "map_point_type": "rest_site",
+        "player_stats": [
+          {
+            "current_gold": 154,
+            "current_hp": 73,
+            "damage_taken": 0,
+            "gold_gained": 0,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 0,
+            "max_hp": 80,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 76561198018482804,
+            "rest_site_choices": [
+              "MEND"
+            ]
+          },
+          {
+            "current_gold": 157,
+            "current_hp": 64,
+            "damage_taken": 0,
+            "gold_gained": 0,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 42,
+            "max_hp": 70,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 76561198071826144,
+            "rest_site_choices": [
+              "HEAL"
+            ]
+          }
+        ],
+        "rooms": [
+          {
+            "room_type": "rest_site",
+            "turns_taken": 0
+          }
+        ]
+      },
+      {
+        "map_point_type": "elite",
+        "player_stats": [
+          {
+            "card_choices": [
+              {
+                "card": {
+                  "floor_added_to_deck": 8,
+                  "id": "CARD.STOMP"
+                },
+                "was_picked": true
+              },
+              {
+                "card": {
+                  "id": "CARD.POMMEL_STRIKE"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "id": "CARD.HELLRAISER"
+                },
+                "was_picked": false
+              }
+            ],
+            "cards_gained": [
+              {
+                "id": "CARD.STOMP"
+              }
+            ],
+            "current_gold": 182,
+            "current_hp": 45,
+            "damage_taken": 34,
+            "gold_gained": 28,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 6,
+            "max_hp": 80,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 76561198018482804,
+            "potion_choices": [
+              {
+                "choice": "POTION.BLOOD_POTION",
+                "was_picked": true
+              }
+            ],
+            "potion_used": [
+              "POTION.FYSH_OIL"
+            ],
+            "relic_choices": [
+              {
+                "choice": "RELIC.MERCURY_HOURGLASS",
+                "was_picked": true
+              }
+            ]
+          },
+          {
+            "card_choices": [
+              {
+                "card": {
+                  "floor_added_to_deck": 8,
+                  "id": "CARD.PREPARED"
+                },
+                "was_picked": true
+              },
+              {
+                "card": {
+                  "id": "CARD.PIERCING_WAIL"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "id": "CARD.UP_MY_SLEEVE"
+                },
+                "was_picked": false
+              }
+            ],
+            "cards_gained": [
+              {
+                "floor_added_to_deck": 8,
+                "id": "CARD.PREPARED"
+              }
+            ],
+            "current_gold": 186,
+            "current_hp": 45,
+            "damage_taken": 19,
+            "gold_gained": 29,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 0,
+            "max_hp": 70,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 76561198071826144,
+            "potion_choices": [
+              {
+                "choice": "POTION.SPEED_POTION",
+                "was_picked": true
+              }
+            ],
+            "potion_used": [
+              "POTION.STRENGTH_POTION"
+            ],
+            "relic_choices": [
+              {
+                "choice": "RELIC.VEXING_PUZZLEBOX",
+                "was_picked": true
+              }
+            ]
+          }
+        ],
+        "rooms": [
+          {
+            "model_id": "ENCOUNTER.BYGONE_EFFIGY_ELITE",
+            "monster_ids": [
+              "MONSTER.BYGONE_EFFIGY"
+            ],
+            "room_type": "elite",
+            "turns_taken": 5
+          }
+        ]
+      },
+      {
+        "map_point_type": "treasure",
+        "player_stats": [
+          {
+            "current_gold": 220,
+            "current_hp": 45,
+            "damage_taken": 0,
+            "gold_gained": 38,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 0,
+            "max_hp": 80,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 76561198018482804,
+            "relic_choices": [
+              {
+                "choice": "RELIC.POCKETWATCH",
+                "was_picked": true
+              }
+            ]
+          },
+          {
+            "current_gold": 218,
+            "current_hp": 45,
+            "damage_taken": 0,
+            "gold_gained": 32,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 0,
+            "max_hp": 70,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 76561198071826144,
+            "relic_choices": [
+              {
+                "choice": "RELIC.GAMBLING_CHIP",
+                "was_picked": true
+              }
+            ]
+          }
+        ],
+        "rooms": [
+          {
+            "room_type": "treasure",
+            "turns_taken": 0
+          }
+        ]
+      },
+      {
+        "map_point_type": "rest_site",
+        "player_stats": [
+          {
+            "current_gold": 220,
+            "current_hp": 61,
+            "damage_taken": 0,
+            "gold_gained": 0,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 16,
+            "max_hp": 80,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 76561198018482804,
+            "potion_used": [
+              "POTION.BLOOD_POTION"
+            ],
+            "rest_site_choices": [
+              "SMITH"
+            ],
+            "upgraded_cards": [
+              "CARD.POMMEL_STRIKE"
+            ]
+          },
+          {
+            "current_gold": 218,
+            "current_hp": 66,
+            "damage_taken": 0,
+            "gold_gained": 0,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 21,
+            "max_hp": 70,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 76561198071826144,
+            "rest_site_choices": [
+              "HEAL"
+            ]
+          }
+        ],
+        "rooms": [
+          {
+            "room_type": "rest_site",
+            "turns_taken": 0
+          }
+        ]
+      },
+      {
+        "map_point_type": "elite",
+        "player_stats": [
+          {
+            "card_choices": [
+              {
+                "card": {
+                  "floor_added_to_deck": 11,
+                  "id": "CARD.HEMOKINESIS"
+                },
+                "was_picked": true
+              },
+              {
+                "card": {
+                  "id": "CARD.BURNING_PACT"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "id": "CARD.EXPECT_A_FIGHT"
+                },
+                "was_picked": false
+              }
+            ],
+            "cards_gained": [
+              {
+                "id": "CARD.HEMOKINESIS"
+              }
+            ],
+            "current_gold": 247,
+            "current_hp": 26,
+            "damage_taken": 41,
+            "gold_gained": 27,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 6,
+            "max_hp": 80,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 76561198018482804,
+            "relic_choices": [
+              {
+                "choice": "RELIC.BRONZE_SCALES",
+                "was_picked": true
+              }
+            ]
+          },
+          {
+            "card_choices": [
+              {
+                "card": {
+                  "floor_added_to_deck": 11,
+                  "id": "CARD.BACKFLIP"
+                },
+                "was_picked": true
+              },
+              {
+                "card": {
+                  "id": "CARD.FINISHER"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "id": "CARD.ACCURACY"
+                },
+                "was_picked": false
+              }
+            ],
+            "cards_gained": [
+              {
+                "floor_added_to_deck": 11,
+                "id": "CARD.BACKFLIP"
+              }
+            ],
+            "current_gold": 247,
+            "current_hp": 55,
+            "damage_taken": 11,
+            "gold_gained": 29,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 0,
+            "max_hp": 70,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 76561198071826144,
+            "potion_choices": [
+              {
+                "choice": "POTION.CLARITY",
+                "was_picked": true
+              }
+            ],
+            "relic_choices": [
+              {
+                "choice": "RELIC.CAPTAINS_WHEEL",
+                "was_picked": true
+              }
+            ]
+          }
+        ],
+        "rooms": [
+          {
+            "model_id": "ENCOUNTER.BYRDONIS_ELITE",
+            "monster_ids": [
+              "MONSTER.BYRDONIS"
+            ],
+            "room_type": "elite",
+            "turns_taken": 5
+          }
+        ]
+      },
+      {
+        "map_point_type": "rest_site",
+        "player_stats": [
+          {
+            "current_gold": 247,
+            "current_hp": 50,
+            "damage_taken": 0,
+            "gold_gained": 0,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 24,
+            "max_hp": 80,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 76561198018482804,
+            "rest_site_choices": [
+              "HEAL"
+            ]
+          },
+          {
+            "current_gold": 247,
+            "current_hp": 70,
+            "damage_taken": 0,
+            "gold_gained": 0,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 15,
+            "max_hp": 70,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 76561198071826144,
+            "rest_site_choices": [
+              "HEAL"
+            ]
+          }
+        ],
+        "rooms": [
+          {
+            "room_type": "rest_site",
+            "turns_taken": 0
+          }
+        ]
+      },
+      {
+        "map_point_type": "elite",
+        "player_stats": [
+          {
+            "card_choices": [
+              {
+                "card": {
+                  "floor_added_to_deck": 13,
+                  "id": "CARD.PYRE"
+                },
+                "was_picked": true
+              },
+              {
+                "card": {
+                  "id": "CARD.HAVOC"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "id": "CARD.BODY_SLAM"
+                },
+                "was_picked": false
+              }
+            ],
+            "cards_gained": [
+              {
+                "id": "CARD.PYRE"
+              }
+            ],
+            "current_gold": 278,
+            "current_hp": 40,
+            "damage_taken": 16,
+            "gold_gained": 31,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 6,
+            "max_hp": 80,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 76561198018482804,
+            "potion_choices": [
+              {
+                "choice": "POTION.HEART_OF_IRON",
+                "was_picked": true
+              }
+            ],
+            "relic_choices": [
+              {
+                "choice": "RELIC.VAMBRACE",
+                "was_picked": true
+              }
+            ]
+          },
+          {
+            "card_choices": [
+              {
+                "card": {
+                  "floor_added_to_deck": 13,
+                  "id": "CARD.OUTBREAK"
+                },
+                "was_picked": true
+              },
+              {
+                "card": {
+                  "id": "CARD.POISONED_STAB"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "id": "CARD.THE_HUNT"
+                },
+                "was_picked": false
+              }
+            ],
+            "cards_gained": [
+              {
+                "floor_added_to_deck": 13,
+                "id": "CARD.OUTBREAK"
+              }
+            ],
+            "current_gold": 274,
+            "current_hp": 64,
+            "damage_taken": 6,
+            "gold_gained": 27,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 0,
+            "max_hp": 70,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 76561198071826144,
+            "potion_choices": [
+              {
+                "choice": "POTION.STRENGTH_POTION",
+                "was_picked": false
+              }
+            ],
+            "relic_choices": [
+              {
+                "choice": "RELIC.GORGET",
+                "was_picked": true
+              }
+            ]
+          }
+        ],
+        "rooms": [
+          {
+            "model_id": "ENCOUNTER.PHROG_PARASITE_ELITE",
+            "monster_ids": [
+              "MONSTER.PHROG_PARASITE"
+            ],
+            "room_type": "elite",
+            "turns_taken": 5
+          }
+        ]
+      },
+      {
+        "map_point_type": "shop",
+        "player_stats": [
+          {
+            "bought_potions": [
+              "POTION.BLOOD_POTION"
+            ],
+            "card_choices": [
+              {
+                "card": {
+                  "id": "CARD.DISMANTLE"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "id": "CARD.IRON_WAVE"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "id": "CARD.BLOOD_WALL"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "id": "CARD.FEEL_NO_PAIN"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "id": "CARD.FISTICUFFS"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "id": "CARD.SCRAWL"
+                },
+                "was_picked": false
+              }
+            ],
+            "cards_gained": [
+              {
+                "id": "CARD.BRAND"
+              }
+            ],
+            "cards_removed": [
+              {
+                "floor_added_to_deck": 1,
+                "id": "CARD.STRIKE_IRONCLAD"
+              }
+            ],
+            "current_gold": 5,
+            "current_hp": 40,
+            "damage_taken": 0,
+            "gold_gained": 0,
+            "gold_lost": 0,
+            "gold_spent": 273,
+            "gold_stolen": 0,
+            "hp_healed": 0,
+            "max_hp": 80,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 76561198018482804,
+            "potion_choices": [
+              {
+                "choice": "POTION.BLOOD_POTION",
+                "was_picked": true
+              },
+              {
+                "choice": "POTION.SWIFT_POTION",
+                "was_picked": false
+              },
+              {
+                "choice": "POTION.CURE_ALL",
+                "was_picked": false
+              }
+            ],
+            "relic_choices": [
+              {
+                "choice": "RELIC.RED_MASK",
+                "was_picked": false
+              },
+              {
+                "choice": "RELIC.PAPER_PHROG",
+                "was_picked": false
+              },
+              {
+                "choice": "RELIC.WING_CHARM",
+                "was_picked": false
+              }
+            ]
+          },
+          {
+            "card_choices": [
+              {
+                "card": {
+                  "floor_added_to_deck": 14,
+                  "id": "CARD.ANTICIPATE"
+                },
+                "was_picked": true
+              }
+            ],
+            "cards_gained": [
+              {
+                "floor_added_to_deck": 14,
+                "id": "CARD.ANTICIPATE"
+              }
+            ],
+            "cards_removed": [
+              {
+                "floor_added_to_deck": 1,
+                "id": "CARD.STRIKE_SILENT"
+              }
+            ],
+            "current_gold": 149,
+            "current_hp": 64,
+            "damage_taken": 0,
+            "gold_gained": 0,
+            "gold_lost": 50,
+            "gold_spent": 75,
+            "gold_stolen": 0,
+            "hp_healed": 0,
+            "max_hp": 70,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 76561198071826144
+          }
+        ],
+        "rooms": [
+          {
+            "room_type": "shop",
+            "turns_taken": 0
+          }
+        ]
+      },
+      {
+        "map_point_type": "rest_site",
+        "player_stats": [
+          {
+            "current_gold": 5,
+            "current_hp": 64,
+            "damage_taken": 0,
+            "gold_gained": 0,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 24,
+            "max_hp": 80,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 76561198018482804,
+            "rest_site_choices": [
+              "HEAL"
+            ]
+          },
+          {
+            "current_gold": 149,
+            "current_hp": 64,
+            "damage_taken": 0,
+            "gold_gained": 0,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 0,
+            "max_hp": 70,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 76561198071826144,
+            "rest_site_choices": [
+              "SMITH"
+            ],
+            "upgraded_cards": [
+              "CARD.NOXIOUS_FUMES"
+            ]
+          }
+        ],
+        "rooms": [
+          {
+            "room_type": "rest_site",
+            "turns_taken": 0
+          }
+        ]
+      },
+      {
+        "map_point_type": "boss",
+        "player_stats": [
+          {
+            "card_choices": [
+              {
+                "card": {
+                  "floor_added_to_deck": 16,
+                  "id": "CARD.IMPERVIOUS"
+                },
+                "was_picked": true
+              },
+              {
+                "card": {
+                  "id": "CARD.CONFLAGRATION"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "id": "CARD.HELLRAISER"
+                },
+                "was_picked": false
+              }
+            ],
+            "cards_gained": [
+              {
+                "id": "CARD.IMPERVIOUS"
+              }
+            ],
+            "current_gold": 80,
+            "current_hp": 53,
+            "damage_taken": 17,
+            "gold_gained": 75,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 6,
+            "max_hp": 80,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 76561198018482804,
+            "potion_choices": [
+              {
+                "choice": "POTION.SPEED_POTION",
+                "was_picked": true
+              }
+            ],
+            "potion_used": [
+              "POTION.HEART_OF_IRON"
+            ]
+          },
+          {
+            "card_choices": [
+              {
+                "card": {
+                  "floor_added_to_deck": 16,
+                  "id": "CARD.MASTER_PLANNER"
+                },
+                "was_picked": true
+              },
+              {
+                "card": {
+                  "id": "CARD.FAN_OF_KNIVES"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "id": "CARD.ASSASSINATE"
+                },
+                "was_picked": false
+              }
+            ],
+            "cards_gained": [
+              {
+                "floor_added_to_deck": 16,
+                "id": "CARD.MASTER_PLANNER"
+              }
+            ],
+            "current_gold": 224,
+            "current_hp": 63,
+            "damage_taken": 1,
+            "gold_gained": 75,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 0,
+            "max_hp": 70,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 76561198071826144
+          }
+        ],
+        "rooms": [
+          {
+            "model_id": "ENCOUNTER.THE_KIN_BOSS",
+            "monster_ids": [
+              "MONSTER.KIN_FOLLOWER",
+              "MONSTER.KIN_FOLLOWER",
+              "MONSTER.KIN_PRIEST"
+            ],
+            "room_type": "boss",
+            "turns_taken": 8
+          }
+        ]
+      }
+    ],
+    [
+      {
+        "map_point_type": "ancient",
+        "player_stats": [
+          {
+            "ancient_choice": [
+              {
+                "TextKey": "PAELS_HORN",
+                "title": {
+                  "key": "PAELS_HORN.title",
+                  "table": "relics"
+                },
+                "was_chosen": false
+              },
+              {
+                "TextKey": "PAELS_TOOTH",
+                "title": {
+                  "key": "PAELS_TOOTH.title",
+                  "table": "relics"
+                },
+                "was_chosen": true
+              },
+              {
+                "TextKey": "PAELS_BLOOD",
+                "title": {
+                  "key": "PAELS_BLOOD.title",
+                  "table": "relics"
+                },
+                "was_chosen": false
+              }
+            ],
+            "cards_removed": [
+              {
+                "floor_added_to_deck": 1,
+                "id": "CARD.DEFEND_IRONCLAD"
+              },
+              {
+                "floor_added_to_deck": 1,
+                "id": "CARD.DEFEND_IRONCLAD"
+              },
+              {
+                "floor_added_to_deck": 1,
+                "id": "CARD.IRON_WAVE"
+              },
+              {
+                "floor_added_to_deck": 1,
+                "id": "CARD.STRIKE_IRONCLAD"
+              },
+              {
+                "floor_added_to_deck": 1,
+                "id": "CARD.STRIKE_IRONCLAD"
+              }
+            ],
+            "current_gold": 80,
+            "current_hp": 74,
+            "damage_taken": 0,
+            "event_choices": [
+              {
+                "title": {
+                  "key": "PAELS_TOOTH.title",
+                  "table": "relics"
+                }
+              }
+            ],
+            "gold_gained": 0,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 21,
+            "max_hp": 80,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 76561198018482804,
+            "relic_choices": [
+              {
+                "choice": "RELIC.PAELS_TOOTH",
+                "was_picked": true
+              }
+            ]
+          },
+          {
+            "ancient_choice": [
+              {
+                "TextKey": "PAELS_HORN",
+                "title": {
+                  "key": "PAELS_HORN.title",
+                  "table": "relics"
+                },
+                "was_chosen": false
+              },
+              {
+                "TextKey": "PAELS_TOOTH",
+                "title": {
+                  "key": "PAELS_TOOTH.title",
+                  "table": "relics"
+                },
+                "was_chosen": false
+              },
+              {
+                "TextKey": "PAELS_BLOOD",
+                "title": {
+                  "key": "PAELS_BLOOD.title",
+                  "table": "relics"
+                },
+                "was_chosen": true
+              }
+            ],
+            "current_gold": 224,
+            "current_hp": 68,
+            "damage_taken": 0,
+            "event_choices": [
+              {
+                "title": {
+                  "key": "PAELS_BLOOD.title",
+                  "table": "relics"
+                }
+              }
+            ],
+            "gold_gained": 0,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 5,
+            "max_hp": 70,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 76561198071826144,
+            "relic_choices": [
+              {
+                "choice": "RELIC.PAELS_BLOOD",
+                "was_picked": true
+              }
+            ]
+          }
+        ],
+        "rooms": [
+          {
+            "model_id": "EVENT.PAEL",
+            "room_type": "event",
+            "turns_taken": 0
+          }
+        ]
+      },
+      {
+        "map_point_type": "monster",
+        "player_stats": [
+          {
+            "card_choices": [
+              {
+                "card": {
+                  "floor_added_to_deck": 18,
+                  "id": "CARD.BLOODLETTING"
+                },
+                "was_picked": true
+              },
+              {
+                "card": {
+                  "id": "CARD.JUGGLING"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "id": "CARD.DEMONIC_SHIELD"
+                },
+                "was_picked": false
+              }
+            ],
+            "cards_gained": [
+              {
+                "current_upgrade_level": 1,
+                "floor_added_to_deck": 1,
+                "id": "CARD.STRIKE_IRONCLAD"
+              },
+              {
+                "floor_added_to_deck": 8,
+                "id": "CARD.STOMP"
+              },
+              {
+                "id": "CARD.BLOODLETTING"
+              }
+            ],
+            "cards_removed": [
+              {
+                "floor_added_to_deck": 8,
+                "id": "CARD.STOMP"
+              }
+            ],
+            "current_gold": 90,
+            "current_hp": 75,
+            "damage_taken": 5,
+            "gold_gained": 10,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 6,
+            "max_hp": 80,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 76561198018482804,
+            "potion_used": [
+              "POTION.SPEED_POTION"
+            ]
+          },
+          {
+            "card_choices": [
+              {
+                "card": {
+                  "current_upgrade_level": 1,
+                  "floor_added_to_deck": 18,
+                  "id": "CARD.NOXIOUS_FUMES"
+                },
+                "was_picked": true
+              },
+              {
+                "card": {
+                  "floor_added_to_deck": 18,
+                  "id": "CARD.UNTOUCHABLE"
+                },
+                "was_picked": true
+              },
+              {
+                "card": {
+                  "id": "CARD.BACKFLIP"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "id": "CARD.LEADING_STRIKE"
+                },
+                "was_picked": false
+              }
+            ],
+            "cards_gained": [
+              {
+                "current_upgrade_level": 1,
+                "floor_added_to_deck": 18,
+                "id": "CARD.NOXIOUS_FUMES"
+              },
+              {
+                "floor_added_to_deck": 18,
+                "id": "CARD.UNTOUCHABLE"
+              }
+            ],
+            "cards_removed": [
+              {
+                "current_upgrade_level": 1,
+                "floor_added_to_deck": 5,
+                "id": "CARD.NOXIOUS_FUMES"
+              }
+            ],
+            "current_gold": 233,
+            "current_hp": 68,
+            "damage_taken": 0,
+            "gold_gained": 9,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 0,
+            "max_hp": 70,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 76561198071826144,
+            "potion_choices": [
+              {
+                "choice": "POTION.SWIFT_POTION",
+                "was_picked": true
+              }
+            ],
+            "potion_used": [
+              "POTION.CLARITY"
+            ]
+          }
+        ],
+        "rooms": [
+          {
+            "model_id": "ENCOUNTER.THIEVING_HOPPER_WEAK",
+            "monster_ids": [
+              "MONSTER.THIEVING_HOPPER"
+            ],
+            "room_type": "monster",
+            "turns_taken": 4
+          }
+        ]
+      },
+      {
+        "map_point_type": "unknown",
+        "player_stats": [
+          {
+            "current_gold": 90,
+            "current_hp": 70,
+            "damage_taken": 5,
+            "event_choices": [
+              {
+                "title": {
+                  "key": "DOLL_ROOM.pages.INITIAL.options.TAKE_SOME_TIME.title",
+                  "table": "events"
+                }
+              },
+              {
+                "title": {
+                  "key": "MR_STRUGGLES.title",
+                  "table": "relics"
+                }
+              }
+            ],
+            "gold_gained": 0,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 0,
+            "max_hp": 80,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 76561198018482804,
+            "relic_choices": [
+              {
+                "choice": "RELIC.MR_STRUGGLES",
+                "was_picked": true
+              }
+            ]
+          },
+          {
+            "current_gold": 233,
+            "current_hp": 53,
+            "damage_taken": 15,
+            "event_choices": [
+              {
+                "title": {
+                  "key": "DOLL_ROOM.pages.INITIAL.options.EXAMINE.title",
+                  "table": "events"
+                }
+              },
+              {
+                "title": {
+                  "key": "DAUGHTER_OF_THE_WIND.title",
+                  "table": "relics"
+                }
+              }
+            ],
+            "gold_gained": 0,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 0,
+            "max_hp": 70,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 76561198071826144,
+            "relic_choices": [
+              {
+                "choice": "RELIC.DAUGHTER_OF_THE_WIND",
+                "was_picked": true
+              }
+            ]
+          }
+        ],
+        "rooms": [
+          {
+            "model_id": "EVENT.DOLL_ROOM",
+            "room_type": "event",
+            "turns_taken": 0
+          }
+        ]
+      },
+      {
+        "map_point_type": "monster",
+        "player_stats": [
+          {
+            "card_choices": [
+              {
+                "card": {
+                  "floor_added_to_deck": 20,
+                  "id": "CARD.TRUE_GRIT"
+                },
+                "was_picked": true
+              },
+              {
+                "card": {
+                  "current_upgrade_level": 1,
+                  "id": "CARD.HEADBUTT"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "id": "CARD.BREAKTHROUGH"
+                },
+                "was_picked": false
+              }
+            ],
+            "cards_gained": [
+              {
+                "current_upgrade_level": 1,
+                "floor_added_to_deck": 1,
+                "id": "CARD.IRON_WAVE"
+              },
+              {
+                "id": "CARD.TRUE_GRIT"
+              }
+            ],
+            "current_gold": 101,
+            "current_hp": 59,
+            "damage_taken": 17,
+            "gold_gained": 11,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 6,
+            "max_hp": 80,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 76561198018482804,
+            "potion_choices": [
+              {
+                "choice": "POTION.BLESSING_OF_THE_FORGE",
+                "was_picked": true
+              }
+            ]
+          },
+          {
+            "card_choices": [
+              {
+                "card": {
+                  "floor_added_to_deck": 20,
+                  "id": "CARD.ANTICIPATE"
+                },
+                "was_picked": true
+              },
+              {
+                "card": {
+                  "current_upgrade_level": 1,
+                  "id": "CARD.ACCURACY"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "id": "CARD.PRECISE_CUT"
+                },
+                "was_picked": false
+              }
+            ],
+            "cards_gained": [
+              {
+                "floor_added_to_deck": 20,
+                "id": "CARD.ANTICIPATE"
+              }
+            ],
+            "current_gold": 240,
+            "current_hp": 53,
+            "damage_taken": 0,
+            "gold_gained": 7,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 0,
+            "max_hp": 70,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 76561198071826144,
+            "potion_choices": [
+              {
+                "choice": "POTION.DROPLET_OF_PRECOGNITION",
+                "was_picked": true
+              }
+            ],
+            "potion_discarded": [
+              "POTION.SWIFT_POTION"
+            ]
+          }
+        ],
+        "rooms": [
+          {
+            "model_id": "ENCOUNTER.BOWLBUGS_WEAK",
+            "monster_ids": [
+              "MONSTER.BOWLBUG_ROCK",
+              "MONSTER.BOWLBUG_EGG"
+            ],
+            "room_type": "monster",
+            "turns_taken": 3
+          }
+        ]
+      },
+      {
+        "map_point_type": "monster",
+        "player_stats": [
+          {
+            "card_choices": [
+              {
+                "card": {
+                  "current_upgrade_level": 1,
+                  "floor_added_to_deck": 21,
+                  "id": "CARD.TAUNT"
+                },
+                "was_picked": true
+              },
+              {
+                "card": {
+                  "id": "CARD.HAVOC"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "id": "CARD.ANGER"
+                },
+                "was_picked": false
+              }
+            ],
+            "cards_gained": [
+              {
+                "current_upgrade_level": 1,
+                "floor_added_to_deck": 1,
+                "id": "CARD.DEFEND_IRONCLAD"
+              },
+              {
+                "current_upgrade_level": 1,
+                "id": "CARD.TAUNT"
+              }
+            ],
+            "current_gold": 113,
+            "current_hp": 44,
+            "damage_taken": 21,
+            "gold_gained": 12,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 6,
+            "max_hp": 80,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 76561198018482804
+          },
+          {
+            "card_choices": [
+              {
+                "card": {
+                  "floor_added_to_deck": 21,
+                  "id": "CARD.NOXIOUS_FUMES"
+                },
+                "was_picked": true
+              },
+              {
+                "card": {
+                  "id": "CARD.ANTICIPATE"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "id": "CARD.PIERCING_WAIL"
+                },
+                "was_picked": false
+              }
+            ],
+            "cards_gained": [
+              {
+                "floor_added_to_deck": 21,
+                "id": "CARD.NOXIOUS_FUMES"
+              }
+            ],
+            "current_gold": 248,
+            "current_hp": 52,
+            "damage_taken": 1,
+            "gold_gained": 8,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 0,
+            "max_hp": 70,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 76561198071826144
+          }
+        ],
+        "rooms": [
+          {
+            "model_id": "ENCOUNTER.LOUSE_PROGENITOR_NORMAL",
+            "monster_ids": [
+              "MONSTER.LOUSE_PROGENITOR"
+            ],
+            "room_type": "monster",
+            "turns_taken": 5
+          }
+        ]
+      },
+      {
+        "map_point_type": "monster",
+        "player_stats": [
+          {
+            "card_choices": [
+              {
+                "card": {
+                  "floor_added_to_deck": 22,
+                  "id": "CARD.RAGE"
+                },
+                "was_picked": true
+              },
+              {
+                "card": {
+                  "id": "CARD.JUGGLING"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "id": "CARD.WHIRLWIND"
+                },
+                "was_picked": false
+              }
+            ],
+            "cards_gained": [
+              {
+                "current_upgrade_level": 1,
+                "floor_added_to_deck": 1,
+                "id": "CARD.DEFEND_IRONCLAD"
+              },
+              {
+                "id": "CARD.RAGE"
+              }
+            ],
+            "current_gold": 122,
+            "current_hp": 33,
+            "damage_taken": 17,
+            "gold_gained": 9,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 6,
+            "max_hp": 80,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 76561198018482804,
+            "potion_used": [
+              "POTION.BLESSING_OF_THE_FORGE"
+            ]
+          },
+          {
+            "card_choices": [
+              {
+                "card": {
+                  "floor_added_to_deck": 22,
+                  "id": "CARD.PREPARED"
+                },
+                "was_picked": true
+              },
+              {
+                "card": {
+                  "id": "CARD.BACKFLIP"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "id": "CARD.STORM_OF_STEEL"
+                },
+                "was_picked": false
+              }
+            ],
+            "cards_gained": [
+              {
+                "floor_added_to_deck": 22,
+                "id": "CARD.PREPARED"
+              }
+            ],
+            "current_gold": 255,
+            "current_hp": 46,
+            "damage_taken": 6,
+            "gold_gained": 7,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 0,
+            "max_hp": 70,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 76561198071826144,
+            "potion_choices": [
+              {
+                "choice": "POTION.BLOCK_POTION",
+                "was_picked": true
+              }
+            ],
+            "potion_discarded": [
+              "POTION.DROPLET_OF_PRECOGNITION"
+            ]
+          }
+        ],
+        "rooms": [
+          {
+            "model_id": "ENCOUNTER.OVICOPTER_NORMAL",
+            "monster_ids": [
+              "MONSTER.OVICOPTER"
+            ],
+            "room_type": "monster",
+            "turns_taken": 4
+          }
+        ]
+      },
+      {
+        "map_point_type": "rest_site",
+        "player_stats": [
+          {
+            "current_gold": 122,
+            "current_hp": 57,
+            "damage_taken": 0,
+            "gold_gained": 0,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 24,
+            "max_hp": 80,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 76561198018482804,
+            "rest_site_choices": [
+              "HEAL"
+            ]
+          },
+          {
+            "current_gold": 255,
+            "current_hp": 67,
+            "damage_taken": 0,
+            "gold_gained": 0,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 21,
+            "max_hp": 70,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 76561198071826144,
+            "rest_site_choices": [
+              "HEAL"
+            ]
+          }
+        ],
+        "rooms": [
+          {
+            "room_type": "rest_site",
+            "turns_taken": 0
+          }
+        ]
+      },
+      {
+        "map_point_type": "treasure",
+        "player_stats": [
+          {
+            "current_gold": 153,
+            "current_hp": 57,
+            "damage_taken": 0,
+            "gold_gained": 31,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 0,
+            "max_hp": 80,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 76561198018482804,
+            "relic_choices": [
+              {
+                "choice": "RELIC.ANCHOR",
+                "was_picked": true
+              }
+            ]
+          },
+          {
+            "current_gold": 288,
+            "current_hp": 67,
+            "damage_taken": 0,
+            "gold_gained": 33,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 0,
+            "max_hp": 70,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 76561198071826144,
+            "relic_choices": [
+              {
+                "choice": "RELIC.PEN_NIB",
+                "was_picked": true
+              }
+            ]
+          }
+        ],
+        "rooms": [
+          {
+            "room_type": "treasure",
+            "turns_taken": 0
+          }
+        ]
+      },
+      {
+        "map_point_type": "elite",
+        "player_stats": [
+          {
+            "card_choices": [
+              {
+                "card": {
+                  "floor_added_to_deck": 25,
+                  "id": "CARD.FEEL_NO_PAIN"
+                },
+                "was_picked": true
+              },
+              {
+                "card": {
+                  "id": "CARD.THUNDERCLAP"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "id": "CARD.TAUNT"
+                },
+                "was_picked": false
+              }
+            ],
+            "cards_gained": [
+              {
+                "current_upgrade_level": 1,
+                "floor_added_to_deck": 1,
+                "id": "CARD.STRIKE_IRONCLAD"
+              },
+              {
+                "id": "CARD.FEEL_NO_PAIN"
+              }
+            ],
+            "current_gold": 180,
+            "current_hp": 26,
+            "damage_taken": 37,
+            "gold_gained": 27,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 6,
+            "max_hp": 80,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 76561198018482804,
+            "relic_choices": [
+              {
+                "choice": "RELIC.THE_COURIER",
+                "was_picked": true
+              }
+            ]
+          },
+          {
+            "card_choices": [
+              {
+                "card": {
+                  "floor_added_to_deck": 25,
+                  "id": "CARD.PIERCING_WAIL"
+                },
+                "was_picked": true
+              },
+              {
+                "card": {
+                  "current_upgrade_level": 1,
+                  "id": "CARD.SPEEDSTER"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "current_upgrade_level": 1,
+                  "id": "CARD.DASH"
+                },
+                "was_picked": false
+              }
+            ],
+            "cards_gained": [
+              {
+                "floor_added_to_deck": 25,
+                "id": "CARD.PIERCING_WAIL"
+              }
+            ],
+            "current_gold": 314,
+            "current_hp": 66,
+            "damage_taken": 1,
+            "gold_gained": 26,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 0,
+            "max_hp": 70,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 76561198071826144,
+            "potion_used": [
+              "POTION.BLOCK_POTION",
+              "POTION.SPEED_POTION"
+            ],
+            "relic_choices": [
+              {
+                "choice": "RELIC.JUZU_BRACELET",
+                "was_picked": true
+              }
+            ]
+          }
+        ],
+        "rooms": [
+          {
+            "model_id": "ENCOUNTER.DECIMILLIPEDE_ELITE",
+            "monster_ids": [
+              "MONSTER.DECIMILLIPEDE_SEGMENT_FRONT",
+              "MONSTER.DECIMILLIPEDE_SEGMENT_MIDDLE",
+              "MONSTER.DECIMILLIPEDE_SEGMENT_BACK"
+            ],
+            "room_type": "elite",
+            "turns_taken": 4
+          }
+        ]
+      },
+      {
+        "map_point_type": "unknown",
+        "player_stats": [
+          {
+            "cards_gained": [
+              {
+                "id": "CARD.SQUASH"
+              }
+            ],
+            "current_gold": 180,
+            "current_hp": 26,
+            "damage_taken": 0,
+            "event_choices": [
+              {
+                "title": {
+                  "key": "BUGSLAYER.pages.INITIAL.options.SQUASH.title",
+                  "table": "events"
+                },
+                "variables": {
+                  "Card1": {
+                    "type": "DynamicString",
+                    "decimal_value": 0,
+                    "bool_value": false,
+                    "string_value": "Exterminate"
+                  },
+                  "Card2": {
+                    "type": "DynamicString",
+                    "decimal_value": 0,
+                    "bool_value": false,
+                    "string_value": "Squash"
+                  }
+                }
+              }
+            ],
+            "gold_gained": 0,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 0,
+            "max_hp": 80,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 76561198018482804
+          },
+          {
+            "cards_gained": [
+              {
+                "id": "CARD.SQUASH"
+              }
+            ],
+            "current_gold": 314,
+            "current_hp": 66,
+            "damage_taken": 0,
+            "event_choices": [
+              {
+                "title": {
+                  "key": "BUGSLAYER.pages.INITIAL.options.SQUASH.title",
+                  "table": "events"
+                }
+              }
+            ],
+            "gold_gained": 0,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 0,
+            "max_hp": 70,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 76561198071826144
+          }
+        ],
+        "rooms": [
+          {
+            "model_id": "EVENT.BUGSLAYER",
+            "room_type": "event",
+            "turns_taken": 0
+          }
+        ]
+      },
+      {
+        "map_point_type": "rest_site",
+        "player_stats": [
+          {
+            "current_gold": 180,
+            "current_hp": 74,
+            "damage_taken": 0,
+            "gold_gained": 0,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 48,
+            "max_hp": 80,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 76561198018482804,
+            "rest_site_choices": [
+              "HEAL"
+            ]
+          },
+          {
+            "current_gold": 314,
+            "current_hp": 66,
+            "damage_taken": 0,
+            "gold_gained": 0,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 0,
+            "max_hp": 70,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 76561198071826144,
+            "rest_site_choices": [
+              "MEND"
+            ]
+          }
+        ],
+        "rooms": [
+          {
+            "room_type": "rest_site",
+            "turns_taken": 0
+          }
+        ]
+      },
+      {
+        "map_point_type": "unknown",
+        "player_stats": [
+          {
+            "cards_gained": [
+              {
+                "id": "CARD.SHRUG_IT_OFF"
+              },
+              {
+                "id": "CARD.BLOODLETTING"
+              }
+            ],
+            "current_gold": 180,
+            "current_hp": 74,
+            "damage_taken": 0,
+            "event_choices": [
+              {
+                "title": {
+                  "key": "ROOM_FULL_OF_CHEESE.pages.INITIAL.options.GORGE.title",
+                  "table": "events"
+                }
+              }
+            ],
+            "gold_gained": 0,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 0,
+            "max_hp": 80,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 76561198018482804
+          },
+          {
+            "current_gold": 314,
+            "current_hp": 52,
+            "damage_taken": 14,
+            "event_choices": [
+              {
+                "title": {
+                  "key": "ROOM_FULL_OF_CHEESE.pages.INITIAL.options.SEARCH.title",
+                  "table": "events"
+                }
+              }
+            ],
+            "gold_gained": 0,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 0,
+            "max_hp": 70,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 76561198071826144,
+            "relic_choices": [
+              {
+                "choice": "RELIC.CHOSEN_CHEESE",
+                "was_picked": true
+              }
+            ]
+          }
+        ],
+        "rooms": [
+          {
+            "model_id": "EVENT.ROOM_FULL_OF_CHEESE",
+            "room_type": "event",
+            "turns_taken": 0
+          }
+        ]
+      },
+      {
+        "map_point_type": "elite",
+        "player_stats": [
+          {
+            "card_choices": [
+              {
+                "card": {
+                  "current_upgrade_level": 1,
+                  "floor_added_to_deck": 29,
+                  "id": "CARD.RAGE"
+                },
+                "was_picked": true
+              },
+              {
+                "card": {
+                  "id": "CARD.WHIRLWIND"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "id": "CARD.CINDER"
+                },
+                "was_picked": false
+              }
+            ],
+            "cards_gained": [
+              {
+                "current_upgrade_level": 1,
+                "id": "CARD.RAGE"
+              }
+            ],
+            "current_gold": 210,
+            "current_hp": 63,
+            "damage_taken": 17,
+            "gold_gained": 30,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 6,
+            "max_hp": 80,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 76561198018482804,
+            "potion_choices": [
+              {
+                "choice": "POTION.ENERGY_POTION",
+                "was_picked": true
+              }
+            ],
+            "relic_choices": [
+              {
+                "choice": "RELIC.CLOAK_CLASP",
+                "was_picked": true
+              }
+            ]
+          },
+          {
+            "card_choices": [
+              {
+                "card": {
+                  "floor_added_to_deck": 29,
+                  "id": "CARD.FOOTWORK"
+                },
+                "was_picked": true
+              },
+              {
+                "card": {
+                  "current_upgrade_level": 1,
+                  "id": "CARD.BACKFLIP"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "id": "CARD.SUCKER_PUNCH"
+                },
+                "was_picked": false
+              }
+            ],
+            "cards_gained": [
+              {
+                "floor_added_to_deck": 29,
+                "id": "CARD.FOOTWORK"
+              }
+            ],
+            "current_gold": 346,
+            "current_hp": 43,
+            "damage_taken": 10,
+            "gold_gained": 32,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 1,
+            "max_hp": 71,
+            "max_hp_gained": 1,
+            "max_hp_lost": 0,
+            "player_id": 76561198071826144,
+            "potion_choices": [
+              {
+                "choice": "POTION.FORTIFIER",
+                "was_picked": true
+              }
+            ],
+            "relic_choices": [
+              {
+                "choice": "RELIC.STONE_CALENDAR",
+                "was_picked": true
+              }
+            ]
+          }
+        ],
+        "rooms": [
+          {
+            "model_id": "ENCOUNTER.ENTOMANCER_ELITE",
+            "monster_ids": [
+              "MONSTER.ENTOMANCER"
+            ],
+            "room_type": "elite",
+            "turns_taken": 7
+          }
+        ]
+      },
+      {
+        "map_point_type": "rest_site",
+        "player_stats": [
+          {
+            "current_gold": 210,
+            "current_hp": 63,
+            "damage_taken": 0,
+            "gold_gained": 0,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 0,
+            "max_hp": 80,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 76561198018482804,
+            "rest_site_choices": [
+              "SMITH"
+            ],
+            "upgraded_cards": [
+              "CARD.PYRE"
+            ]
+          },
+          {
+            "current_gold": 346,
+            "current_hp": 64,
+            "damage_taken": 0,
+            "gold_gained": 0,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 21,
+            "max_hp": 71,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 76561198071826144,
+            "rest_site_choices": [
+              "HEAL"
+            ]
+          }
+        ],
+        "rooms": [
+          {
+            "room_type": "rest_site",
+            "turns_taken": 0
+          }
+        ]
+      },
+      {
+        "map_point_type": "boss",
+        "player_stats": [
+          {
+            "card_choices": [
+              {
+                "card": {
+                  "floor_added_to_deck": 31,
+                  "id": "CARD.PACTS_END"
+                },
+                "was_picked": true
+              },
+              {
+                "card": {
+                  "id": "CARD.MANGLE"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "id": "CARD.ONE_TWO_PUNCH"
+                },
+                "was_picked": false
+              }
+            ],
+            "cards_gained": [
+              {
+                "id": "CARD.PACTS_END"
+              }
+            ],
+            "current_gold": 285,
+            "current_hp": 32,
+            "damage_taken": 37,
+            "gold_gained": 75,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 6,
+            "max_hp": 80,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 76561198018482804,
+            "potion_choices": [
+              {
+                "choice": "POTION.FORTIFIER",
+                "was_picked": true
+              }
+            ],
+            "potion_used": [
+              "POTION.ENERGY_POTION"
+            ]
+          },
+          {
+            "card_choices": [
+              {
+                "card": {
+                  "floor_added_to_deck": 31,
+                  "id": "CARD.ABRASIVE"
+                },
+                "was_picked": true
+              },
+              {
+                "card": {
+                  "id": "CARD.SHADOWMELD"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "id": "CARD.ECHOING_SLASH"
+                },
+                "was_picked": false
+              }
+            ],
+            "cards_gained": [
+              {
+                "floor_added_to_deck": 31,
+                "id": "CARD.ABRASIVE"
+              }
+            ],
+            "current_gold": 421,
+            "current_hp": 22,
+            "damage_taken": 43,
+            "gold_gained": 75,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 1,
+            "max_hp": 72,
+            "max_hp_gained": 1,
+            "max_hp_lost": 0,
+            "player_id": 76561198071826144
+          }
+        ],
+        "rooms": [
+          {
+            "model_id": "ENCOUNTER.THE_INSATIABLE_BOSS",
+            "monster_ids": [
+              "MONSTER.THE_INSATIABLE"
+            ],
+            "room_type": "boss",
+            "turns_taken": 10
+          }
+        ]
+      }
+    ],
+    [
+      {
+        "map_point_type": "ancient",
+        "player_stats": [
+          {
+            "ancient_choice": [
+              {
+                "TextKey": "FIDDLE",
+                "title": {
+                  "key": "FIDDLE.title",
+                  "table": "relics"
+                },
+                "was_chosen": false
+              },
+              {
+                "TextKey": "DISTINGUISHED_CAPE",
+                "title": {
+                  "key": "DISTINGUISHED_CAPE.title",
+                  "table": "relics"
+                },
+                "was_chosen": true
+              },
+              {
+                "TextKey": "LORDS_PARASOL",
+                "title": {
+                  "key": "LORDS_PARASOL.title",
+                  "table": "relics"
+                },
+                "was_chosen": false
+              }
+            ],
+            "cards_gained": [
+              {
+                "id": "CARD.APPARITION"
+              },
+              {
+                "id": "CARD.APPARITION"
+              },
+              {
+                "id": "CARD.APPARITION"
+              }
+            ],
+            "current_gold": 0,
+            "current_hp": 0,
+            "damage_taken": 0,
+            "gold_gained": 0,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 38,
+            "max_hp": 0,
+            "max_hp_gained": 0,
+            "max_hp_lost": 9,
+            "player_id": 76561198018482804,
+            "relic_choices": [
+              {
+                "choice": "RELIC.DISTINGUISHED_CAPE",
+                "was_picked": true
+              }
+            ]
+          },
+          {
+            "ancient_choice": [
+              {
+                "TextKey": "FIDDLE",
+                "title": {
+                  "key": "FIDDLE.title",
+                  "table": "relics"
+                },
+                "was_chosen": false
+              },
+              {
+                "TextKey": "DISTINGUISHED_CAPE",
+                "title": {
+                  "key": "DISTINGUISHED_CAPE.title",
+                  "table": "relics"
+                },
+                "was_chosen": true
+              },
+              {
+                "TextKey": "LORDS_PARASOL",
+                "title": {
+                  "key": "LORDS_PARASOL.title",
+                  "table": "relics"
+                },
+                "was_chosen": false
+              }
+            ],
+            "cards_gained": [
+              {
+                "id": "CARD.APPARITION"
+              },
+              {
+                "id": "CARD.APPARITION"
+              },
+              {
+                "id": "CARD.APPARITION"
+              }
+            ],
+            "current_gold": 0,
+            "current_hp": 0,
+            "damage_taken": 0,
+            "event_choices": [
+              {
+                "title": {
+                  "key": "DISTINGUISHED_CAPE.title",
+                  "table": "relics"
+                }
+              }
+            ],
+            "gold_gained": 0,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 40,
+            "max_hp": 0,
+            "max_hp_gained": 0,
+            "max_hp_lost": 9,
+            "player_id": 76561198071826144,
+            "relic_choices": [
+              {
+                "choice": "RELIC.DISTINGUISHED_CAPE",
+                "was_picked": true
+              }
+            ]
+          }
+        ],
+        "rooms": [
+          {
+            "model_id": "EVENT.VAKUU",
+            "room_type": "event",
+            "turns_taken": 0
+          }
+        ]
+      }
+    ]
+  ],
+  "modifiers": [],
+  "odds": {
+    "unknown_map_point_elite_odds_value": -1,
+    "unknown_map_point_monster_odds_value": 0.1,
+    "unknown_map_point_shop_odds_value": 0.03,
+    "unknown_map_point_treasure_odds_value": 0.02
+  },
+  "platform_type": "steam",
+  "players": [
+    {
+      "base_orb_slot_count": 0,
+      "character_id": "CHARACTER.IRONCLAD",
+      "current_hp": 70,
+      "deck": [
+        {
+          "floor_added_to_deck": 1,
+          "id": "CARD.STRIKE_IRONCLAD"
+        },
+        {
+          "floor_added_to_deck": 1,
+          "id": "CARD.STRIKE_IRONCLAD"
+        },
+        {
+          "floor_added_to_deck": 1,
+          "id": "CARD.DEFEND_IRONCLAD"
+        },
+        {
+          "floor_added_to_deck": 1,
+          "id": "CARD.DEFEND_IRONCLAD"
+        },
+        {
+          "floor_added_to_deck": 1,
+          "id": "CARD.BASH"
+        },
+        {
+          "floor_added_to_deck": 2,
+          "id": "CARD.BODY_SLAM"
+        },
+        {
+          "floor_added_to_deck": 3,
+          "id": "CARD.BATTLE_TRANCE"
+        },
+        {
+          "current_upgrade_level": 1,
+          "floor_added_to_deck": 4,
+          "id": "CARD.POMMEL_STRIKE"
+        },
+        {
+          "floor_added_to_deck": 5,
+          "id": "CARD.BURNING_PACT"
+        },
+        {
+          "floor_added_to_deck": 11,
+          "id": "CARD.HEMOKINESIS"
+        },
+        {
+          "current_upgrade_level": 1,
+          "floor_added_to_deck": 13,
+          "id": "CARD.PYRE"
+        },
+        {
+          "floor_added_to_deck": 14,
+          "id": "CARD.BRAND"
+        },
+        {
+          "floor_added_to_deck": 16,
+          "id": "CARD.IMPERVIOUS"
+        },
+        {
+          "current_upgrade_level": 1,
+          "floor_added_to_deck": 18,
+          "id": "CARD.STRIKE_IRONCLAD"
+        },
+        {
+          "floor_added_to_deck": 18,
+          "id": "CARD.STOMP"
+        },
+        {
+          "floor_added_to_deck": 18,
+          "id": "CARD.BLOODLETTING"
+        },
+        {
+          "current_upgrade_level": 1,
+          "floor_added_to_deck": 20,
+          "id": "CARD.IRON_WAVE"
+        },
+        {
+          "floor_added_to_deck": 20,
+          "id": "CARD.TRUE_GRIT"
+        },
+        {
+          "current_upgrade_level": 1,
+          "floor_added_to_deck": 21,
+          "id": "CARD.DEFEND_IRONCLAD"
+        },
+        {
+          "current_upgrade_level": 1,
+          "floor_added_to_deck": 21,
+          "id": "CARD.TAUNT"
+        },
+        {
+          "current_upgrade_level": 1,
+          "floor_added_to_deck": 22,
+          "id": "CARD.DEFEND_IRONCLAD"
+        },
+        {
+          "floor_added_to_deck": 22,
+          "id": "CARD.RAGE"
+        },
+        {
+          "current_upgrade_level": 1,
+          "floor_added_to_deck": 25,
+          "id": "CARD.STRIKE_IRONCLAD"
+        },
+        {
+          "floor_added_to_deck": 25,
+          "id": "CARD.FEEL_NO_PAIN"
+        },
+        {
+          "floor_added_to_deck": 26,
+          "id": "CARD.SQUASH"
+        },
+        {
+          "floor_added_to_deck": 28,
+          "id": "CARD.SHRUG_IT_OFF"
+        },
+        {
+          "floor_added_to_deck": 28,
+          "id": "CARD.BLOODLETTING"
+        },
+        {
+          "current_upgrade_level": 1,
+          "floor_added_to_deck": 29,
+          "id": "CARD.RAGE"
+        },
+        {
+          "floor_added_to_deck": 31,
+          "id": "CARD.PACTS_END"
+        },
+        {
+          "floor_added_to_deck": 32,
+          "id": "CARD.APPARITION"
+        },
+        {
+          "floor_added_to_deck": 32,
+          "id": "CARD.APPARITION"
+        },
+        {
+          "floor_added_to_deck": 32,
+          "id": "CARD.APPARITION"
+        }
+      ],
+      "extra_fields": {
+        "card_shop_removals_used": 1
+      },
+      "gold": 285,
+      "max_energy": 3,
+      "max_hp": 71,
+      "max_potion_slot_count": 2,
+      "net_id": "PLACEHOLDER_net_id",
+      "odds": {
+        "card_rarity_odds_value": -0.05,
+        "potion_reward_odds_value": 0.6
+      },
+      "potions": [
+        {
+          "id": "POTION.FORTIFIER",
+          "slot_index": 0
+        },
+        {
+          "id": "POTION.BLOOD_POTION",
+          "slot_index": 1
+        }
+      ],
+      "relic_grab_bag": {
+        "relic_id_lists": {
+          "uncommon": [
+            "RELIC.NUNCHAKU",
+            "RELIC.STONE_CRACKER",
+            "RELIC.PEAR",
+            "RELIC.PARRYING_SHIELD",
+            "RELIC.JOSS_PAPER",
+            "RELIC.SPARKLING_ROUGE",
+            "RELIC.PETRIFIED_TOAD",
+            "RELIC.PANTOGRAPH",
+            "RELIC.KUSARIGAMA",
+            "RELIC.MINIATURE_CANNON",
+            "RELIC.AKABEKO",
+            "RELIC.PERMAFROST",
+            "RELIC.LETTER_OPENER",
+            "RELIC.LUCKY_FYSH",
+            "RELIC.RIPPLE_BASIN",
+            "RELIC.PLANISPHERE",
+            "RELIC.TUNING_FORK",
+            "RELIC.BOWLER_HAT",
+            "RELIC.TINY_MAILBOX",
+            "RELIC.ETERNAL_FEATHER",
+            "RELIC.GREMLIN_HORN",
+            "RELIC.ORNAMENTAL_FAN",
+            "RELIC.ORICHALCUM",
+            "RELIC.CANDELABRA",
+            "RELIC.SELF_FORMING_CLAY",
+            "RELIC.REPTILE_TRINKET",
+            "RELIC.LASTING_CANDY",
+            "RELIC.HORN_CLEAT"
+          ],
+          "common": [
+            "RELIC.LANTERN",
+            "RELIC.CENTENNIAL_PUZZLE",
+            "RELIC.BAG_OF_MARBLES",
+            "RELIC.ODDLY_SMOOTH_STONE",
+            "RELIC.RED_SKULL",
+            "RELIC.JUZU_BRACELET",
+            "RELIC.STRAWBERRY",
+            "RELIC.GORGET",
+            "RELIC.VAJRA",
+            "RELIC.POTION_BELT",
+            "RELIC.STRIKE_DUMMY",
+            "RELIC.WAR_PAINT",
+            "RELIC.PENDULUM",
+            "RELIC.FESTIVE_POPPER",
+            "RELIC.WHETSTONE",
+            "RELIC.AMETHYST_AUBERGINE",
+            "RELIC.VENERABLE_TEA_SET",
+            "RELIC.BOOK_OF_FIVE_RINGS",
+            "RELIC.MEAL_TICKET",
+            "RELIC.REGAL_PILLOW",
+            "RELIC.BLOOD_VIAL",
+            "RELIC.BAG_OF_PREPARATION",
+            "RELIC.HAPPY_FLOWER"
+          ],
+          "rare": [
+            "RELIC.INTIMIDATING_HELMET",
+            "RELIC.TUNGSTEN_ROD",
+            "RELIC.CHARONS_ASHES",
+            "RELIC.LIZARD_TAIL",
+            "RELIC.TOXIC_EGG",
+            "RELIC.MEAT_ON_THE_BONE",
+            "RELIC.CHANDELIER",
+            "RELIC.KUNAI",
+            "RELIC.ART_OF_WAR",
+            "RELIC.PRAYER_WHEEL",
+            "RELIC.CAPTAINS_WHEEL",
+            "RELIC.WHITE_BEAST_STATUE",
+            "RELIC.ICE_CREAM",
+            "RELIC.FROZEN_EGG",
+            "RELIC.RAZOR_TOOTH",
+            "RELIC.RAINBOW_RING",
+            "RELIC.WHITE_STAR",
+            "RELIC.STURDY_CLAMP",
+            "RELIC.BEATING_REMNANT",
+            "RELIC.GAME_PIECE",
+            "RELIC.SHOVEL",
+            "RELIC.DEMON_TONGUE",
+            "RELIC.STONE_CALENDAR",
+            "RELIC.BELLOWS",
+            "RELIC.UNSETTLING_LAMP",
+            "RELIC.MOLTEN_EGG",
+            "RELIC.MUMMIFIED_HAND",
+            "RELIC.OLD_COIN",
+            "RELIC.VEXING_PUZZLEBOX",
+            "RELIC.UNCEASING_TOP",
+            "RELIC.RUINED_HELMET",
+            "RELIC.GIRYA",
+            "RELIC.SHURIKEN",
+            "RELIC.MANGO"
+          ],
+          "shop": [
+            "RELIC.KIFUDA",
+            "RELIC.BRIMSTONE",
+            "RELIC.RINGING_TRIANGLE",
+            "RELIC.BELT_BUCKLE",
+            "RELIC.DINGY_RUG",
+            "RELIC.ROYAL_STAMP",
+            "RELIC.PUNCH_DAGGER",
+            "RELIC.SCREAMING_FLAGON",
+            "RELIC.BURNING_STICKS",
+            "RELIC.DOLLYS_MIRROR",
+            "RELIC.CAULDRON",
+            "RELIC.GHOST_SEED",
+            "RELIC.LEES_WAFFLE",
+            "RELIC.LAVA_LAMP",
+            "RELIC.GNARLED_HAMMER",
+            "RELIC.TOOLBOX",
+            "RELIC.DRAGON_FRUIT",
+            "RELIC.BREAD",
+            "RELIC.CHEMICAL_X",
+            "RELIC.THE_ABACUS",
+            "RELIC.MINIATURE_TENT",
+            "RELIC.SLING_OF_COURAGE",
+            "RELIC.MEMBERSHIP_CARD",
+            "RELIC.ORRERY",
+            "RELIC.MYSTIC_LIGHTER"
+          ]
+        }
+      },
+      "relics": [
+        {
+          "floor_added_to_deck": 1,
+          "id": "RELIC.BURNING_BLOOD"
+        },
+        {
+          "floor_added_to_deck": 1,
+          "id": "RELIC.LOST_COFFER"
+        },
+        {
+          "floor_added_to_deck": 8,
+          "id": "RELIC.MERCURY_HOURGLASS"
+        },
+        {
+          "floor_added_to_deck": 9,
+          "id": "RELIC.POCKETWATCH"
+        },
+        {
+          "floor_added_to_deck": 11,
+          "id": "RELIC.BRONZE_SCALES"
+        },
+        {
+          "floor_added_to_deck": 13,
+          "id": "RELIC.VAMBRACE"
+        },
+        {
+          "floor_added_to_deck": 17,
+          "id": "RELIC.PAELS_TOOTH",
+          "props": {
+            "card_arrays": [
+              {
+                "name": "SerializableCards",
+                "value": []
+              }
+            ]
+          }
+        },
+        {
+          "floor_added_to_deck": 19,
+          "id": "RELIC.MR_STRUGGLES"
+        },
+        {
+          "floor_added_to_deck": 24,
+          "id": "RELIC.ANCHOR"
+        },
+        {
+          "floor_added_to_deck": 25,
+          "id": "RELIC.THE_COURIER"
+        },
+        {
+          "floor_added_to_deck": 29,
+          "id": "RELIC.CLOAK_CLASP"
+        },
+        {
+          "floor_added_to_deck": 32,
+          "id": "RELIC.DISTINGUISHED_CAPE"
+        }
+      ],
+      "rng": {
+        "counters": {
+          "rewards": 237,
+          "shops": 28,
+          "transformations": 0
+        },
+        "seed": 2320672338
+      },
+      "unlock_state": {
+        "encounters_seen": [
+          "ENCOUNTER.NIBBITS_WEAK",
+          "ENCOUNTER.SLIMES_WEAK",
+          "ENCOUNTER.SHRINKER_BEETLE_WEAK",
+          "ENCOUNTER.INKLETS_NORMAL",
+          "ENCOUNTER.MAWLER_NORMAL",
+          "ENCOUNTER.BYRDONIS_ELITE",
+          "ENCOUNTER.RUBY_RAIDERS_NORMAL",
+          "ENCOUNTER.VANTOM_BOSS",
+          "ENCOUNTER.EXOSKELETONS_WEAK",
+          "ENCOUNTER.TUNNELER_WEAK",
+          "ENCOUNTER.SPINY_TOAD_NORMAL",
+          "ENCOUNTER.BOWLBUGS_NORMAL",
+          "ENCOUNTER.MYTES_NORMAL",
+          "ENCOUNTER.FUZZY_WURM_CRAWLER_WEAK",
+          "ENCOUNTER.FLYCONID_NORMAL",
+          "ENCOUNTER.OVERGROWTH_CRAWLERS",
+          "ENCOUNTER.SLIMES_NORMAL",
+          "ENCOUNTER.BYGONE_EFFIGY_ELITE",
+          "ENCOUNTER.PHROG_PARASITE_ELITE",
+          "ENCOUNTER.CEREMONIAL_BEAST_BOSS",
+          "ENCOUNTER.NIBBITS_NORMAL",
+          "ENCOUNTER.SNAPPING_JAXFRUIT_NORMAL",
+          "ENCOUNTER.VINE_SHAMBLER_NORMAL",
+          "ENCOUNTER.FOGMOG_NORMAL",
+          "ENCOUNTER.SLITHERING_STRANGLER_NORMAL",
+          "ENCOUNTER.THE_KIN_BOSS",
+          "ENCOUNTER.BOWLBUGS_WEAK",
+          "ENCOUNTER.HUNTER_KILLER_NORMAL",
+          "ENCOUNTER.THE_OBSCURA_NORMAL",
+          "ENCOUNTER.THIEVING_HOPPER_WEAK",
+          "ENCOUNTER.LOUSE_PROGENITOR_NORMAL",
+          "ENCOUNTER.EXOSKELETONS_NORMAL",
+          "ENCOUNTER.OVICOPTER_NORMAL",
+          "ENCOUNTER.KNOWLEDGE_DEMON_BOSS",
+          "ENCOUNTER.SCROLLS_OF_BITING_WEAK",
+          "ENCOUNTER.DEVOTED_SCULPTOR_WEAK",
+          "ENCOUNTER.AXEBOTS_NORMAL",
+          "ENCOUNTER.OWL_MAGISTRATE_NORMAL",
+          "ENCOUNTER.THE_LOST_AND_FORGOTTEN_NORMAL",
+          "ENCOUNTER.FABRICATOR_NORMAL",
+          "ENCOUNTER.DOORMAKER_BOSS",
+          "ENCOUNTER.THE_INSATIABLE_BOSS",
+          "ENCOUNTER.CORPSE_SLUGS_WEAK",
+          "ENCOUNTER.SEAPUNK_WEAK",
+          "ENCOUNTER.SLUDGE_SPINNER_WEAK",
+          "ENCOUNTER.SKULKING_COLONY_ELITE",
+          "ENCOUNTER.LIVING_FOG_NORMAL",
+          "ENCOUNTER.GREMLIN_MERC_NORMAL",
+          "ENCOUNTER.WATERFALL_GIANT_BOSS",
+          "ENCOUNTER.SLUMBERING_BEETLE_NORMAL",
+          "ENCOUNTER.INFESTED_PRISMS_ELITE",
+          "ENCOUNTER.KAISER_CRAB_BOSS",
+          "ENCOUNTER.TOADPOLES_WEAK",
+          "ENCOUNTER.HAUNTED_SHIP_NORMAL",
+          "ENCOUNTER.TWO_TAILED_RATS_NORMAL",
+          "ENCOUNTER.SOUL_FYSH_BOSS",
+          "ENCOUNTER.ENTOMANCER_ELITE",
+          "ENCOUNTER.CHOMPERS_NORMAL",
+          "ENCOUNTER.CUBEX_CONSTRUCT_NORMAL",
+          "ENCOUNTER.DECIMILLIPEDE_ELITE",
+          "ENCOUNTER.TURRET_OPERATOR_WEAK",
+          "ENCOUNTER.FROG_KNIGHT_NORMAL",
+          "ENCOUNTER.MECHA_KNIGHT_ELITE",
+          "ENCOUNTER.GLOBE_HEAD_NORMAL",
+          "ENCOUNTER.QUEEN_BOSS",
+          "ENCOUNTER.SOUL_NEXUS_ELITE",
+          "ENCOUNTER.KNIGHTS_ELITE",
+          "ENCOUNTER.CONSTRUCT_MENAGERIE_NORMAL",
+          "ENCOUNTER.PUNCH_CONSTRUCT_NORMAL",
+          "ENCOUNTER.CORPSE_SLUGS_NORMAL",
+          "ENCOUNTER.LAGAVULIN_MATRIARCH_BOSS",
+          "ENCOUNTER.TEST_SUBJECT_BOSS",
+          "ENCOUNTER.TERROR_EEL_ELITE",
+          "ENCOUNTER.FOSSIL_STALKER_NORMAL",
+          "ENCOUNTER.SEWER_CLAM_NORMAL",
+          "ENCOUNTER.PHANTASMAL_GARDENERS_ELITE",
+          "ENCOUNTER.SCROLLS_OF_BITING_NORMAL",
+          "ENCOUNTER.SLIMED_BERSERKER_NORMAL",
+          "ENCOUNTER.CULTISTS_NORMAL",
+          "ENCOUNTER.BATTLEWORN_DUMMY_EVENT_ENCOUNTER",
+          "ENCOUNTER.DENSE_VEGETATION_EVENT_ENCOUNTER",
+          "ENCOUNTER.TUNNELER_NORMAL",
+          "ENCOUNTER.MYSTERIOUS_KNIGHT_EVENT_ENCOUNTER"
+        ],
+        "number_of_runs": 109,
+        "unlocked_epochs": [
+          "COLORLESS1_EPOCH",
+          "RELIC1_EPOCH",
+          "COLORLESS2_EPOCH",
+          "CUSTOM_AND_SEEDS_EPOCH",
+          "ACT3_B_EPOCH",
+          "RELIC2_EPOCH",
+          "COLORLESS3_EPOCH",
+          "IRONCLAD4_EPOCH",
+          "IRONCLAD3_EPOCH",
+          "ACT2_B_EPOCH",
+          "COLORLESS4_EPOCH",
+          "RELIC4_EPOCH",
+          "EVENT3_EPOCH",
+          "IRONCLAD2_EPOCH",
+          "COLORLESS5_EPOCH",
+          "SILENT4_EPOCH",
+          "IRONCLAD5_EPOCH",
+          "POTION2_EPOCH",
+          "SILENT2_EPOCH",
+          "OROBAS_EPOCH",
+          "EVENT1_EPOCH",
+          "RELIC5_EPOCH",
+          "DEFECT3_EPOCH",
+          "RELIC3_EPOCH",
+          "REGENT1_EPOCH",
+          "SILENT3_EPOCH",
+          "IRONCLAD6_EPOCH",
+          "POTION1_EPOCH",
+          "NEOW_EPOCH",
+          "NECROBINDER2_EPOCH",
+          "SILENT1_EPOCH",
+          "REGENT2_EPOCH",
+          "EVENT2_EPOCH",
+          "DEFECT1_EPOCH",
+          "UNDERDOCKS_EPOCH",
+          "DEFECT2_EPOCH",
+          "DARV_EPOCH",
+          "NECROBINDER1_EPOCH",
+          "IRONCLAD7_EPOCH",
+          "DAILY_RUN_EPOCH"
+        ]
+      }
+    },
+    {
+      "base_orb_slot_count": 0,
+      "character_id": "CHARACTER.SILENT",
+      "current_hp": 62,
+      "deck": [
+        {
+          "floor_added_to_deck": 1,
+          "id": "CARD.STRIKE_SILENT"
+        },
+        {
+          "floor_added_to_deck": 1,
+          "id": "CARD.STRIKE_SILENT"
+        },
+        {
+          "floor_added_to_deck": 1,
+          "id": "CARD.STRIKE_SILENT"
+        },
+        {
+          "floor_added_to_deck": 1,
+          "id": "CARD.STRIKE_SILENT"
+        },
+        {
+          "floor_added_to_deck": 1,
+          "id": "CARD.DEFEND_SILENT"
+        },
+        {
+          "floor_added_to_deck": 1,
+          "id": "CARD.DEFEND_SILENT"
+        },
+        {
+          "floor_added_to_deck": 1,
+          "id": "CARD.DEFEND_SILENT"
+        },
+        {
+          "floor_added_to_deck": 1,
+          "id": "CARD.DEFEND_SILENT"
+        },
+        {
+          "floor_added_to_deck": 1,
+          "id": "CARD.NEUTRALIZE"
+        },
+        {
+          "floor_added_to_deck": 1,
+          "id": "CARD.SURVIVOR"
+        },
+        {
+          "floor_added_to_deck": 2,
+          "id": "CARD.MIRAGE"
+        },
+        {
+          "floor_added_to_deck": 3,
+          "id": "CARD.SLICE"
+        },
+        {
+          "floor_added_to_deck": 4,
+          "id": "CARD.RICOCHET"
+        },
+        {
+          "floor_added_to_deck": 6,
+          "id": "CARD.HAZE"
+        },
+        {
+          "floor_added_to_deck": 8,
+          "id": "CARD.PREPARED"
+        },
+        {
+          "floor_added_to_deck": 11,
+          "id": "CARD.BACKFLIP"
+        },
+        {
+          "floor_added_to_deck": 13,
+          "id": "CARD.OUTBREAK"
+        },
+        {
+          "floor_added_to_deck": 14,
+          "id": "CARD.ANTICIPATE"
+        },
+        {
+          "floor_added_to_deck": 16,
+          "id": "CARD.MASTER_PLANNER"
+        },
+        {
+          "current_upgrade_level": 1,
+          "floor_added_to_deck": 18,
+          "id": "CARD.NOXIOUS_FUMES"
+        },
+        {
+          "floor_added_to_deck": 18,
+          "id": "CARD.UNTOUCHABLE"
+        },
+        {
+          "floor_added_to_deck": 20,
+          "id": "CARD.ANTICIPATE"
+        },
+        {
+          "floor_added_to_deck": 21,
+          "id": "CARD.NOXIOUS_FUMES"
+        },
+        {
+          "floor_added_to_deck": 22,
+          "id": "CARD.PREPARED"
+        },
+        {
+          "floor_added_to_deck": 25,
+          "id": "CARD.PIERCING_WAIL"
+        },
+        {
+          "floor_added_to_deck": 26,
+          "id": "CARD.SQUASH"
+        },
+        {
+          "floor_added_to_deck": 29,
+          "id": "CARD.FOOTWORK"
+        },
+        {
+          "floor_added_to_deck": 31,
+          "id": "CARD.ABRASIVE"
+        },
+        {
+          "floor_added_to_deck": 32,
+          "id": "CARD.APPARITION"
+        },
+        {
+          "floor_added_to_deck": 32,
+          "id": "CARD.APPARITION"
+        },
+        {
+          "floor_added_to_deck": 32,
+          "id": "CARD.APPARITION"
+        }
+      ],
+      "discovered_cards": [
+        "CARD.BEACON_OF_HOPE"
+      ],
+      "extra_fields": {
+        "card_shop_removals_used": 1
+      },
+      "gold": 421,
+      "max_energy": 3,
+      "max_hp": 63,
+      "max_potion_slot_count": 2,
+      "net_id": "PLACEHOLDER_net_id",
+      "odds": {
+        "card_rarity_odds_value": -0.05,
+        "potion_reward_odds_value": 0.6
+      },
+      "potions": [
+        {
+          "id": "POTION.FORTIFIER",
+          "slot_index": 0
+        }
+      ],
+      "relic_grab_bag": {
+        "relic_id_lists": {
+          "uncommon": [
+            "RELIC.REPTILE_TRINKET",
+            "RELIC.MINIATURE_CANNON",
+            "RELIC.HORN_CLEAT",
+            "RELIC.PEAR",
+            "RELIC.VAMBRACE",
+            "RELIC.PARRYING_SHIELD",
+            "RELIC.RIPPLE_BASIN",
+            "RELIC.GREMLIN_HORN",
+            "RELIC.ETERNAL_FEATHER",
+            "RELIC.LASTING_CANDY",
+            "RELIC.PERMAFROST",
+            "RELIC.LETTER_OPENER",
+            "RELIC.PLANISPHERE",
+            "RELIC.MERCURY_HOURGLASS",
+            "RELIC.ORICHALCUM",
+            "RELIC.TUNING_FORK",
+            "RELIC.PANTOGRAPH",
+            "RELIC.ORNAMENTAL_FAN",
+            "RELIC.LUCKY_FYSH",
+            "RELIC.SPARKLING_ROUGE",
+            "RELIC.TWISTED_FUNNEL",
+            "RELIC.AKABEKO",
+            "RELIC.NUNCHAKU",
+            "RELIC.CANDELABRA",
+            "RELIC.TINGSHA",
+            "RELIC.STONE_CRACKER",
+            "RELIC.PETRIFIED_TOAD",
+            "RELIC.BOWLER_HAT"
+          ],
+          "common": [
+            "RELIC.STRAWBERRY",
+            "RELIC.SNECKO_SKULL",
+            "RELIC.MEAL_TICKET",
+            "RELIC.BAG_OF_PREPARATION",
+            "RELIC.STRIKE_DUMMY",
+            "RELIC.BRONZE_SCALES",
+            "RELIC.BLOOD_VIAL",
+            "RELIC.BAG_OF_MARBLES",
+            "RELIC.WAR_PAINT",
+            "RELIC.CENTENNIAL_PUZZLE",
+            "RELIC.FESTIVE_POPPER",
+            "RELIC.VAJRA",
+            "RELIC.REGAL_PILLOW",
+            "RELIC.AMETHYST_AUBERGINE",
+            "RELIC.BOOK_OF_FIVE_RINGS",
+            "RELIC.RED_MASK",
+            "RELIC.LANTERN",
+            "RELIC.POTION_BELT",
+            "RELIC.ODDLY_SMOOTH_STONE",
+            "RELIC.VENERABLE_TEA_SET",
+            "RELIC.WHETSTONE",
+            "RELIC.HAPPY_FLOWER",
+            "RELIC.PENDULUM"
+          ],
+          "rare": [
+            "RELIC.HELICAL_DART",
+            "RELIC.STURDY_CLAMP",
+            "RELIC.KUNAI",
+            "RELIC.UNCEASING_TOP",
+            "RELIC.BELLOWS",
+            "RELIC.PAPER_KRANE",
+            "RELIC.RAZOR_TOOTH",
+            "RELIC.INTIMIDATING_HELMET",
+            "RELIC.UNSETTLING_LAMP",
+            "RELIC.ICE_CREAM",
+            "RELIC.MEAT_ON_THE_BONE",
+            "RELIC.THE_COURIER",
+            "RELIC.MANGO",
+            "RELIC.TUNGSTEN_ROD",
+            "RELIC.LIZARD_TAIL",
+            "RELIC.CHANDELIER",
+            "RELIC.MUMMIFIED_HAND",
+            "RELIC.CLOAK_CLASP",
+            "RELIC.GAME_PIECE",
+            "RELIC.FROZEN_EGG",
+            "RELIC.RAINBOW_RING",
+            "RELIC.ART_OF_WAR",
+            "RELIC.WHITE_BEAST_STATUE",
+            "RELIC.WHITE_STAR",
+            "RELIC.GIRYA",
+            "RELIC.TOXIC_EGG",
+            "RELIC.MOLTEN_EGG",
+            "RELIC.SHOVEL",
+            "RELIC.TOUGH_BANDAGES",
+            "RELIC.OLD_COIN",
+            "RELIC.SHURIKEN"
+          ],
+          "shop": [
+            "RELIC.ROYAL_STAMP",
+            "RELIC.SCREAMING_FLAGON",
+            "RELIC.MINIATURE_TENT",
+            "RELIC.BURNING_STICKS",
+            "RELIC.SLING_OF_COURAGE",
+            "RELIC.CHEMICAL_X",
+            "RELIC.DINGY_RUG",
+            "RELIC.LEES_WAFFLE",
+            "RELIC.THE_ABACUS",
+            "RELIC.BREAD",
+            "RELIC.MEMBERSHIP_CARD",
+            "RELIC.WING_CHARM",
+            "RELIC.MYSTIC_LIGHTER",
+            "RELIC.LAVA_LAMP",
+            "RELIC.GHOST_SEED",
+            "RELIC.KIFUDA",
+            "RELIC.TOOLBOX",
+            "RELIC.NINJA_SCROLL",
+            "RELIC.ORRERY",
+            "RELIC.DOLLYS_MIRROR",
+            "RELIC.BELT_BUCKLE",
+            "RELIC.RINGING_TRIANGLE",
+            "RELIC.DRAGON_FRUIT",
+            "RELIC.PUNCH_DAGGER",
+            "RELIC.GNARLED_HAMMER"
+          ]
+        }
+      },
+      "relics": [
+        {
+          "floor_added_to_deck": 1,
+          "id": "RELIC.RING_OF_THE_SNAKE"
+        },
+        {
+          "floor_added_to_deck": 1,
+          "id": "RELIC.PRECISE_SCISSORS"
+        },
+        {
+          "floor_added_to_deck": 8,
+          "id": "RELIC.VEXING_PUZZLEBOX"
+        },
+        {
+          "floor_added_to_deck": 9,
+          "id": "RELIC.GAMBLING_CHIP"
+        },
+        {
+          "floor_added_to_deck": 11,
+          "id": "RELIC.CAPTAINS_WHEEL"
+        },
+        {
+          "floor_added_to_deck": 13,
+          "id": "RELIC.GORGET"
+        },
+        {
+          "floor_added_to_deck": 17,
+          "id": "RELIC.PAELS_BLOOD"
+        },
+        {
+          "floor_added_to_deck": 19,
+          "id": "RELIC.DAUGHTER_OF_THE_WIND"
+        },
+        {
+          "floor_added_to_deck": 24,
+          "id": "RELIC.PEN_NIB",
+          "props": {
+            "ints": [
+              {
+                "name": "AttacksPlayed",
+                "value": 4
+              }
+            ]
+          }
+        },
+        {
+          "floor_added_to_deck": 25,
+          "id": "RELIC.JUZU_BRACELET"
+        },
+        {
+          "floor_added_to_deck": 28,
+          "id": "RELIC.CHOSEN_CHEESE"
+        },
+        {
+          "floor_added_to_deck": 29,
+          "id": "RELIC.STONE_CALENDAR"
+        },
+        {
+          "floor_added_to_deck": 32,
+          "id": "RELIC.DISTINGUISHED_CAPE"
+        }
+      ],
+      "rng": {
+        "counters": {
+          "rewards": 215,
+          "shops": 28,
+          "transformations": 0
+        },
+        "seed": 2374015678
+      },
+      "unlock_state": {
+        "encounters_seen": [
+          "ENCOUNTER.CORPSE_SLUGS_WEAK",
+          "ENCOUNTER.SEAPUNK_WEAK",
+          "ENCOUNTER.SLUDGE_SPINNER_WEAK",
+          "ENCOUNTER.FOSSIL_STALKER_NORMAL",
+          "ENCOUNTER.LIVING_FOG_NORMAL",
+          "ENCOUNTER.HAUNTED_SHIP_NORMAL",
+          "ENCOUNTER.PHANTASMAL_GARDENERS_ELITE",
+          "ENCOUNTER.NIBBITS_WEAK",
+          "ENCOUNTER.SLIMES_WEAK",
+          "ENCOUNTER.SHRINKER_BEETLE_WEAK",
+          "ENCOUNTER.INKLETS_NORMAL",
+          "ENCOUNTER.MAWLER_NORMAL",
+          "ENCOUNTER.RUBY_RAIDERS_NORMAL",
+          "ENCOUNTER.BYRDONIS_ELITE",
+          "ENCOUNTER.NIBBITS_NORMAL",
+          "ENCOUNTER.PHROG_PARASITE_ELITE",
+          "ENCOUNTER.VANTOM_BOSS",
+          "ENCOUNTER.SEWER_CLAM_NORMAL",
+          "ENCOUNTER.FUZZY_WURM_CRAWLER_WEAK",
+          "ENCOUNTER.BYGONE_EFFIGY_ELITE",
+          "ENCOUNTER.OVERGROWTH_CRAWLERS",
+          "ENCOUNTER.VINE_SHAMBLER_NORMAL",
+          "ENCOUNTER.SLIMES_NORMAL",
+          "ENCOUNTER.SLITHERING_STRANGLER_NORMAL",
+          "ENCOUNTER.FOGMOG_NORMAL",
+          "ENCOUNTER.THIEVING_HOPPER_WEAK",
+          "ENCOUNTER.EXOSKELETONS_WEAK",
+          "ENCOUNTER.LOUSE_PROGENITOR_NORMAL",
+          "ENCOUNTER.EXOSKELETONS_NORMAL",
+          "ENCOUNTER.OVICOPTER_NORMAL",
+          "ENCOUNTER.KNOWLEDGE_DEMON_BOSS",
+          "ENCOUNTER.SCROLLS_OF_BITING_WEAK",
+          "ENCOUNTER.DEVOTED_SCULPTOR_WEAK",
+          "ENCOUNTER.AXEBOTS_NORMAL",
+          "ENCOUNTER.OWL_MAGISTRATE_NORMAL",
+          "ENCOUNTER.THE_LOST_AND_FORGOTTEN_NORMAL",
+          "ENCOUNTER.FABRICATOR_NORMAL",
+          "ENCOUNTER.DOORMAKER_BOSS",
+          "ENCOUNTER.FLYCONID_NORMAL",
+          "ENCOUNTER.CEREMONIAL_BEAST_BOSS",
+          "ENCOUNTER.INFESTED_PRISMS_ELITE",
+          "ENCOUNTER.ENTOMANCER_ELITE",
+          "ENCOUNTER.KAISER_CRAB_BOSS",
+          "ENCOUNTER.SOUL_NEXUS_ELITE",
+          "ENCOUNTER.KNIGHTS_ELITE",
+          "ENCOUNTER.CONSTRUCT_MENAGERIE_NORMAL",
+          "ENCOUNTER.SKULKING_COLONY_ELITE",
+          "ENCOUNTER.LAGAVULIN_MATRIARCH_BOSS",
+          "ENCOUNTER.TOADPOLES_WEAK",
+          "ENCOUNTER.GREMLIN_MERC_NORMAL",
+          "ENCOUNTER.SOUL_FYSH_BOSS",
+          "ENCOUNTER.TUNNELER_WEAK",
+          "ENCOUNTER.DECIMILLIPEDE_ELITE",
+          "ENCOUNTER.TURRET_OPERATOR_WEAK",
+          "ENCOUNTER.MECHA_KNIGHT_ELITE",
+          "ENCOUNTER.QUEEN_BOSS",
+          "ENCOUNTER.TERROR_EEL_ELITE",
+          "ENCOUNTER.WATERFALL_GIANT_BOSS",
+          "ENCOUNTER.BOWLBUGS_WEAK",
+          "ENCOUNTER.HUNTER_KILLER_NORMAL",
+          "ENCOUNTER.THE_INSATIABLE_BOSS",
+          "ENCOUNTER.FROG_KNIGHT_NORMAL",
+          "ENCOUNTER.GLOBE_HEAD_NORMAL",
+          "ENCOUNTER.SLIMED_BERSERKER_NORMAL",
+          "ENCOUNTER.TWO_TAILED_RATS_NORMAL",
+          "ENCOUNTER.CULTISTS_NORMAL",
+          "ENCOUNTER.CUBEX_CONSTRUCT_NORMAL",
+          "ENCOUNTER.SNAPPING_JAXFRUIT_NORMAL",
+          "ENCOUNTER.THE_KIN_BOSS",
+          "ENCOUNTER.BOWLBUGS_NORMAL",
+          "ENCOUNTER.CORPSE_SLUGS_NORMAL",
+          "ENCOUNTER.PUNCH_CONSTRUCT_NORMAL",
+          "ENCOUNTER.CHOMPERS_NORMAL",
+          "ENCOUNTER.TUNNELER_NORMAL",
+          "ENCOUNTER.SPINY_TOAD_NORMAL",
+          "ENCOUNTER.SLUMBERING_BEETLE_NORMAL",
+          "ENCOUNTER.THE_OBSCURA_NORMAL",
+          "ENCOUNTER.SCROLLS_OF_BITING_NORMAL",
+          "ENCOUNTER.TEST_SUBJECT_BOSS",
+          "ENCOUNTER.PUNCH_OFF_EVENT_ENCOUNTER",
+          "ENCOUNTER.BATTLEWORN_DUMMY_EVENT_ENCOUNTER",
+          "ENCOUNTER.MYTES_NORMAL"
+        ],
+        "number_of_runs": 44,
+        "unlocked_epochs": [
+          "COLORLESS1_EPOCH",
+          "RELIC1_EPOCH",
+          "COLORLESS2_EPOCH",
+          "SILENT6_EPOCH",
+          "CUSTOM_AND_SEEDS_EPOCH",
+          "ACT3_B_EPOCH",
+          "RELIC2_EPOCH",
+          "COLORLESS3_EPOCH",
+          "ACT2_B_EPOCH",
+          "COLORLESS4_EPOCH",
+          "RELIC4_EPOCH",
+          "SILENT4_EPOCH",
+          "SILENT5_EPOCH",
+          "POTION2_EPOCH",
+          "SILENT2_EPOCH",
+          "RELIC3_EPOCH",
+          "REGENT1_EPOCH",
+          "SILENT3_EPOCH",
+          "POTION1_EPOCH",
+          "NEOW_EPOCH",
+          "SILENT1_EPOCH",
+          "UNDERDOCKS_EPOCH",
+          "DARV_EPOCH",
+          "SILENT7_EPOCH"
+        ]
+      }
+    }
+  ],
+  "pre_finished_room": {
+    "encounter_id": null,
+    "event_id": "EVENT.VAKUU",
+    "is_pre_finished": true,
+    "parent_event_id": null,
+    "reward_proportion": 0,
+    "room_type": "event",
+    "should_resume_parent_event": true
+  },
+  "rng": {
+    "counters": {
+      "up_front": 522,
+      "shuffle": 1365,
+      "unknown_map_point": 3,
+      "combat_card_generation": 792,
+      "combat_potion_generation": 0,
+      "combat_card_selection": 2,
+      "combat_energy_costs": 0,
+      "combat_targets": 84,
+      "monster_ai": 9,
+      "niche": 37,
+      "combat_orbs": 0,
+      "treasure_room_relics": 4
+    },
+    "seed": "30FY7P2U40"
+  },
+  "run_time": 3730,
+  "save_time": 1776467449,
+  "schema_version": 16,
+  "shared_relic_grab_bag": {
+    "relic_id_lists": {
+      "uncommon": [
+        "RELIC.LASTING_CANDY",
+        "RELIC.ORNAMENTAL_FAN",
+        "RELIC.TUNING_FORK",
+        "RELIC.CANDELABRA",
+        "RELIC.NUNCHAKU",
+        "RELIC.HORN_CLEAT",
+        "RELIC.REPTILE_TRINKET",
+        "RELIC.LETTER_OPENER",
+        "RELIC.PERMAFROST",
+        "RELIC.JOSS_PAPER",
+        "RELIC.BOWLER_HAT",
+        "RELIC.ORICHALCUM",
+        "RELIC.SPARKLING_ROUGE",
+        "RELIC.AKABEKO",
+        "RELIC.PEAR",
+        "RELIC.LUCKY_FYSH",
+        "RELIC.PARRYING_SHIELD",
+        "RELIC.RIPPLE_BASIN",
+        "RELIC.PLANISPHERE",
+        "RELIC.MINIATURE_CANNON",
+        "RELIC.PANTOGRAPH",
+        "RELIC.KUSARIGAMA",
+        "RELIC.PETRIFIED_TOAD",
+        "RELIC.TINY_MAILBOX",
+        "RELIC.GREMLIN_HORN",
+        "RELIC.ETERNAL_FEATHER",
+        "RELIC.STONE_CRACKER"
+      ],
+      "common": [
+        "RELIC.LANTERN",
+        "RELIC.AMETHYST_AUBERGINE",
+        "RELIC.FESTIVE_POPPER",
+        "RELIC.PENDULUM",
+        "RELIC.VENERABLE_TEA_SET",
+        "RELIC.WHETSTONE",
+        "RELIC.BLOOD_VIAL",
+        "RELIC.BAG_OF_PREPARATION",
+        "RELIC.ODDLY_SMOOTH_STONE",
+        "RELIC.MEAL_TICKET",
+        "RELIC.STRIKE_DUMMY",
+        "RELIC.WAR_PAINT",
+        "RELIC.CENTENNIAL_PUZZLE",
+        "RELIC.HAPPY_FLOWER",
+        "RELIC.BOOK_OF_FIVE_RINGS",
+        "RELIC.POTION_BELT",
+        "RELIC.REGAL_PILLOW",
+        "RELIC.VAJRA",
+        "RELIC.STRAWBERRY",
+        "RELIC.BAG_OF_MARBLES"
+      ],
+      "rare": [
+        "RELIC.GAME_PIECE",
+        "RELIC.SHURIKEN",
+        "RELIC.PRAYER_WHEEL",
+        "RELIC.MOLTEN_EGG",
+        "RELIC.SHOVEL",
+        "RELIC.ART_OF_WAR",
+        "RELIC.CHANDELIER",
+        "RELIC.RAINBOW_RING",
+        "RELIC.BELLOWS",
+        "RELIC.MEAT_ON_THE_BONE",
+        "RELIC.ICE_CREAM",
+        "RELIC.OLD_COIN",
+        "RELIC.RAZOR_TOOTH",
+        "RELIC.WHITE_BEAST_STATUE",
+        "RELIC.MUMMIFIED_HAND",
+        "RELIC.MANGO",
+        "RELIC.STURDY_CLAMP",
+        "RELIC.TUNGSTEN_ROD",
+        "RELIC.UNSETTLING_LAMP",
+        "RELIC.LIZARD_TAIL",
+        "RELIC.TOXIC_EGG",
+        "RELIC.UNCEASING_TOP",
+        "RELIC.KUNAI",
+        "RELIC.INTIMIDATING_HELMET",
+        "RELIC.GIRYA",
+        "RELIC.BEATING_REMNANT",
+        "RELIC.FROZEN_EGG",
+        "RELIC.WHITE_STAR"
+      ],
+      "shop": [
+        "RELIC.ROYAL_STAMP",
+        "RELIC.GHOST_SEED",
+        "RELIC.DOLLYS_MIRROR",
+        "RELIC.KIFUDA",
+        "RELIC.ORRERY",
+        "RELIC.MYSTIC_LIGHTER",
+        "RELIC.MEMBERSHIP_CARD",
+        "RELIC.CHEMICAL_X",
+        "RELIC.SCREAMING_FLAGON",
+        "RELIC.LEES_WAFFLE",
+        "RELIC.LAVA_LAMP",
+        "RELIC.GNARLED_HAMMER",
+        "RELIC.TOOLBOX",
+        "RELIC.BURNING_STICKS",
+        "RELIC.PUNCH_DAGGER",
+        "RELIC.DRAGON_FRUIT",
+        "RELIC.BREAD",
+        "RELIC.RINGING_TRIANGLE",
+        "RELIC.BELT_BUCKLE",
+        "RELIC.CAULDRON",
+        "RELIC.THE_ABACUS",
+        "RELIC.DINGY_RUG",
+        "RELIC.MINIATURE_TENT",
+        "RELIC.SLING_OF_COURAGE"
+      ],
+      "event": [
+        "RELIC.FRESNEL_LENS"
+      ],
+      "ancient": [
+        "RELIC.VERY_HOT_COCOA",
+        "RELIC.LOOMING_FRUIT"
+      ]
+    }
+  },
+  "start_time": 1776463611,
+  "visited_map_coords": [
+    {
+      "col": 3,
+      "row": 0
+    }
+  ],
+  "win_time": 0
+}

--- a/apps/desktop/src-tauri/tests/fixtures/sp_abandon.run
+++ b/apps/desktop/src-tauri/tests/fixtures/sp_abandon.run
@@ -1,0 +1,373 @@
+{
+  "acts": [
+    "ACT.UNDERDOCKS",
+    "ACT.HIVE",
+    "ACT.GLORY"
+  ],
+  "ascension": 6,
+  "build_id": "v0.99.1",
+  "game_mode": "standard",
+  "killed_by_encounter": "NONE.NONE",
+  "killed_by_event": "NONE.NONE",
+  "map_point_history": [
+    [
+      {
+        "map_point_type": "ancient",
+        "player_stats": [
+          {
+            "ancient_choice": [
+              {
+                "TextKey": "ARCANE_SCROLL",
+                "title": {
+                  "key": "ARCANE_SCROLL.title",
+                  "table": "relics"
+                },
+                "was_chosen": true
+              },
+              {
+                "TextKey": "POMANDER",
+                "title": {
+                  "key": "POMANDER.title",
+                  "table": "relics"
+                },
+                "was_chosen": false
+              },
+              {
+                "TextKey": "SCROLL_BOXES",
+                "title": {
+                  "key": "SCROLL_BOXES.title",
+                  "table": "relics"
+                },
+                "was_chosen": false
+              }
+            ],
+            "cards_gained": [
+              {
+                "id": "CARD.CRIMSON_MANTLE"
+              }
+            ],
+            "current_gold": 99,
+            "current_hp": 64,
+            "damage_taken": 0,
+            "event_choices": [
+              {
+                "title": {
+                  "key": "ARCANE_SCROLL.title",
+                  "table": "relics"
+                }
+              }
+            ],
+            "gold_gained": 0,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 64,
+            "max_hp": 80,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 1,
+            "relic_choices": [
+              {
+                "choice": "RELIC.ARCANE_SCROLL",
+                "was_picked": true
+              }
+            ]
+          }
+        ],
+        "rooms": [
+          {
+            "model_id": "EVENT.NEOW",
+            "room_type": "event",
+            "turns_taken": 0
+          }
+        ]
+      },
+      {
+        "map_point_type": "monster",
+        "player_stats": [
+          {
+            "card_choices": [
+              {
+                "card": {
+                  "floor_added_to_deck": 2,
+                  "id": "CARD.BURNING_PACT"
+                },
+                "was_picked": true
+              },
+              {
+                "card": {
+                  "id": "CARD.FLAME_BARRIER"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "id": "CARD.IRON_WAVE"
+                },
+                "was_picked": false
+              }
+            ],
+            "cards_gained": [
+              {
+                "id": "CARD.BURNING_PACT"
+              }
+            ],
+            "current_gold": 111,
+            "current_hp": 51,
+            "damage_taken": 19,
+            "gold_gained": 12,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 6,
+            "max_hp": 80,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 1
+          }
+        ],
+        "rooms": [
+          {
+            "model_id": "ENCOUNTER.CORPSE_SLUGS_WEAK",
+            "monster_ids": [
+              "MONSTER.CORPSE_SLUG",
+              "MONSTER.CORPSE_SLUG"
+            ],
+            "room_type": "monster",
+            "turns_taken": 5
+          }
+        ]
+      },
+      {
+        "map_point_type": "monster",
+        "player_stats": [
+          {
+            "card_choices": [
+              {
+                "card": {
+                  "floor_added_to_deck": 3,
+                  "id": "CARD.BLOODLETTING"
+                },
+                "was_picked": true
+              },
+              {
+                "card": {
+                  "id": "CARD.TRUE_GRIT"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "id": "CARD.SECOND_WIND"
+                },
+                "was_picked": false
+              }
+            ],
+            "cards_gained": [
+              {
+                "id": "CARD.BLOODLETTING"
+              }
+            ],
+            "current_gold": 120,
+            "current_hp": 44,
+            "damage_taken": 13,
+            "gold_gained": 9,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 6,
+            "max_hp": 80,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 1
+          }
+        ],
+        "rooms": [
+          {
+            "model_id": "ENCOUNTER.TOADPOLES_WEAK",
+            "monster_ids": [
+              "MONSTER.TOADPOLE",
+              "MONSTER.TOADPOLE"
+            ],
+            "room_type": "monster",
+            "turns_taken": 4
+          }
+        ]
+      },
+      {
+        "map_point_type": "monster",
+        "player_stats": [
+          {
+            "card_choices": [
+              {
+                "card": {
+                  "floor_added_to_deck": 4,
+                  "id": "CARD.FORGOTTEN_RITUAL"
+                },
+                "was_picked": true
+              },
+              {
+                "card": {
+                  "id": "CARD.STOMP"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "id": "CARD.CINDER"
+                },
+                "was_picked": false
+              }
+            ],
+            "cards_gained": [
+              {
+                "id": "CARD.FORGOTTEN_RITUAL"
+              }
+            ],
+            "current_gold": 128,
+            "current_hp": 42,
+            "damage_taken": 8,
+            "gold_gained": 8,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 6,
+            "max_hp": 80,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 1
+          }
+        ],
+        "rooms": [
+          {
+            "model_id": "ENCOUNTER.SEAPUNK_WEAK",
+            "monster_ids": [
+              "MONSTER.SEAPUNK"
+            ],
+            "room_type": "monster",
+            "turns_taken": 4
+          }
+        ]
+      },
+      {
+        "map_point_type": "monster",
+        "player_stats": [
+          {
+            "current_gold": 128,
+            "current_hp": 0,
+            "damage_taken": 42,
+            "gold_gained": 0,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 0,
+            "max_hp": 80,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 1
+          }
+        ],
+        "rooms": [
+          {
+            "model_id": "ENCOUNTER.CORPSE_SLUGS_NORMAL",
+            "monster_ids": [
+              "MONSTER.CORPSE_SLUG",
+              "MONSTER.CORPSE_SLUG",
+              "MONSTER.CORPSE_SLUG"
+            ],
+            "room_type": "monster",
+            "turns_taken": 6
+          }
+        ]
+      }
+    ]
+  ],
+  "modifiers": [],
+  "platform_type": "steam",
+  "players": [
+    {
+      "character": "CHARACTER.IRONCLAD",
+      "deck": [
+        {
+          "floor_added_to_deck": 1,
+          "id": "CARD.STRIKE_IRONCLAD"
+        },
+        {
+          "floor_added_to_deck": 1,
+          "id": "CARD.STRIKE_IRONCLAD"
+        },
+        {
+          "floor_added_to_deck": 1,
+          "id": "CARD.STRIKE_IRONCLAD"
+        },
+        {
+          "floor_added_to_deck": 1,
+          "id": "CARD.STRIKE_IRONCLAD"
+        },
+        {
+          "floor_added_to_deck": 1,
+          "id": "CARD.STRIKE_IRONCLAD"
+        },
+        {
+          "floor_added_to_deck": 1,
+          "id": "CARD.DEFEND_IRONCLAD"
+        },
+        {
+          "floor_added_to_deck": 1,
+          "id": "CARD.DEFEND_IRONCLAD"
+        },
+        {
+          "floor_added_to_deck": 1,
+          "id": "CARD.DEFEND_IRONCLAD"
+        },
+        {
+          "floor_added_to_deck": 1,
+          "id": "CARD.DEFEND_IRONCLAD"
+        },
+        {
+          "floor_added_to_deck": 1,
+          "id": "CARD.BASH"
+        },
+        {
+          "floor_added_to_deck": 1,
+          "id": "CARD.ASCENDERS_BANE"
+        },
+        {
+          "floor_added_to_deck": 1,
+          "id": "CARD.CRIMSON_MANTLE"
+        },
+        {
+          "floor_added_to_deck": 2,
+          "id": "CARD.BURNING_PACT"
+        },
+        {
+          "floor_added_to_deck": 3,
+          "id": "CARD.BLOODLETTING"
+        },
+        {
+          "floor_added_to_deck": 4,
+          "id": "CARD.FORGOTTEN_RITUAL"
+        }
+      ],
+      "id": "PLACEHOLDER_id",
+      "max_potion_slot_count": 2,
+      "potions": [],
+      "relics": [
+        {
+          "floor_added_to_deck": 1,
+          "id": "RELIC.BURNING_BLOOD"
+        },
+        {
+          "floor_added_to_deck": 1,
+          "id": "RELIC.ARCANE_SCROLL"
+        }
+      ]
+    }
+  ],
+  "run_time": 501,
+  "schema_version": 8,
+  "seed": "E3TFSGEA6E",
+  "start_time": 1774613246,
+  "was_abandoned": true,
+  "win": false
+}

--- a/apps/desktop/src-tauri/tests/fixtures/sp_death.run
+++ b/apps/desktop/src-tauri/tests/fixtures/sp_death.run
@@ -1,0 +1,373 @@
+{
+  "acts": [
+    "ACT.UNDERDOCKS",
+    "ACT.HIVE",
+    "ACT.GLORY"
+  ],
+  "ascension": 6,
+  "build_id": "v0.99.1",
+  "game_mode": "standard",
+  "killed_by_encounter": "ENCOUNTER.CORPSE_SLUGS_NORMAL",
+  "killed_by_event": "NONE.NONE",
+  "map_point_history": [
+    [
+      {
+        "map_point_type": "ancient",
+        "player_stats": [
+          {
+            "ancient_choice": [
+              {
+                "TextKey": "ARCANE_SCROLL",
+                "title": {
+                  "key": "ARCANE_SCROLL.title",
+                  "table": "relics"
+                },
+                "was_chosen": true
+              },
+              {
+                "TextKey": "POMANDER",
+                "title": {
+                  "key": "POMANDER.title",
+                  "table": "relics"
+                },
+                "was_chosen": false
+              },
+              {
+                "TextKey": "SCROLL_BOXES",
+                "title": {
+                  "key": "SCROLL_BOXES.title",
+                  "table": "relics"
+                },
+                "was_chosen": false
+              }
+            ],
+            "cards_gained": [
+              {
+                "id": "CARD.CRIMSON_MANTLE"
+              }
+            ],
+            "current_gold": 99,
+            "current_hp": 64,
+            "damage_taken": 0,
+            "event_choices": [
+              {
+                "title": {
+                  "key": "ARCANE_SCROLL.title",
+                  "table": "relics"
+                }
+              }
+            ],
+            "gold_gained": 0,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 64,
+            "max_hp": 80,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 1,
+            "relic_choices": [
+              {
+                "choice": "RELIC.ARCANE_SCROLL",
+                "was_picked": true
+              }
+            ]
+          }
+        ],
+        "rooms": [
+          {
+            "model_id": "EVENT.NEOW",
+            "room_type": "event",
+            "turns_taken": 0
+          }
+        ]
+      },
+      {
+        "map_point_type": "monster",
+        "player_stats": [
+          {
+            "card_choices": [
+              {
+                "card": {
+                  "floor_added_to_deck": 2,
+                  "id": "CARD.BURNING_PACT"
+                },
+                "was_picked": true
+              },
+              {
+                "card": {
+                  "id": "CARD.FLAME_BARRIER"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "id": "CARD.IRON_WAVE"
+                },
+                "was_picked": false
+              }
+            ],
+            "cards_gained": [
+              {
+                "id": "CARD.BURNING_PACT"
+              }
+            ],
+            "current_gold": 111,
+            "current_hp": 51,
+            "damage_taken": 19,
+            "gold_gained": 12,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 6,
+            "max_hp": 80,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 1
+          }
+        ],
+        "rooms": [
+          {
+            "model_id": "ENCOUNTER.CORPSE_SLUGS_WEAK",
+            "monster_ids": [
+              "MONSTER.CORPSE_SLUG",
+              "MONSTER.CORPSE_SLUG"
+            ],
+            "room_type": "monster",
+            "turns_taken": 5
+          }
+        ]
+      },
+      {
+        "map_point_type": "monster",
+        "player_stats": [
+          {
+            "card_choices": [
+              {
+                "card": {
+                  "floor_added_to_deck": 3,
+                  "id": "CARD.BLOODLETTING"
+                },
+                "was_picked": true
+              },
+              {
+                "card": {
+                  "id": "CARD.TRUE_GRIT"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "id": "CARD.SECOND_WIND"
+                },
+                "was_picked": false
+              }
+            ],
+            "cards_gained": [
+              {
+                "id": "CARD.BLOODLETTING"
+              }
+            ],
+            "current_gold": 120,
+            "current_hp": 44,
+            "damage_taken": 13,
+            "gold_gained": 9,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 6,
+            "max_hp": 80,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 1
+          }
+        ],
+        "rooms": [
+          {
+            "model_id": "ENCOUNTER.TOADPOLES_WEAK",
+            "monster_ids": [
+              "MONSTER.TOADPOLE",
+              "MONSTER.TOADPOLE"
+            ],
+            "room_type": "monster",
+            "turns_taken": 4
+          }
+        ]
+      },
+      {
+        "map_point_type": "monster",
+        "player_stats": [
+          {
+            "card_choices": [
+              {
+                "card": {
+                  "floor_added_to_deck": 4,
+                  "id": "CARD.FORGOTTEN_RITUAL"
+                },
+                "was_picked": true
+              },
+              {
+                "card": {
+                  "id": "CARD.STOMP"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "id": "CARD.CINDER"
+                },
+                "was_picked": false
+              }
+            ],
+            "cards_gained": [
+              {
+                "id": "CARD.FORGOTTEN_RITUAL"
+              }
+            ],
+            "current_gold": 128,
+            "current_hp": 42,
+            "damage_taken": 8,
+            "gold_gained": 8,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 6,
+            "max_hp": 80,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 1
+          }
+        ],
+        "rooms": [
+          {
+            "model_id": "ENCOUNTER.SEAPUNK_WEAK",
+            "monster_ids": [
+              "MONSTER.SEAPUNK"
+            ],
+            "room_type": "monster",
+            "turns_taken": 4
+          }
+        ]
+      },
+      {
+        "map_point_type": "monster",
+        "player_stats": [
+          {
+            "current_gold": 128,
+            "current_hp": 0,
+            "damage_taken": 42,
+            "gold_gained": 0,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 0,
+            "max_hp": 80,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 1
+          }
+        ],
+        "rooms": [
+          {
+            "model_id": "ENCOUNTER.CORPSE_SLUGS_NORMAL",
+            "monster_ids": [
+              "MONSTER.CORPSE_SLUG",
+              "MONSTER.CORPSE_SLUG",
+              "MONSTER.CORPSE_SLUG"
+            ],
+            "room_type": "monster",
+            "turns_taken": 6
+          }
+        ]
+      }
+    ]
+  ],
+  "modifiers": [],
+  "platform_type": "steam",
+  "players": [
+    {
+      "character": "CHARACTER.IRONCLAD",
+      "deck": [
+        {
+          "floor_added_to_deck": 1,
+          "id": "CARD.STRIKE_IRONCLAD"
+        },
+        {
+          "floor_added_to_deck": 1,
+          "id": "CARD.STRIKE_IRONCLAD"
+        },
+        {
+          "floor_added_to_deck": 1,
+          "id": "CARD.STRIKE_IRONCLAD"
+        },
+        {
+          "floor_added_to_deck": 1,
+          "id": "CARD.STRIKE_IRONCLAD"
+        },
+        {
+          "floor_added_to_deck": 1,
+          "id": "CARD.STRIKE_IRONCLAD"
+        },
+        {
+          "floor_added_to_deck": 1,
+          "id": "CARD.DEFEND_IRONCLAD"
+        },
+        {
+          "floor_added_to_deck": 1,
+          "id": "CARD.DEFEND_IRONCLAD"
+        },
+        {
+          "floor_added_to_deck": 1,
+          "id": "CARD.DEFEND_IRONCLAD"
+        },
+        {
+          "floor_added_to_deck": 1,
+          "id": "CARD.DEFEND_IRONCLAD"
+        },
+        {
+          "floor_added_to_deck": 1,
+          "id": "CARD.BASH"
+        },
+        {
+          "floor_added_to_deck": 1,
+          "id": "CARD.ASCENDERS_BANE"
+        },
+        {
+          "floor_added_to_deck": 1,
+          "id": "CARD.CRIMSON_MANTLE"
+        },
+        {
+          "floor_added_to_deck": 2,
+          "id": "CARD.BURNING_PACT"
+        },
+        {
+          "floor_added_to_deck": 3,
+          "id": "CARD.BLOODLETTING"
+        },
+        {
+          "floor_added_to_deck": 4,
+          "id": "CARD.FORGOTTEN_RITUAL"
+        }
+      ],
+      "id": "PLACEHOLDER_id",
+      "max_potion_slot_count": 2,
+      "potions": [],
+      "relics": [
+        {
+          "floor_added_to_deck": 1,
+          "id": "RELIC.BURNING_BLOOD"
+        },
+        {
+          "floor_added_to_deck": 1,
+          "id": "RELIC.ARCANE_SCROLL"
+        }
+      ]
+    }
+  ],
+  "run_time": 501,
+  "schema_version": 8,
+  "seed": "E3TFSGEA6E",
+  "start_time": 1774613245,
+  "was_abandoned": false,
+  "win": false
+}

--- a/apps/desktop/src-tauri/tests/fixtures/sp_win.run
+++ b/apps/desktop/src-tauri/tests/fixtures/sp_win.run
@@ -1,0 +1,2787 @@
+{
+  "acts": [
+    "ACT.UNDERDOCKS",
+    "ACT.HIVE",
+    "ACT.GLORY"
+  ],
+  "ascension": 7,
+  "build_id": "v0.99.1",
+  "game_mode": "standard",
+  "killed_by_encounter": "NONE.NONE",
+  "killed_by_event": "NONE.NONE",
+  "map_point_history": [
+    [
+      {
+        "map_point_type": "ancient",
+        "player_stats": [
+          {
+            "ancient_choice": [
+              {
+                "TextKey": "PRECISE_SCISSORS",
+                "title": {
+                  "key": "PRECISE_SCISSORS.title",
+                  "table": "relics"
+                },
+                "was_chosen": true
+              },
+              {
+                "TextKey": "LOST_COFFER",
+                "title": {
+                  "key": "LOST_COFFER.title",
+                  "table": "relics"
+                },
+                "was_chosen": false
+              },
+              {
+                "TextKey": "SILVER_CRUCIBLE",
+                "title": {
+                  "key": "SILVER_CRUCIBLE.title",
+                  "table": "relics"
+                },
+                "was_chosen": false
+              }
+            ],
+            "cards_removed": [
+              {
+                "floor_added_to_deck": 1,
+                "id": "CARD.STRIKE_IRONCLAD"
+              }
+            ],
+            "current_gold": 99,
+            "current_hp": 64,
+            "damage_taken": 0,
+            "event_choices": [
+              {
+                "title": {
+                  "key": "PRECISE_SCISSORS.title",
+                  "table": "relics"
+                }
+              }
+            ],
+            "gold_gained": 0,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 64,
+            "max_hp": 80,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 1,
+            "relic_choices": [
+              {
+                "choice": "RELIC.PRECISE_SCISSORS",
+                "was_picked": true
+              }
+            ]
+          }
+        ],
+        "rooms": [
+          {
+            "model_id": "EVENT.NEOW",
+            "room_type": "event",
+            "turns_taken": 0
+          }
+        ]
+      },
+      {
+        "map_point_type": "monster",
+        "player_stats": [
+          {
+            "card_choices": [
+              {
+                "card": {
+                  "floor_added_to_deck": 2,
+                  "id": "CARD.ARMAMENTS"
+                },
+                "was_picked": true
+              },
+              {
+                "card": {
+                  "id": "CARD.HAVOC"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "id": "CARD.TREMBLE"
+                },
+                "was_picked": false
+              }
+            ],
+            "cards_gained": [
+              {
+                "id": "CARD.ARMAMENTS"
+              }
+            ],
+            "current_gold": 112,
+            "current_hp": 62,
+            "damage_taken": 8,
+            "gold_gained": 13,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 6,
+            "max_hp": 80,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 1,
+            "potion_choices": [
+              {
+                "choice": "POTION.SOLDIERS_STEW",
+                "was_picked": true
+              }
+            ]
+          }
+        ],
+        "rooms": [
+          {
+            "model_id": "ENCOUNTER.TOADPOLES_WEAK",
+            "monster_ids": [
+              "MONSTER.TOADPOLE",
+              "MONSTER.TOADPOLE"
+            ],
+            "room_type": "monster",
+            "turns_taken": 4
+          }
+        ]
+      },
+      {
+        "map_point_type": "monster",
+        "player_stats": [
+          {
+            "card_choices": [
+              {
+                "card": {
+                  "floor_added_to_deck": 3,
+                  "id": "CARD.BODY_SLAM"
+                },
+                "was_picked": true
+              },
+              {
+                "card": {
+                  "id": "CARD.INFERNAL_BLADE"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "id": "CARD.IRON_WAVE"
+                },
+                "was_picked": false
+              }
+            ],
+            "cards_gained": [
+              {
+                "id": "CARD.BODY_SLAM"
+              }
+            ],
+            "current_gold": 123,
+            "current_hp": 57,
+            "damage_taken": 11,
+            "gold_gained": 11,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 6,
+            "max_hp": 80,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 1
+          }
+        ],
+        "rooms": [
+          {
+            "model_id": "ENCOUNTER.CORPSE_SLUGS_WEAK",
+            "monster_ids": [
+              "MONSTER.CORPSE_SLUG",
+              "MONSTER.CORPSE_SLUG"
+            ],
+            "room_type": "monster",
+            "turns_taken": 5
+          }
+        ]
+      },
+      {
+        "map_point_type": "unknown",
+        "player_stats": [
+          {
+            "card_choices": [
+              {
+                "card": {
+                  "floor_added_to_deck": 4,
+                  "id": "CARD.DISMANTLE"
+                },
+                "was_picked": true
+              },
+              {
+                "card": {
+                  "id": "CARD.MOLTEN_FIST"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "id": "CARD.CINDER"
+                },
+                "was_picked": false
+              }
+            ],
+            "cards_gained": [
+              {
+                "id": "CARD.DISMANTLE"
+              }
+            ],
+            "current_gold": 136,
+            "current_hp": 59,
+            "damage_taken": 4,
+            "gold_gained": 13,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 6,
+            "max_hp": 80,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 1
+          }
+        ],
+        "rooms": [
+          {
+            "model_id": "ENCOUNTER.SLUDGE_SPINNER_WEAK",
+            "monster_ids": [
+              "MONSTER.SLUDGE_SPINNER"
+            ],
+            "room_type": "monster",
+            "turns_taken": 3
+          }
+        ]
+      },
+      {
+        "map_point_type": "monster",
+        "player_stats": [
+          {
+            "card_choices": [
+              {
+                "card": {
+                  "floor_added_to_deck": 5,
+                  "id": "CARD.BLOODLETTING"
+                },
+                "was_picked": true
+              },
+              {
+                "card": {
+                  "id": "CARD.PILLAGE"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "id": "CARD.POMMEL_STRIKE"
+                },
+                "was_picked": false
+              }
+            ],
+            "cards_gained": [
+              {
+                "id": "CARD.BLOODLETTING"
+              }
+            ],
+            "current_gold": 151,
+            "current_hp": 58,
+            "damage_taken": 7,
+            "gold_gained": 15,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 6,
+            "max_hp": 80,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 1
+          }
+        ],
+        "rooms": [
+          {
+            "model_id": "ENCOUNTER.TOADPOLES_NORMAL",
+            "monster_ids": [
+              "MONSTER.CALCIFIED_CULTIST",
+              "MONSTER.TOADPOLE"
+            ],
+            "room_type": "monster",
+            "turns_taken": 4
+          }
+        ]
+      },
+      {
+        "map_point_type": "unknown",
+        "player_stats": [
+          {
+            "current_gold": 151,
+            "current_hp": 58,
+            "damage_taken": 0,
+            "event_choices": [
+              {
+                "title": {
+                  "key": "DOORS_OF_LIGHT_AND_DARK.pages.INITIAL.options.LIGHT.title",
+                  "table": "events"
+                }
+              }
+            ],
+            "gold_gained": 0,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 0,
+            "max_hp": 80,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 1,
+            "upgraded_cards": [
+              "CARD.DEFEND_IRONCLAD",
+              "CARD.STRIKE_IRONCLAD"
+            ]
+          }
+        ],
+        "rooms": [
+          {
+            "model_id": "EVENT.DOORS_OF_LIGHT_AND_DARK",
+            "room_type": "event",
+            "turns_taken": 0
+          }
+        ]
+      },
+      {
+        "map_point_type": "rest_site",
+        "player_stats": [
+          {
+            "current_gold": 151,
+            "current_hp": 58,
+            "damage_taken": 0,
+            "gold_gained": 0,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 0,
+            "max_hp": 80,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 1,
+            "rest_site_choices": [
+              "SMITH"
+            ],
+            "upgraded_cards": [
+              "CARD.ARMAMENTS"
+            ]
+          }
+        ],
+        "rooms": [
+          {
+            "room_type": "rest_site",
+            "turns_taken": 0
+          }
+        ]
+      },
+      {
+        "map_point_type": "monster",
+        "player_stats": [
+          {
+            "card_choices": [
+              {
+                "card": {
+                  "id": "CARD.IRON_WAVE"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "id": "CARD.THUNDERCLAP"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "id": "CARD.HEADBUTT"
+                },
+                "was_picked": false
+              }
+            ],
+            "current_gold": 164,
+            "current_hp": 51,
+            "damage_taken": 13,
+            "gold_gained": 13,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 6,
+            "max_hp": 80,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 1
+          }
+        ],
+        "rooms": [
+          {
+            "model_id": "ENCOUNTER.GREMLIN_MERC_NORMAL",
+            "monster_ids": [
+              "MONSTER.GREMLIN_MERC"
+            ],
+            "room_type": "monster",
+            "turns_taken": 6
+          }
+        ]
+      },
+      {
+        "map_point_type": "rest_site",
+        "player_stats": [
+          {
+            "current_gold": 164,
+            "current_hp": 51,
+            "damage_taken": 0,
+            "gold_gained": 0,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 0,
+            "max_hp": 80,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 1,
+            "rest_site_choices": [
+              "SMITH"
+            ],
+            "upgraded_cards": [
+              "CARD.BASH"
+            ]
+          }
+        ],
+        "rooms": [
+          {
+            "room_type": "rest_site",
+            "turns_taken": 0
+          }
+        ]
+      },
+      {
+        "map_point_type": "treasure",
+        "player_stats": [
+          {
+            "current_gold": 197,
+            "current_hp": 51,
+            "damage_taken": 0,
+            "gold_gained": 33,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 0,
+            "max_hp": 80,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 1,
+            "relic_choices": [
+              {
+                "choice": "RELIC.PENDULUM",
+                "was_picked": true
+              }
+            ]
+          }
+        ],
+        "rooms": [
+          {
+            "room_type": "treasure",
+            "turns_taken": 0
+          }
+        ]
+      },
+      {
+        "map_point_type": "rest_site",
+        "player_stats": [
+          {
+            "current_gold": 197,
+            "current_hp": 75,
+            "damage_taken": 0,
+            "gold_gained": 0,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 24,
+            "max_hp": 80,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 1,
+            "rest_site_choices": [
+              "HEAL"
+            ]
+          }
+        ],
+        "rooms": [
+          {
+            "room_type": "rest_site",
+            "turns_taken": 0
+          }
+        ]
+      },
+      {
+        "map_point_type": "elite",
+        "player_stats": [
+          {
+            "card_choices": [
+              {
+                "card": {
+                  "floor_added_to_deck": 12,
+                  "id": "CARD.HEADBUTT"
+                },
+                "was_picked": true
+              },
+              {
+                "card": {
+                  "id": "CARD.SECOND_WIND"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "id": "CARD.THUNDERCLAP"
+                },
+                "was_picked": false
+              }
+            ],
+            "cards_gained": [
+              {
+                "id": "CARD.HEADBUTT"
+              }
+            ],
+            "current_gold": 223,
+            "current_hp": 66,
+            "damage_taken": 15,
+            "gold_gained": 26,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 6,
+            "max_hp": 80,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 1,
+            "potion_used": [
+              "POTION.SOLDIERS_STEW"
+            ],
+            "relic_choices": [
+              {
+                "choice": "RELIC.STONE_CRACKER",
+                "was_picked": true
+              }
+            ]
+          }
+        ],
+        "rooms": [
+          {
+            "model_id": "ENCOUNTER.TERROR_EEL_ELITE",
+            "monster_ids": [
+              "MONSTER.TERROR_EEL"
+            ],
+            "room_type": "elite",
+            "turns_taken": 3
+          }
+        ]
+      },
+      {
+        "map_point_type": "rest_site",
+        "player_stats": [
+          {
+            "current_gold": 223,
+            "current_hp": 66,
+            "damage_taken": 0,
+            "gold_gained": 0,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 0,
+            "max_hp": 80,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 1,
+            "rest_site_choices": [
+              "SMITH"
+            ],
+            "upgraded_cards": [
+              "CARD.BODY_SLAM"
+            ]
+          }
+        ],
+        "rooms": [
+          {
+            "room_type": "rest_site",
+            "turns_taken": 0
+          }
+        ]
+      },
+      {
+        "map_point_type": "shop",
+        "player_stats": [
+          {
+            "bought_potions": [
+              "POTION.WEAK_POTION",
+              "POTION.SWIFT_POTION"
+            ],
+            "card_choices": [
+              {
+                "card": {
+                  "id": "CARD.ANGER"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "id": "CARD.GRAPPLE"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "id": "CARD.INFERNAL_BLADE"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "id": "CARD.TREMBLE"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "id": "CARD.STAMPEDE"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "id": "CARD.SHOCKWAVE"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "id": "CARD.CALAMITY"
+                },
+                "was_picked": false
+              }
+            ],
+            "cards_removed": [
+              {
+                "floor_added_to_deck": 1,
+                "id": "CARD.STRIKE_IRONCLAD"
+              }
+            ],
+            "current_gold": 48,
+            "current_hp": 66,
+            "damage_taken": 0,
+            "gold_gained": 0,
+            "gold_lost": 0,
+            "gold_spent": 175,
+            "gold_stolen": 0,
+            "hp_healed": 0,
+            "max_hp": 80,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 1,
+            "potion_choices": [
+              {
+                "choice": "POTION.WEAK_POTION",
+                "was_picked": true
+              },
+              {
+                "choice": "POTION.SWIFT_POTION",
+                "was_picked": true
+              },
+              {
+                "choice": "POTION.FLEX_POTION",
+                "was_picked": false
+              }
+            ],
+            "relic_choices": [
+              {
+                "choice": "RELIC.BAG_OF_PREPARATION",
+                "was_picked": false
+              },
+              {
+                "choice": "RELIC.RED_SKULL",
+                "was_picked": false
+              },
+              {
+                "choice": "RELIC.TOOLBOX",
+                "was_picked": false
+              }
+            ]
+          }
+        ],
+        "rooms": [
+          {
+            "room_type": "shop",
+            "turns_taken": 0
+          }
+        ]
+      },
+      {
+        "map_point_type": "monster",
+        "player_stats": [
+          {
+            "card_choices": [
+              {
+                "card": {
+                  "floor_added_to_deck": 15,
+                  "id": "CARD.BREAKTHROUGH"
+                },
+                "was_picked": true
+              },
+              {
+                "card": {
+                  "id": "CARD.SWORD_BOOMERANG"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "id": "CARD.HEADBUTT"
+                },
+                "was_picked": false
+              }
+            ],
+            "cards_gained": [
+              {
+                "id": "CARD.BREAKTHROUGH"
+              }
+            ],
+            "current_gold": 61,
+            "current_hp": 64,
+            "damage_taken": 8,
+            "gold_gained": 13,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 6,
+            "max_hp": 80,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 1,
+            "potion_choices": [
+              {
+                "choice": "POTION.EXPLOSIVE_AMPOULE",
+                "was_picked": false
+              }
+            ]
+          }
+        ],
+        "rooms": [
+          {
+            "model_id": "ENCOUNTER.LIVING_FOG_NORMAL",
+            "monster_ids": [
+              "MONSTER.LIVING_FOG"
+            ],
+            "room_type": "monster",
+            "turns_taken": 3
+          }
+        ]
+      },
+      {
+        "map_point_type": "rest_site",
+        "player_stats": [
+          {
+            "current_gold": 61,
+            "current_hp": 80,
+            "damage_taken": 0,
+            "gold_gained": 0,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 16,
+            "max_hp": 80,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 1,
+            "rest_site_choices": [
+              "HEAL"
+            ]
+          }
+        ],
+        "rooms": [
+          {
+            "room_type": "rest_site",
+            "turns_taken": 0
+          }
+        ]
+      },
+      {
+        "map_point_type": "boss",
+        "player_stats": [
+          {
+            "card_choices": [
+              {
+                "card": {
+                  "floor_added_to_deck": 17,
+                  "id": "CARD.FIEND_FIRE"
+                },
+                "was_picked": true
+              },
+              {
+                "card": {
+                  "id": "CARD.STOKE"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "id": "CARD.PRIMAL_FORCE"
+                },
+                "was_picked": false
+              }
+            ],
+            "cards_gained": [
+              {
+                "id": "CARD.FIEND_FIRE"
+              }
+            ],
+            "current_gold": 136,
+            "current_hp": 19,
+            "damage_taken": 67,
+            "gold_gained": 75,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 6,
+            "max_hp": 80,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 1,
+            "potion_choices": [
+              {
+                "choice": "POTION.DISTILLED_CHAOS",
+                "was_picked": true
+              }
+            ],
+            "potion_used": [
+              "POTION.SWIFT_POTION",
+              "POTION.WEAK_POTION"
+            ]
+          }
+        ],
+        "rooms": [
+          {
+            "model_id": "ENCOUNTER.LAGAVULIN_MATRIARCH_BOSS",
+            "monster_ids": [
+              "MONSTER.LAGAVULIN_MATRIARCH"
+            ],
+            "room_type": "boss",
+            "turns_taken": 7
+          }
+        ]
+      }
+    ],
+    [
+      {
+        "map_point_type": "ancient",
+        "player_stats": [
+          {
+            "ancient_choice": [
+              {
+                "TextKey": "PAELS_TEARS",
+                "title": {
+                  "key": "PAELS_TEARS.title",
+                  "table": "relics"
+                },
+                "was_chosen": false
+              },
+              {
+                "TextKey": "PAELS_WING",
+                "title": {
+                  "key": "PAELS_WING.title",
+                  "table": "relics"
+                },
+                "was_chosen": false
+              },
+              {
+                "TextKey": "PAELS_BLOOD",
+                "title": {
+                  "key": "PAELS_BLOOD.title",
+                  "table": "relics"
+                },
+                "was_chosen": true
+              }
+            ],
+            "current_gold": 136,
+            "current_hp": 67,
+            "damage_taken": 0,
+            "event_choices": [
+              {
+                "title": {
+                  "key": "PAELS_BLOOD.title",
+                  "table": "relics"
+                }
+              }
+            ],
+            "gold_gained": 0,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 48,
+            "max_hp": 80,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 1,
+            "relic_choices": [
+              {
+                "choice": "RELIC.PAELS_BLOOD",
+                "was_picked": true
+              }
+            ]
+          }
+        ],
+        "rooms": [
+          {
+            "model_id": "EVENT.PAEL",
+            "room_type": "event",
+            "turns_taken": 0
+          }
+        ]
+      },
+      {
+        "map_point_type": "monster",
+        "player_stats": [
+          {
+            "card_choices": [
+              {
+                "card": {
+                  "floor_added_to_deck": 19,
+                  "id": "CARD.BATTLE_TRANCE"
+                },
+                "was_picked": true
+              },
+              {
+                "card": {
+                  "id": "CARD.BULLY"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "id": "CARD.CINDER"
+                },
+                "was_picked": false
+              }
+            ],
+            "cards_gained": [
+              {
+                "id": "CARD.BATTLE_TRANCE"
+              }
+            ],
+            "current_gold": 148,
+            "current_hp": 62,
+            "damage_taken": 11,
+            "gold_gained": 12,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 6,
+            "max_hp": 80,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 1
+          }
+        ],
+        "rooms": [
+          {
+            "model_id": "ENCOUNTER.EXOSKELETONS_WEAK",
+            "monster_ids": [
+              "MONSTER.EXOSKELETON",
+              "MONSTER.EXOSKELETON",
+              "MONSTER.EXOSKELETON"
+            ],
+            "room_type": "monster",
+            "turns_taken": 3
+          }
+        ]
+      },
+      {
+        "map_point_type": "shop",
+        "player_stats": [
+          {
+            "card_choices": [
+              {
+                "card": {
+                  "id": "CARD.SETUP_STRIKE"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "id": "CARD.IRON_WAVE"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "id": "CARD.BLOOD_WALL"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "id": "CARD.FORGOTTEN_RITUAL"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "id": "CARD.STONE_ARMOR"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "id": "CARD.THE_BOMB"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "id": "CARD.ROLLING_BOULDER"
+                },
+                "was_picked": false
+              }
+            ],
+            "cards_removed": [
+              {
+                "floor_added_to_deck": 1,
+                "id": "CARD.DEFEND_IRONCLAD"
+              }
+            ],
+            "current_gold": 48,
+            "current_hp": 62,
+            "damage_taken": 0,
+            "gold_gained": 0,
+            "gold_lost": 0,
+            "gold_spent": 100,
+            "gold_stolen": 0,
+            "hp_healed": 0,
+            "max_hp": 80,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 1,
+            "potion_choices": [
+              {
+                "choice": "POTION.BLESSING_OF_THE_FORGE",
+                "was_picked": false
+              },
+              {
+                "choice": "POTION.CURE_ALL",
+                "was_picked": false
+              },
+              {
+                "choice": "POTION.SWIFT_POTION",
+                "was_picked": false
+              }
+            ],
+            "relic_choices": [
+              {
+                "choice": "RELIC.AMETHYST_AUBERGINE",
+                "was_picked": false
+              },
+              {
+                "choice": "RELIC.BOWLER_HAT",
+                "was_picked": false
+              },
+              {
+                "choice": "RELIC.DINGY_RUG",
+                "was_picked": false
+              }
+            ]
+          }
+        ],
+        "rooms": [
+          {
+            "room_type": "shop",
+            "turns_taken": 0
+          }
+        ]
+      },
+      {
+        "map_point_type": "monster",
+        "player_stats": [
+          {
+            "card_choices": [
+              {
+                "card": {
+                  "current_upgrade_level": 1,
+                  "floor_added_to_deck": 21,
+                  "id": "CARD.BATTLE_TRANCE"
+                },
+                "was_picked": true
+              },
+              {
+                "card": {
+                  "id": "CARD.BREAKTHROUGH"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "id": "CARD.STONE_ARMOR"
+                },
+                "was_picked": false
+              }
+            ],
+            "cards_gained": [
+              {
+                "current_upgrade_level": 1,
+                "id": "CARD.BATTLE_TRANCE"
+              }
+            ],
+            "current_gold": 60,
+            "current_hp": 57,
+            "damage_taken": 11,
+            "gold_gained": 12,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 6,
+            "max_hp": 80,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 1,
+            "potion_choices": [
+              {
+                "choice": "POTION.WEAK_POTION",
+                "was_picked": true
+              }
+            ]
+          }
+        ],
+        "rooms": [
+          {
+            "model_id": "ENCOUNTER.BOWLBUGS_WEAK",
+            "monster_ids": [
+              "MONSTER.BOWLBUG_ROCK",
+              "MONSTER.BOWLBUG_EGG"
+            ],
+            "room_type": "monster",
+            "turns_taken": 3
+          }
+        ]
+      },
+      {
+        "map_point_type": "unknown",
+        "player_stats": [
+          {
+            "current_gold": 60,
+            "current_hp": 67,
+            "damage_taken": 0,
+            "event_choices": [
+              {
+                "title": {
+                  "key": "STONE_OF_ALL_TIME.pages.INITIAL.options.LIFT.title",
+                  "table": "events"
+                },
+                "variables": {
+                  "DrinkRandomPotion": {
+                    "type": "DynamicString",
+                    "decimal_value": 0,
+                    "bool_value": false,
+                    "string_value": "Distilled Chaos"
+                  },
+                  "DrinkMaxHpGain": {
+                    "type": "BaseDynamic",
+                    "decimal_value": 10,
+                    "bool_value": false,
+                    "string_value": null
+                  },
+                  "PushHpLoss": {
+                    "type": "BaseDynamic",
+                    "decimal_value": 6,
+                    "bool_value": false,
+                    "string_value": null
+                  },
+                  "PushVigorousAmount": {
+                    "type": "BaseDynamic",
+                    "decimal_value": 8,
+                    "bool_value": false,
+                    "string_value": null
+                  }
+                }
+              }
+            ],
+            "gold_gained": 0,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 10,
+            "max_hp": 90,
+            "max_hp_gained": 10,
+            "max_hp_lost": 0,
+            "player_id": 1,
+            "potion_discarded": [
+              "POTION.DISTILLED_CHAOS"
+            ]
+          }
+        ],
+        "rooms": [
+          {
+            "model_id": "EVENT.STONE_OF_ALL_TIME",
+            "room_type": "event",
+            "turns_taken": 0
+          }
+        ]
+      },
+      {
+        "map_point_type": "unknown",
+        "player_stats": [
+          {
+            "card_choices": [
+              {
+                "card": {
+                  "floor_added_to_deck": 23,
+                  "id": "CARD.SHOCKWAVE"
+                },
+                "was_picked": true
+              },
+              {
+                "card": {
+                  "id": "CARD.PRODUCTION"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "id": "CARD.THE_BOMB"
+                },
+                "was_picked": false
+              }
+            ],
+            "cards_gained": [
+              {
+                "id": "CARD.SHOCKWAVE"
+              }
+            ],
+            "current_gold": 60,
+            "current_hp": 62,
+            "damage_taken": 5,
+            "event_choices": [
+              {
+                "title": {
+                  "key": "BRAIN_LEECH.pages.INITIAL.options.RIP.title",
+                  "table": "events"
+                },
+                "variables": {}
+              }
+            ],
+            "gold_gained": 0,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 0,
+            "max_hp": 90,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 1
+          }
+        ],
+        "rooms": [
+          {
+            "model_id": "EVENT.BRAIN_LEECH",
+            "room_type": "event",
+            "turns_taken": 0
+          }
+        ]
+      },
+      {
+        "map_point_type": "unknown",
+        "player_stats": [
+          {
+            "cards_enchanted": [
+              {
+                "card": {
+                  "enchantment": {
+                    "amount": 2,
+                    "id": "ENCHANTMENT.SHARP"
+                  },
+                  "floor_added_to_deck": 17,
+                  "id": "CARD.FIEND_FIRE"
+                },
+                "enchantment": "ENCHANTMENT.SHARP"
+              }
+            ],
+            "current_gold": 60,
+            "current_hp": 62,
+            "damage_taken": 0,
+            "event_choices": [
+              {
+                "title": {
+                  "key": "SELF_HELP_BOOK.pages.INITIAL.options.READ_THE_BACK.title",
+                  "table": "events"
+                },
+                "variables": {
+                  "Enchantment1": {
+                    "type": "DynamicString",
+                    "decimal_value": 0,
+                    "bool_value": false,
+                    "string_value": "Sharp"
+                  },
+                  "Enchantment2": {
+                    "type": "DynamicString",
+                    "decimal_value": 0,
+                    "bool_value": false,
+                    "string_value": "Nimble"
+                  },
+                  "Enchantment3": {
+                    "type": "DynamicString",
+                    "decimal_value": 0,
+                    "bool_value": false,
+                    "string_value": "Swift"
+                  }
+                }
+              }
+            ],
+            "gold_gained": 0,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 0,
+            "max_hp": 90,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 1
+          }
+        ],
+        "rooms": [
+          {
+            "model_id": "EVENT.SELF_HELP_BOOK",
+            "room_type": "event",
+            "turns_taken": 0
+          }
+        ]
+      },
+      {
+        "map_point_type": "rest_site",
+        "player_stats": [
+          {
+            "current_gold": 60,
+            "current_hp": 62,
+            "damage_taken": 0,
+            "gold_gained": 0,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 0,
+            "max_hp": 90,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 1,
+            "rest_site_choices": [
+              "SMITH"
+            ],
+            "upgraded_cards": [
+              "CARD.BATTLE_TRANCE"
+            ]
+          }
+        ],
+        "rooms": [
+          {
+            "room_type": "rest_site",
+            "turns_taken": 0
+          }
+        ]
+      },
+      {
+        "map_point_type": "treasure",
+        "player_stats": [
+          {
+            "current_gold": 95,
+            "current_hp": 62,
+            "damage_taken": 0,
+            "gold_gained": 35,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 0,
+            "max_hp": 90,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 1,
+            "relic_choices": [
+              {
+                "choice": "RELIC.BAG_OF_MARBLES",
+                "was_picked": true
+              }
+            ]
+          }
+        ],
+        "rooms": [
+          {
+            "room_type": "treasure",
+            "turns_taken": 0
+          }
+        ]
+      },
+      {
+        "map_point_type": "monster",
+        "player_stats": [
+          {
+            "card_choices": [
+              {
+                "card": {
+                  "floor_added_to_deck": 27,
+                  "id": "CARD.POMMEL_STRIKE"
+                },
+                "was_picked": true
+              },
+              {
+                "card": {
+                  "id": "CARD.EXPECT_A_FIGHT"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "id": "CARD.ASHEN_STRIKE"
+                },
+                "was_picked": false
+              }
+            ],
+            "cards_gained": [
+              {
+                "id": "CARD.POMMEL_STRIKE"
+              }
+            ],
+            "current_gold": 107,
+            "current_hp": 60,
+            "damage_taken": 8,
+            "gold_gained": 12,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 6,
+            "max_hp": 90,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 1
+          }
+        ],
+        "rooms": [
+          {
+            "model_id": "ENCOUNTER.THE_OBSCURA_NORMAL",
+            "monster_ids": [
+              "MONSTER.THE_OBSCURA"
+            ],
+            "room_type": "monster",
+            "turns_taken": 4
+          }
+        ]
+      },
+      {
+        "map_point_type": "rest_site",
+        "player_stats": [
+          {
+            "current_gold": 107,
+            "current_hp": 87,
+            "damage_taken": 0,
+            "gold_gained": 0,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 27,
+            "max_hp": 90,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 1,
+            "rest_site_choices": [
+              "HEAL"
+            ]
+          }
+        ],
+        "rooms": [
+          {
+            "room_type": "rest_site",
+            "turns_taken": 0
+          }
+        ]
+      },
+      {
+        "map_point_type": "elite",
+        "player_stats": [
+          {
+            "card_choices": [
+              {
+                "card": {
+                  "floor_added_to_deck": 29,
+                  "id": "CARD.STOMP"
+                },
+                "was_picked": true
+              },
+              {
+                "card": {
+                  "id": "CARD.WHIRLWIND"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "current_upgrade_level": 1,
+                  "id": "CARD.HEADBUTT"
+                },
+                "was_picked": false
+              }
+            ],
+            "cards_gained": [
+              {
+                "id": "CARD.STOMP"
+              }
+            ],
+            "current_gold": 140,
+            "current_hp": 52,
+            "damage_taken": 41,
+            "gold_gained": 33,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 6,
+            "max_hp": 90,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 1,
+            "potion_choices": [
+              {
+                "choice": "POTION.BLOCK_POTION",
+                "was_picked": true
+              }
+            ],
+            "relic_choices": [
+              {
+                "choice": "RELIC.VENERABLE_TEA_SET",
+                "was_picked": true
+              }
+            ]
+          }
+        ],
+        "rooms": [
+          {
+            "model_id": "ENCOUNTER.INFESTED_PRISMS_ELITE",
+            "monster_ids": [
+              "MONSTER.INFESTED_PRISM"
+            ],
+            "room_type": "elite",
+            "turns_taken": 4
+          }
+        ]
+      },
+      {
+        "map_point_type": "monster",
+        "player_stats": [
+          {
+            "card_choices": [
+              {
+                "card": {
+                  "current_upgrade_level": 1,
+                  "floor_added_to_deck": 30,
+                  "id": "CARD.POMMEL_STRIKE"
+                },
+                "was_picked": true
+              },
+              {
+                "card": {
+                  "id": "CARD.SETUP_STRIKE"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "id": "CARD.BREAKTHROUGH"
+                },
+                "was_picked": false
+              }
+            ],
+            "cards_gained": [
+              {
+                "current_upgrade_level": 1,
+                "id": "CARD.POMMEL_STRIKE"
+              }
+            ],
+            "current_gold": 147,
+            "current_hp": 58,
+            "damage_taken": 0,
+            "gold_gained": 7,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 6,
+            "max_hp": 90,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 1,
+            "potion_choices": [
+              {
+                "choice": "POTION.SKILL_POTION",
+                "was_picked": true
+              }
+            ],
+            "potion_discarded": [
+              "POTION.BLOCK_POTION"
+            ]
+          }
+        ],
+        "rooms": [
+          {
+            "model_id": "ENCOUNTER.OVICOPTER_NORMAL",
+            "monster_ids": [
+              "MONSTER.OVICOPTER"
+            ],
+            "room_type": "monster",
+            "turns_taken": 2
+          }
+        ]
+      },
+      {
+        "map_point_type": "unknown",
+        "player_stats": [
+          {
+            "card_choices": [
+              {
+                "card": {
+                  "id": "CARD.BREAKTHROUGH"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "id": "CARD.RAMPAGE"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "id": "CARD.BLOOD_WALL"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "id": "CARD.TREMBLE"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "id": "CARD.DRUM_OF_BATTLE"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "id": "CARD.PANACHE"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "id": "CARD.BEAT_DOWN"
+                },
+                "was_picked": false
+              }
+            ],
+            "cards_removed": [
+              {
+                "floor_added_to_deck": 1,
+                "id": "CARD.STRIKE_IRONCLAD"
+              }
+            ],
+            "current_gold": 22,
+            "current_hp": 58,
+            "damage_taken": 0,
+            "gold_gained": 0,
+            "gold_lost": 0,
+            "gold_spent": 125,
+            "gold_stolen": 0,
+            "hp_healed": 0,
+            "max_hp": 90,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 1,
+            "potion_choices": [
+              {
+                "choice": "POTION.BLESSING_OF_THE_FORGE",
+                "was_picked": false
+              },
+              {
+                "choice": "POTION.WEAK_POTION",
+                "was_picked": false
+              },
+              {
+                "choice": "POTION.EXPLOSIVE_AMPOULE",
+                "was_picked": false
+              }
+            ],
+            "relic_choices": [
+              {
+                "choice": "RELIC.STRAWBERRY",
+                "was_picked": false
+              },
+              {
+                "choice": "RELIC.LANTERN",
+                "was_picked": false
+              },
+              {
+                "choice": "RELIC.MINIATURE_TENT",
+                "was_picked": false
+              }
+            ]
+          }
+        ],
+        "rooms": [
+          {
+            "room_type": "shop",
+            "turns_taken": 0
+          }
+        ]
+      },
+      {
+        "map_point_type": "rest_site",
+        "player_stats": [
+          {
+            "current_gold": 22,
+            "current_hp": 85,
+            "damage_taken": 0,
+            "gold_gained": 0,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 27,
+            "max_hp": 90,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 1,
+            "rest_site_choices": [
+              "HEAL"
+            ]
+          }
+        ],
+        "rooms": [
+          {
+            "room_type": "rest_site",
+            "turns_taken": 0
+          }
+        ]
+      },
+      {
+        "map_point_type": "boss",
+        "player_stats": [
+          {
+            "card_choices": [
+              {
+                "card": {
+                  "floor_added_to_deck": 33,
+                  "id": "CARD.IMPERVIOUS"
+                },
+                "was_picked": true
+              },
+              {
+                "card": {
+                  "id": "CARD.COLOSSUS"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "id": "CARD.PACTS_END"
+                },
+                "was_picked": false
+              }
+            ],
+            "cards_gained": [
+              {
+                "id": "CARD.IMPERVIOUS"
+              }
+            ],
+            "current_gold": 97,
+            "current_hp": 56,
+            "damage_taken": 35,
+            "gold_gained": 75,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 6,
+            "max_hp": 90,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 1,
+            "potion_choices": [
+              {
+                "choice": "POTION.SOLDIERS_STEW",
+                "was_picked": true
+              }
+            ],
+            "potion_used": [
+              "POTION.SKILL_POTION"
+            ]
+          }
+        ],
+        "rooms": [
+          {
+            "model_id": "ENCOUNTER.THE_INSATIABLE_BOSS",
+            "monster_ids": [
+              "MONSTER.THE_INSATIABLE"
+            ],
+            "room_type": "boss",
+            "turns_taken": 6
+          }
+        ]
+      }
+    ],
+    [
+      {
+        "map_point_type": "ancient",
+        "player_stats": [
+          {
+            "ancient_choice": [
+              {
+                "TextKey": "WHISPERING_EARRING",
+                "title": {
+                  "key": "WHISPERING_EARRING.title",
+                  "table": "relics"
+                },
+                "was_chosen": false
+              },
+              {
+                "TextKey": "SERE_TALON",
+                "title": {
+                  "key": "SERE_TALON.title",
+                  "table": "relics"
+                },
+                "was_chosen": false
+              },
+              {
+                "TextKey": "JEWELED_MASK",
+                "title": {
+                  "key": "JEWELED_MASK.title",
+                  "table": "relics"
+                },
+                "was_chosen": true
+              }
+            ],
+            "current_gold": 97,
+            "current_hp": 83,
+            "damage_taken": 0,
+            "event_choices": [
+              {
+                "title": {
+                  "key": "JEWELED_MASK.title",
+                  "table": "relics"
+                }
+              }
+            ],
+            "gold_gained": 0,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 27,
+            "max_hp": 90,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 1,
+            "relic_choices": [
+              {
+                "choice": "RELIC.JEWELED_MASK",
+                "was_picked": true
+              }
+            ]
+          }
+        ],
+        "rooms": [
+          {
+            "model_id": "EVENT.VAKUU",
+            "room_type": "event",
+            "turns_taken": 0
+          }
+        ]
+      },
+      {
+        "map_point_type": "monster",
+        "player_stats": [
+          {
+            "card_choices": [
+              {
+                "card": {
+                  "floor_added_to_deck": 35,
+                  "id": "CARD.TAUNT"
+                },
+                "was_picked": true
+              },
+              {
+                "card": {
+                  "id": "CARD.INFLAME"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "id": "CARD.PERFECTED_STRIKE"
+                },
+                "was_picked": false
+              }
+            ],
+            "cards_gained": [
+              {
+                "id": "CARD.TAUNT"
+              }
+            ],
+            "current_gold": 105,
+            "current_hp": 76,
+            "damage_taken": 13,
+            "gold_gained": 8,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 6,
+            "max_hp": 90,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 1
+          }
+        ],
+        "rooms": [
+          {
+            "model_id": "ENCOUNTER.DEVOTED_SCULPTOR_WEAK",
+            "monster_ids": [
+              "MONSTER.DEVOTED_SCULPTOR"
+            ],
+            "room_type": "monster",
+            "turns_taken": 3
+          }
+        ]
+      },
+      {
+        "map_point_type": "unknown",
+        "player_stats": [
+          {
+            "current_gold": 105,
+            "current_hp": 76,
+            "damage_taken": 0,
+            "downgraded_cards": [
+              "CARD.BATTLE_TRANCE",
+              "CARD.POMMEL_STRIKE"
+            ],
+            "event_choices": [
+              {
+                "title": {
+                  "key": "REFLECTIONS.pages.INITIAL.options.TOUCH_A_MIRROR.title",
+                  "table": "events"
+                }
+              }
+            ],
+            "gold_gained": 0,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 0,
+            "max_hp": 90,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 1,
+            "upgraded_cards": [
+              "CARD.POMMEL_STRIKE",
+              "CARD.SHOCKWAVE",
+              "CARD.STOMP",
+              "CARD.DEFEND_IRONCLAD"
+            ]
+          }
+        ],
+        "rooms": [
+          {
+            "model_id": "EVENT.REFLECTIONS",
+            "room_type": "event",
+            "turns_taken": 0
+          }
+        ]
+      },
+      {
+        "map_point_type": "shop",
+        "player_stats": [
+          {
+            "card_choices": [
+              {
+                "card": {
+                  "id": "CARD.STOMP"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "id": "CARD.BLUDGEON"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "id": "CARD.BURNING_PACT"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "id": "CARD.EXPECT_A_FIGHT"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "id": "CARD.PANACHE"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "id": "CARD.SECRET_WEAPON"
+                },
+                "was_picked": false
+              }
+            ],
+            "cards_gained": [
+              {
+                "id": "CARD.INFLAME"
+              }
+            ],
+            "current_gold": 29,
+            "current_hp": 76,
+            "damage_taken": 0,
+            "gold_gained": 0,
+            "gold_lost": 0,
+            "gold_spent": 76,
+            "gold_stolen": 0,
+            "hp_healed": 0,
+            "max_hp": 90,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 1,
+            "potion_choices": [
+              {
+                "choice": "POTION.WEAK_POTION",
+                "was_picked": false
+              },
+              {
+                "choice": "POTION.LIQUID_BRONZE",
+                "was_picked": false
+              },
+              {
+                "choice": "POTION.ENERGY_POTION",
+                "was_picked": false
+              }
+            ],
+            "relic_choices": [
+              {
+                "choice": "RELIC.REPTILE_TRINKET",
+                "was_picked": false
+              },
+              {
+                "choice": "RELIC.PANTOGRAPH",
+                "was_picked": false
+              },
+              {
+                "choice": "RELIC.ROYAL_STAMP",
+                "was_picked": false
+              }
+            ]
+          }
+        ],
+        "rooms": [
+          {
+            "room_type": "shop",
+            "turns_taken": 0
+          }
+        ]
+      },
+      {
+        "map_point_type": "monster",
+        "player_stats": [
+          {
+            "card_choices": [
+              {
+                "card": {
+                  "id": "CARD.ASHEN_STRIKE"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "id": "CARD.INFERNO"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "current_upgrade_level": 1,
+                  "id": "CARD.CINDER"
+                },
+                "was_picked": false
+              }
+            ],
+            "current_gold": 36,
+            "current_hp": 78,
+            "damage_taken": 4,
+            "gold_gained": 7,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 6,
+            "max_hp": 90,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 1
+          }
+        ],
+        "rooms": [
+          {
+            "model_id": "ENCOUNTER.TURRET_OPERATOR_WEAK",
+            "monster_ids": [
+              "MONSTER.LIVING_SHIELD",
+              "MONSTER.TURRET_OPERATOR"
+            ],
+            "room_type": "monster",
+            "turns_taken": 2
+          }
+        ]
+      },
+      {
+        "map_point_type": "elite",
+        "player_stats": [
+          {
+            "card_choices": [
+              {
+                "card": {
+                  "id": "CARD.SETUP_STRIKE"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "id": "CARD.BLUDGEON"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "id": "CARD.AGGRESSION"
+                },
+                "was_picked": false
+              }
+            ],
+            "current_gold": 63,
+            "current_hp": 60,
+            "damage_taken": 24,
+            "gold_gained": 27,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 6,
+            "max_hp": 90,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 1,
+            "potion_choices": [
+              {
+                "choice": "POTION.BEETLE_JUICE",
+                "was_picked": true
+              }
+            ],
+            "potion_used": [
+              "POTION.SOLDIERS_STEW"
+            ],
+            "relic_choices": [
+              {
+                "choice": "RELIC.BRONZE_SCALES",
+                "was_picked": true
+              }
+            ]
+          }
+        ],
+        "rooms": [
+          {
+            "model_id": "ENCOUNTER.SOUL_NEXUS_ELITE",
+            "monster_ids": [
+              "MONSTER.SOUL_NEXUS"
+            ],
+            "room_type": "elite",
+            "turns_taken": 3
+          }
+        ]
+      },
+      {
+        "map_point_type": "rest_site",
+        "player_stats": [
+          {
+            "current_gold": 63,
+            "current_hp": 60,
+            "damage_taken": 0,
+            "gold_gained": 0,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 0,
+            "max_hp": 90,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 1,
+            "rest_site_choices": [
+              "SMITH"
+            ],
+            "upgraded_cards": [
+              "CARD.BATTLE_TRANCE"
+            ]
+          }
+        ],
+        "rooms": [
+          {
+            "room_type": "rest_site",
+            "turns_taken": 0
+          }
+        ]
+      },
+      {
+        "map_point_type": "treasure",
+        "player_stats": [
+          {
+            "current_gold": 100,
+            "current_hp": 60,
+            "damage_taken": 0,
+            "gold_gained": 37,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 0,
+            "max_hp": 90,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 1,
+            "relic_choices": [
+              {
+                "choice": "RELIC.PRAYER_WHEEL",
+                "was_picked": true
+              }
+            ]
+          }
+        ],
+        "rooms": [
+          {
+            "room_type": "treasure",
+            "turns_taken": 0
+          }
+        ]
+      },
+      {
+        "map_point_type": "rest_site",
+        "player_stats": [
+          {
+            "current_gold": 100,
+            "current_hp": 60,
+            "damage_taken": 0,
+            "gold_gained": 0,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 0,
+            "max_hp": 90,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 1,
+            "rest_site_choices": [
+              "SMITH"
+            ],
+            "upgraded_cards": [
+              "CARD.FIEND_FIRE"
+            ]
+          }
+        ],
+        "rooms": [
+          {
+            "room_type": "rest_site",
+            "turns_taken": 0
+          }
+        ]
+      },
+      {
+        "map_point_type": "unknown",
+        "player_stats": [
+          {
+            "cards_enchanted": [
+              {
+                "card": {
+                  "current_upgrade_level": 1,
+                  "enchantment": {
+                    "amount": 1,
+                    "id": "ENCHANTMENT.CORRUPTED"
+                  },
+                  "floor_added_to_deck": 29,
+                  "id": "CARD.STOMP"
+                },
+                "enchantment": "ENCHANTMENT.CORRUPTED"
+              }
+            ],
+            "current_gold": 100,
+            "current_hp": 60,
+            "damage_taken": 0,
+            "event_choices": [
+              {
+                "title": {
+                  "key": "SYMBIOTE.pages.INITIAL.options.APPROACH.title",
+                  "table": "events"
+                },
+                "variables": {
+                  "Enchantment": {
+                    "type": "DynamicString",
+                    "decimal_value": 0,
+                    "bool_value": false,
+                    "string_value": "Corrupted"
+                  }
+                }
+              }
+            ],
+            "gold_gained": 0,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 0,
+            "max_hp": 90,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 1
+          }
+        ],
+        "rooms": [
+          {
+            "model_id": "EVENT.SYMBIOTE",
+            "room_type": "event",
+            "turns_taken": 0
+          }
+        ]
+      },
+      {
+        "map_point_type": "rest_site",
+        "player_stats": [
+          {
+            "current_gold": 100,
+            "current_hp": 87,
+            "damage_taken": 0,
+            "gold_gained": 0,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 27,
+            "max_hp": 90,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 1,
+            "rest_site_choices": [
+              "HEAL"
+            ]
+          }
+        ],
+        "rooms": [
+          {
+            "room_type": "rest_site",
+            "turns_taken": 0
+          }
+        ]
+      },
+      {
+        "map_point_type": "unknown",
+        "player_stats": [
+          {
+            "card_choices": [
+              {
+                "card": {
+                  "id": "CARD.ANGER"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "id": "CARD.TAUNT"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "current_upgrade_level": 1,
+                  "id": "CARD.FIGHT_ME"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "id": "CARD.INFERNAL_BLADE"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "id": "CARD.STONE_ARMOR"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "current_upgrade_level": 1,
+                  "id": "CARD.SETUP_STRIKE"
+                },
+                "was_picked": false
+              }
+            ],
+            "current_gold": 111,
+            "current_hp": 72,
+            "damage_taken": 21,
+            "gold_gained": 11,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 6,
+            "max_hp": 90,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 1,
+            "potion_choices": [
+              {
+                "choice": "POTION.REGEN_POTION",
+                "was_picked": false
+              }
+            ]
+          }
+        ],
+        "rooms": [
+          {
+            "model_id": "ENCOUNTER.OWL_MAGISTRATE_NORMAL",
+            "monster_ids": [
+              "MONSTER.OWL_MAGISTRATE"
+            ],
+            "room_type": "monster",
+            "turns_taken": 3
+          }
+        ]
+      },
+      {
+        "map_point_type": "unknown",
+        "player_stats": [
+          {
+            "card_choices": [
+              {
+                "card": {
+                  "id": "CARD.MOLTEN_FIST"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "id": "CARD.ARMAMENTS"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "id": "CARD.THUNDERCLAP"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "current_upgrade_level": 1,
+                  "id": "CARD.RUPTURE"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "id": "CARD.ARMAMENTS"
+                },
+                "was_picked": false
+              },
+              {
+                "card": {
+                  "current_upgrade_level": 1,
+                  "id": "CARD.BURNING_PACT"
+                },
+                "was_picked": false
+              }
+            ],
+            "current_gold": 122,
+            "current_hp": 69,
+            "damage_taken": 9,
+            "gold_gained": 11,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 6,
+            "max_hp": 90,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 1,
+            "potion_choices": [
+              {
+                "choice": "POTION.FLEX_POTION",
+                "was_picked": false
+              }
+            ]
+          }
+        ],
+        "rooms": [
+          {
+            "model_id": "ENCOUNTER.CONSTRUCT_MENAGERIE_NORMAL",
+            "monster_ids": [
+              "MONSTER.PUNCH_CONSTRUCT",
+              "MONSTER.CUBEX_CONSTRUCT",
+              "MONSTER.CUBEX_CONSTRUCT"
+            ],
+            "room_type": "monster",
+            "turns_taken": 3
+          }
+        ]
+      },
+      {
+        "map_point_type": "rest_site",
+        "player_stats": [
+          {
+            "current_gold": 122,
+            "current_hp": 90,
+            "damage_taken": 0,
+            "gold_gained": 0,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 21,
+            "max_hp": 90,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 1,
+            "rest_site_choices": [
+              "HEAL"
+            ]
+          }
+        ],
+        "rooms": [
+          {
+            "room_type": "rest_site",
+            "turns_taken": 0
+          }
+        ]
+      },
+      {
+        "map_point_type": "boss",
+        "player_stats": [
+          {
+            "current_gold": 122,
+            "current_hp": 34,
+            "damage_taken": 62,
+            "gold_gained": 0,
+            "gold_lost": 0,
+            "gold_spent": 0,
+            "gold_stolen": 0,
+            "hp_healed": 6,
+            "max_hp": 90,
+            "max_hp_gained": 0,
+            "max_hp_lost": 0,
+            "player_id": 1,
+            "potion_used": [
+              "POTION.BEETLE_JUICE",
+              "POTION.WEAK_POTION"
+            ]
+          }
+        ],
+        "rooms": [
+          {
+            "model_id": "ENCOUNTER.QUEEN_BOSS",
+            "monster_ids": [
+              "MONSTER.TORCH_HEAD_AMALGAM",
+              "MONSTER.QUEEN"
+            ],
+            "room_type": "boss",
+            "turns_taken": 9
+          }
+        ]
+      }
+    ]
+  ],
+  "modifiers": [],
+  "platform_type": "steam",
+  "players": [
+    {
+      "character": "CHARACTER.IRONCLAD",
+      "deck": [
+        {
+          "floor_added_to_deck": 1,
+          "id": "CARD.STRIKE_IRONCLAD"
+        },
+        {
+          "current_upgrade_level": 1,
+          "floor_added_to_deck": 1,
+          "id": "CARD.STRIKE_IRONCLAD"
+        },
+        {
+          "floor_added_to_deck": 1,
+          "id": "CARD.DEFEND_IRONCLAD"
+        },
+        {
+          "current_upgrade_level": 1,
+          "floor_added_to_deck": 1,
+          "id": "CARD.DEFEND_IRONCLAD"
+        },
+        {
+          "current_upgrade_level": 1,
+          "floor_added_to_deck": 1,
+          "id": "CARD.DEFEND_IRONCLAD"
+        },
+        {
+          "current_upgrade_level": 1,
+          "floor_added_to_deck": 1,
+          "id": "CARD.BASH"
+        },
+        {
+          "floor_added_to_deck": 1,
+          "id": "CARD.ASCENDERS_BANE"
+        },
+        {
+          "current_upgrade_level": 1,
+          "floor_added_to_deck": 2,
+          "id": "CARD.ARMAMENTS"
+        },
+        {
+          "current_upgrade_level": 1,
+          "floor_added_to_deck": 3,
+          "id": "CARD.BODY_SLAM"
+        },
+        {
+          "floor_added_to_deck": 4,
+          "id": "CARD.DISMANTLE"
+        },
+        {
+          "floor_added_to_deck": 5,
+          "id": "CARD.BLOODLETTING"
+        },
+        {
+          "floor_added_to_deck": 12,
+          "id": "CARD.HEADBUTT"
+        },
+        {
+          "floor_added_to_deck": 15,
+          "id": "CARD.BREAKTHROUGH"
+        },
+        {
+          "current_upgrade_level": 1,
+          "enchantment": {
+            "amount": 2,
+            "id": "ENCHANTMENT.SHARP"
+          },
+          "floor_added_to_deck": 17,
+          "id": "CARD.FIEND_FIRE"
+        },
+        {
+          "current_upgrade_level": 1,
+          "floor_added_to_deck": 19,
+          "id": "CARD.BATTLE_TRANCE"
+        },
+        {
+          "current_upgrade_level": 1,
+          "floor_added_to_deck": 21,
+          "id": "CARD.BATTLE_TRANCE"
+        },
+        {
+          "current_upgrade_level": 1,
+          "floor_added_to_deck": 23,
+          "id": "CARD.SHOCKWAVE"
+        },
+        {
+          "current_upgrade_level": 1,
+          "floor_added_to_deck": 27,
+          "id": "CARD.POMMEL_STRIKE"
+        },
+        {
+          "current_upgrade_level": 1,
+          "enchantment": {
+            "amount": 1,
+            "id": "ENCHANTMENT.CORRUPTED"
+          },
+          "floor_added_to_deck": 29,
+          "id": "CARD.STOMP"
+        },
+        {
+          "floor_added_to_deck": 30,
+          "id": "CARD.POMMEL_STRIKE"
+        },
+        {
+          "floor_added_to_deck": 33,
+          "id": "CARD.IMPERVIOUS"
+        },
+        {
+          "floor_added_to_deck": 35,
+          "id": "CARD.TAUNT"
+        },
+        {
+          "floor_added_to_deck": 37,
+          "id": "CARD.INFLAME"
+        }
+      ],
+      "id": "PLACEHOLDER_id",
+      "max_potion_slot_count": 2,
+      "potions": [],
+      "relics": [
+        {
+          "floor_added_to_deck": 1,
+          "id": "RELIC.BURNING_BLOOD"
+        },
+        {
+          "floor_added_to_deck": 1,
+          "id": "RELIC.PRECISE_SCISSORS"
+        },
+        {
+          "floor_added_to_deck": 10,
+          "id": "RELIC.PENDULUM"
+        },
+        {
+          "floor_added_to_deck": 12,
+          "id": "RELIC.STONE_CRACKER"
+        },
+        {
+          "floor_added_to_deck": 18,
+          "id": "RELIC.PAELS_BLOOD"
+        },
+        {
+          "floor_added_to_deck": 26,
+          "id": "RELIC.BAG_OF_MARBLES"
+        },
+        {
+          "floor_added_to_deck": 29,
+          "id": "RELIC.VENERABLE_TEA_SET",
+          "props": {
+            "bools": [
+              {
+                "name": "GainEnergyInNextCombat",
+                "value": false
+              }
+            ]
+          }
+        },
+        {
+          "floor_added_to_deck": 34,
+          "id": "RELIC.JEWELED_MASK"
+        },
+        {
+          "floor_added_to_deck": 39,
+          "id": "RELIC.BRONZE_SCALES"
+        },
+        {
+          "floor_added_to_deck": 41,
+          "id": "RELIC.PRAYER_WHEEL"
+        }
+      ]
+    }
+  ],
+  "run_time": 4891,
+  "schema_version": 8,
+  "seed": "T56EYEG207",
+  "start_time": 1775360294,
+  "was_abandoned": false,
+  "win": true
+}

--- a/apps/desktop/src/__tests__/fixtures/map-state.ts
+++ b/apps/desktop/src/__tests__/fixtures/map-state.ts
@@ -133,6 +133,7 @@ export function createPreloadedState(overrides: {
           player: null,
           mapEval,
           mapContext: null,
+          runIdSource: null,
           ...overrides.runOverrides,
         },
       },

--- a/apps/desktop/src/features/run/__tests__/invokeGetActiveRunWithRetry.test.ts
+++ b/apps/desktop/src/features/run/__tests__/invokeGetActiveRunWithRetry.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@tauri-apps/api/core", () => ({ invoke: vi.fn() }));
+import { invoke } from "@tauri-apps/api/core";
+import { invokeGetActiveRunWithRetry } from "../runAnalyticsListener";
+
+const SAMPLE = {
+  start_time: 1776540732,
+  seed: "A",
+  ascension: 10,
+  character: "CHARACTER.IRONCLAD",
+  is_mp: false,
+};
+
+describe("invokeGetActiveRunWithRetry", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns the first successful result without extra retries", async () => {
+    (invoke as ReturnType<typeof vi.fn>).mockResolvedValueOnce(SAMPLE);
+    const sleep = vi.fn().mockResolvedValue(undefined);
+    const got = await invokeGetActiveRunWithRetry(3, 1, sleep);
+    expect(got).toEqual(SAMPLE);
+    expect(invoke).toHaveBeenCalledTimes(1);
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it("retries when invoke resolves null, succeeds on third try", async () => {
+    (invoke as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(SAMPLE);
+    const sleep = vi.fn().mockResolvedValue(undefined);
+    const got = await invokeGetActiveRunWithRetry(3, 1, sleep);
+    expect(got).toEqual(SAMPLE);
+    expect(invoke).toHaveBeenCalledTimes(3);
+    expect(sleep).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns null after all attempts fail", async () => {
+    (invoke as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("nope"));
+    const sleep = vi.fn().mockResolvedValue(undefined);
+    const got = await invokeGetActiveRunWithRetry(3, 1, sleep);
+    expect(got).toBeNull();
+    expect(invoke).toHaveBeenCalledTimes(3);
+  });
+
+  it("returns null when invoke consistently resolves null", async () => {
+    (invoke as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+    const sleep = vi.fn().mockResolvedValue(undefined);
+    const got = await invokeGetActiveRunWithRetry(3, 1, sleep);
+    expect(got).toBeNull();
+    expect(invoke).toHaveBeenCalledTimes(3);
+  });
+});

--- a/apps/desktop/src/features/run/__tests__/saveFileSubscription.test.ts
+++ b/apps/desktop/src/features/run/__tests__/saveFileSubscription.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { listenMock, invokeMock } = vi.hoisted(() => ({
+  listenMock: vi.fn(),
+  invokeMock: vi.fn(),
+}));
+vi.mock("@tauri-apps/api/event", () => ({ listen: listenMock }));
+vi.mock("@tauri-apps/api/core", () => ({ invoke: invokeMock }));
+
+import { setupSaveFileSubscription } from "../saveFileSubscription";
+
+describe("setupSaveFileSubscription", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+    listenMock.mockImplementation(async () => () => {});
+  });
+
+  it("arms the watcher, runs a backfill scan, and subscribes to run-completed", async () => {
+    invokeMock.mockImplementation(async (cmd: string) => {
+      if (cmd === "start_run_history_watch") return undefined;
+      if (cmd === "list_run_history") {
+        return {
+          entries: [
+            { start_time: 1776000000, seed: "A", ascension: 4, character: "Ironclad", win: false, was_abandoned: false, killed_by_encounter: "ROOM.MONSTER", run_time: 500, build_id: "v0.103.2", act_reached: 1, players_count: 1 },
+            { start_time: 1776000100, seed: "B", ascension: 10, character: "Ironclad", win: true,  was_abandoned: false, killed_by_encounter: "NONE.NONE",     run_time: 4800, build_id: "v0.103.2", act_reached: 3, players_count: 1 },
+          ],
+          skipped: 0,
+        };
+      }
+      return undefined;
+    });
+    const dispatchAsThunk = (_a: unknown) => ({ unwrap: () => Promise.resolve(undefined) });
+
+    await setupSaveFileSubscription(dispatchAsThunk as never);
+
+    expect(invokeMock).toHaveBeenCalledWith("start_run_history_watch");
+    expect(invokeMock).toHaveBeenCalledWith(
+      "list_run_history",
+      { after_start_time: 0 }
+    );
+    expect(listenMock).toHaveBeenCalledWith("run-completed", expect.any(Function));
+    expect(localStorage.getItem("lastSyncedStartTime")).toBe("1776000100");
+  });
+
+  it("respects existing lastSyncedStartTime", async () => {
+    localStorage.setItem("lastSyncedStartTime", "1776000050");
+    invokeMock.mockImplementation(async (cmd: string) => {
+      if (cmd === "list_run_history") return { entries: [], skipped: 0 };
+      return undefined;
+    });
+    const dispatch = (_a: unknown) => ({ unwrap: () => Promise.resolve(undefined) });
+    await setupSaveFileSubscription(dispatch as never);
+    expect(invokeMock).toHaveBeenCalledWith(
+      "list_run_history",
+      { after_start_time: 1776000050 }
+    );
+  });
+});

--- a/apps/desktop/src/features/run/__tests__/should-resume-run.test.ts
+++ b/apps/desktop/src/features/run/__tests__/should-resume-run.test.ts
@@ -29,6 +29,8 @@ function makeRun(overrides: Partial<RunData> = {}): RunData {
 
 const baseArgs = {
   isFirstRunTransition: true,
+  existingRunId: null,
+  canonicalRunId: null,
   character: "The Ironclad",
   ascension: 8,
   currentFloor: 21,
@@ -118,11 +120,79 @@ describe("shouldResumeRun", () => {
       shouldResumeRun({
         isFirstRunTransition: true,
         existingRun,
+        existingRunId: null,
+        canonicalRunId: null,
         character: "The Ironclad",
         ascension: 8,
         currentFloor: 21,
         currentAct: 2,
       })
     ).toBe(true);
+  });
+});
+
+describe("shouldResumeRun with canonicalRunId", () => {
+  it("returns true when canonicalRunId matches existingRunId", () => {
+    const existing = { runIdSource: "save_file", character: "Ironclad", ascension: 10, floor: 17, act: 3, deck: [{ name: "Strike" }] } as never;
+    expect(
+      shouldResumeRun({
+        isFirstRunTransition: false,
+        existingRun: existing,
+        existingRunId: "1776540732",
+        canonicalRunId: "1776540732",
+        character: "Ironclad",
+        ascension: 10,
+        currentFloor: 17,
+        currentAct: 3,
+      })
+    ).toBe(true);
+  });
+
+  it("returns false when canonicalRunId mismatches and heuristic cannot save it (non-first transition)", () => {
+    const existing = { runIdSource: "save_file", character: "Ironclad", ascension: 10, floor: 17, act: 3, deck: [{ name: "Strike" }] } as never;
+    expect(
+      shouldResumeRun({
+        isFirstRunTransition: true,
+        existingRun: existing,
+        existingRunId: "1776540732",
+        canonicalRunId: "9999999999",
+        character: "Ironclad",
+        ascension: 10,
+        currentFloor: 17,
+        currentAct: 3,
+      })
+    ).toBe(false);
+  });
+
+  it("falls back to heuristic when canonicalRunId is null AND existing is legacy", () => {
+    const existing = { runIdSource: null, character: "Ironclad", ascension: 10, floor: 17, act: 3, deck: [{ name: "Strike" }] } as never;
+    expect(
+      shouldResumeRun({
+        isFirstRunTransition: true,
+        existingRun: existing,
+        existingRunId: "run_legacy_abc",
+        canonicalRunId: null,
+        character: "Ironclad",
+        ascension: 10,
+        currentFloor: 17,
+        currentAct: 3,
+      })
+    ).toBe(true);
+  });
+
+  it("refuses heuristic fallback when both sides have canonical ids that disagree", () => {
+    const existing = { runIdSource: "save_file", character: "Ironclad", ascension: 10, floor: 17, act: 3, deck: [{ name: "Strike" }] } as never;
+    expect(
+      shouldResumeRun({
+        isFirstRunTransition: true,
+        existingRun: existing,
+        existingRunId: "1776000000",
+        canonicalRunId: "1776540732",
+        character: "Ironclad",
+        ascension: 10,
+        currentFloor: 17,
+        currentAct: 3,
+      })
+    ).toBe(false);
   });
 });

--- a/apps/desktop/src/features/run/__tests__/should-resume-run.test.ts
+++ b/apps/desktop/src/features/run/__tests__/should-resume-run.test.ts
@@ -22,6 +22,7 @@ function makeRun(overrides: Partial<RunData> = {}): RunData {
       nodePreferences: null,
     },
     mapContext: null,
+    runIdSource: null,
     ...overrides,
   };
 }

--- a/apps/desktop/src/features/run/runAnalyticsListener.ts
+++ b/apps/desktop/src/features/run/runAnalyticsListener.ts
@@ -345,7 +345,7 @@ export function setupRunAnalyticsListener() {
           const gameMode = gameState.game_mode ?? "singleplayer";
 
           listenerApi.dispatch(
-            runStarted({ runId: newRunId, character, ascension, gameMode })
+            runStarted({ runId: newRunId, character, ascension, gameMode, runIdSource: null })
           );
 
           logDevEvent("run", "started", {

--- a/apps/desktop/src/features/run/runAnalyticsListener.ts
+++ b/apps/desktop/src/features/run/runAnalyticsListener.ts
@@ -335,11 +335,12 @@ export function setupRunAnalyticsListener() {
         // Canonical runId from the STS2 save file, if available.
         const active = await invokeGetActiveRunWithRetry();
         const canonicalRunId = active ? String(active.start_time) : null;
-        void canonicalRunId; // Task 15 will plumb this into shouldResumeRun
 
         const canResume = shouldResumeRun({
           isFirstRunTransition,
           existingRun,
+          existingRunId,
+          canonicalRunId,
           character,
           ascension,
           currentFloor,

--- a/apps/desktop/src/features/run/runAnalyticsListener.ts
+++ b/apps/desktop/src/features/run/runAnalyticsListener.ts
@@ -23,10 +23,36 @@ import { buildActPathRecord } from "@sts2/shared/choice-detection/build-act-path
 import { clearAllPendingChoices } from "@sts2/shared/choice-detection/pending-choice-registry";
 import { shouldResumeRun } from "./should-resume-run";
 import { logDevEvent, logReduxSnapshot } from "../../lib/dev-logger";
+import { invoke } from "@tauri-apps/api/core";
 import type { MapEvalState, RunData } from "./runSlice";
 
 function generateRunId(): string {
   return `run_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+}
+
+export interface ActiveRun {
+  start_time: number;
+  seed: string;
+  ascension: number;
+  character: string;
+  is_mp: boolean;
+}
+
+export async function invokeGetActiveRunWithRetry(
+  maxAttempts = 3,
+  delayMs = 3000,
+  sleepFn: (ms: number) => Promise<void> = (ms) => new Promise((r) => setTimeout(r, ms)),
+): Promise<ActiveRun | null> {
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    try {
+      const result = await invoke<ActiveRun | null>("get_active_run_identifier");
+      if (result) return result;
+    } catch (err) {
+      console.warn(`[runAnalytics] get_active_run_identifier attempt ${attempt + 1} failed`, err);
+    }
+    if (attempt < maxAttempts - 1) await sleepFn(delayMs);
+  }
+  return null;
 }
 
 /**
@@ -110,7 +136,7 @@ export function setupRunAnalyticsListener() {
 
   startAppListening({
     matcher: gameStateApi.endpoints.getGameState.matchFulfilled,
-    effect: (action, listenerApi) => {
+    effect: async (action, listenerApi) => {
       const gameState: GameState = action.payload;
       const currentType = gameState.state_type;
       const state = listenerApi.getState();
@@ -306,6 +332,11 @@ export function setupRunAnalyticsListener() {
         const currentFloor = hasRun(gameState) ? gameState.run.floor : 0;
         const currentAct = hasRun(gameState) ? gameState.run.act : 0;
 
+        // Canonical runId from the STS2 save file, if available.
+        const active = await invokeGetActiveRunWithRetry();
+        const canonicalRunId = active ? String(active.start_time) : null;
+        void canonicalRunId; // Task 15 will plumb this into shouldResumeRun
+
         const canResume = shouldResumeRun({
           isFirstRunTransition,
           existingRun,
@@ -341,11 +372,19 @@ export function setupRunAnalyticsListener() {
           initializeNarrative(existingRunId, character, ascension);
           console.log("[RunAnalytics] Resumed persisted run:", existingRunId);
         } else {
-          const newRunId = generateRunId();
+          let newRunId: string;
+          let runIdSource: "save_file" | "client_fallback";
+          if (active) {
+            newRunId = String(active.start_time);
+            runIdSource = "save_file";
+          } else {
+            newRunId = generateRunId();
+            runIdSource = "client_fallback";
+          }
           const gameMode = gameState.game_mode ?? "singleplayer";
 
           listenerApi.dispatch(
-            runStarted({ runId: newRunId, character, ascension, gameMode, runIdSource: null })
+            runStarted({ runId: newRunId, character, ascension, gameMode, runIdSource })
           );
 
           logDevEvent("run", "started", {
@@ -365,6 +404,7 @@ export function setupRunAnalyticsListener() {
                 ascension,
                 gameMode,
                 userId: getUserId(),
+                runIdSource,
               })
             )
             .unwrap()

--- a/apps/desktop/src/features/run/runSlice.ts
+++ b/apps/desktop/src/features/run/runSlice.ts
@@ -1,6 +1,8 @@
 import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
 import type { CombatCard } from "@sts2/shared/types/game-state";
 
+export type RunIdSource = "save_file" | "client_fallback" | null;
+
 // --- Run-scoped types ---
 
 export interface TrackedPlayer {
@@ -54,6 +56,7 @@ export interface RunData {
   player: TrackedPlayer | null;
   mapEval: MapEvalState;
   mapContext: MapContext | null;
+  runIdSource: RunIdSource;
 }
 
 interface CompletedRun {
@@ -93,9 +96,10 @@ export const runSlice = createSlice({
         character: string;
         ascension: number;
         gameMode: "singleplayer" | "multiplayer";
+        runIdSource: RunIdSource;
       }>
     ) {
-      const { runId, character, ascension, gameMode } = action.payload;
+      const { runId, character, ascension, gameMode, runIdSource } = action.payload;
       state.activeRunId = runId;
       state.pendingOutcome = null;
       state.lastCompletedRun = null;
@@ -115,6 +119,7 @@ export const runSlice = createSlice({
           nodePreferences: null,
         },
         mapContext: null,
+        runIdSource,
       };
     },
 

--- a/apps/desktop/src/features/run/saveFileSubscription.ts
+++ b/apps/desktop/src/features/run/saveFileSubscription.ts
@@ -1,0 +1,143 @@
+import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
+import type { AppDispatch } from "../../store/store";
+import { evaluationApi } from "../../services/evaluationApi";
+import {
+  drainPendingRunSyncs,
+  queueRunSync,
+  type PendingRunSync,
+} from "../../lib/run-sync-queue";
+
+const LAST_SYNCED_KEY = "lastSyncedStartTime";
+
+interface RunSummary {
+  start_time: number;
+  seed: string;
+  ascension: number;
+  character: string;
+  win: boolean;
+  was_abandoned: boolean;
+  killed_by_encounter: string;
+  run_time: number;
+  build_id: string;
+  act_reached: number;
+  players_count: number;
+}
+
+interface RunHistoryListing {
+  entries: RunSummary[];
+  skipped: number;
+}
+
+function loadLastSynced(): number {
+  const raw = localStorage.getItem(LAST_SYNCED_KEY);
+  const n = raw ? Number(raw) : 0;
+  return Number.isFinite(n) ? n : 0;
+}
+
+function saveLastSynced(ts: number) {
+  localStorage.setItem(LAST_SYNCED_KEY, String(ts));
+}
+
+function summaryToSyncs(s: RunSummary): PendingRunSync[] {
+  const runId = String(s.start_time);
+  const gameMode: "singleplayer" | "multiplayer" =
+    s.players_count > 1 ? "multiplayer" : "singleplayer";
+  const cause =
+    s.killed_by_encounter && s.killed_by_encounter !== "NONE.NONE"
+      ? s.killed_by_encounter
+      : null;
+  const notes = s.was_abandoned ? "save_file: abandoned" : null;
+  return [
+    {
+      action: "start",
+      runId,
+      character: s.character,
+      ascension: s.ascension,
+      gameMode,
+      runIdSource: "save_file",
+    },
+    {
+      action: "end",
+      runId,
+      victory: s.win,
+      actReached: s.act_reached,
+      causeOfDeath: cause,
+      notes,
+      runIdSource: "save_file",
+    },
+  ];
+}
+
+async function sendViaDispatch(dispatch: AppDispatch, entry: PendingRunSync): Promise<void> {
+  if (entry.action === "start") {
+    await dispatch(
+      evaluationApi.endpoints.startRun.initiate({
+        runId: entry.runId,
+        character: entry.character,
+        ascension: entry.ascension,
+        gameMode: entry.gameMode,
+        userId: null,
+        runIdSource: entry.runIdSource ?? null,
+      })
+    ).unwrap();
+  } else {
+    await dispatch(
+      evaluationApi.endpoints.endRun.initiate({
+        runId: entry.runId,
+        victory: entry.victory ?? undefined,
+        actReached: entry.actReached ?? undefined,
+        causeOfDeath: entry.causeOfDeath ?? null,
+        notes: entry.notes ?? undefined,
+        runIdSource: entry.runIdSource ?? null,
+      })
+    ).unwrap();
+  }
+}
+
+export async function setupSaveFileSubscription(dispatch: AppDispatch) {
+  try {
+    await invoke("start_run_history_watch");
+  } catch (err) {
+    console.info("[saveFileSubscription] start_run_history_watch skipped", err);
+  }
+
+  await drainPendingRunSyncs((entry) => sendViaDispatch(dispatch, entry));
+
+  const lastSynced = loadLastSynced();
+  try {
+    const listing = await invoke<RunHistoryListing>("list_run_history", {
+      after_start_time: lastSynced,
+    });
+    for (const summary of listing.entries) {
+      for (const sync of summaryToSyncs(summary)) {
+        try {
+          await sendViaDispatch(dispatch, sync);
+        } catch (err) {
+          console.warn("[saveFileSubscription] backfill post failed; queueing", err);
+          queueRunSync(sync);
+        }
+      }
+      if (summary.start_time > lastSynced) {
+        saveLastSynced(summary.start_time);
+      }
+    }
+  } catch (err) {
+    console.info("[saveFileSubscription] list_run_history skipped", err);
+  }
+
+  await listen<RunSummary>("run-completed", async (event) => {
+    const summary = event.payload;
+    for (const sync of summaryToSyncs(summary)) {
+      try {
+        await sendViaDispatch(dispatch, sync);
+      } catch (err) {
+        console.warn("[saveFileSubscription] live post failed; queueing", err);
+        queueRunSync(sync);
+      }
+    }
+    if (summary.start_time > loadLastSynced()) {
+      saveLastSynced(summary.start_time);
+    }
+  });
+}

--- a/apps/desktop/src/features/run/should-resume-run.ts
+++ b/apps/desktop/src/features/run/should-resume-run.ts
@@ -1,40 +1,50 @@
 import type { RunData } from "./runSlice";
 
 export interface ShouldResumeRunArgs {
-  /** True only on the first menu→in-run transition of the current app session. */
   isFirstRunTransition: boolean;
-  /** Persisted run loaded from localStorage, or null if none. */
   existingRun: RunData | null;
-  /** Character reported by the current game state poll. */
+  /** The runId key under which `existingRun` is stored in state.run.runs. */
+  existingRunId: string | null;
+  /** Canonical runId from the STS2 save file, if available. */
+  canonicalRunId: string | null;
   character: string;
-  /** Ascension reported by the current game state poll. */
   ascension: number;
-  /** Floor reported by the current game state poll. */
   currentFloor: number;
-  /** Act reported by the current game state poll. */
   currentAct: number;
 }
 
-/**
- * Decide whether the persisted run should be resumed instead of starting a new one.
- *
- * Resume is allowed only on the first in-run transition of a session to avoid
- * re-resuming after the user legitimately starts a new run mid-session. A full
- * character + ascension + floor + act match protects against picking up a
- * stale run when the user starts a brand-new run as the same character.
- *
- * Deck must already be populated because the STS2 mod only exposes master deck
- * data via combat piles or card_select screens — without a persisted deck we
- * cannot rebuild it from non-combat states.
- */
 export function shouldResumeRun({
   isFirstRunTransition,
   existingRun,
+  existingRunId,
+  canonicalRunId,
   character,
   ascension,
   currentFloor,
   currentAct,
 }: ShouldResumeRunArgs): boolean {
+  // Canonical path: if the save file reports an id that matches the
+  // persisted run, resume regardless of heuristic fields.
+  if (canonicalRunId && existingRun && existingRunId === canonicalRunId) {
+    return true;
+  }
+
+  // Anti-false-match guard: if we have a canonical id AND the persisted
+  // run was also canonically-sourced AND they disagree, this is a new run.
+  // Don't fall through to the heuristic — doing so would risk picking up
+  // a stale same-character run whose floor/act accidentally collide.
+  if (
+    canonicalRunId &&
+    existingRun &&
+    existingRun.runIdSource === "save_file" &&
+    existingRunId !== canonicalRunId
+  ) {
+    return false;
+  }
+
+  // Legacy heuristic path: first transition + exact match on character +
+  // ascension + floor + act + non-empty deck. Only applies to legacy
+  // (runIdSource === null) persisted runs.
   if (!isFirstRunTransition) return false;
   if (!existingRun) return false;
   if (existingRun.character !== character) return false;

--- a/apps/desktop/src/lib/__tests__/run-sync-queue.test.ts
+++ b/apps/desktop/src/lib/__tests__/run-sync-queue.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  queueRunSync,
+  readPendingRunSyncs,
+  drainPendingRunSyncs,
+  PENDING_RUN_SYNCS_KEY,
+  MAX_QUEUE,
+} from "../run-sync-queue";
+
+describe("run-sync-queue", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("queues, reads, and drains in FIFO order", async () => {
+    queueRunSync({ action: "start", runId: "a", character: "Ironclad", ascension: 0, gameMode: "singleplayer" });
+    queueRunSync({ action: "end", runId: "a", victory: true });
+    expect(readPendingRunSyncs()).toHaveLength(2);
+
+    const send = vi.fn().mockResolvedValue(undefined);
+    await drainPendingRunSyncs(send);
+
+    expect(send).toHaveBeenCalledTimes(2);
+    expect((send.mock.calls[0][0] as { action: string }).action).toBe("start");
+    expect((send.mock.calls[1][0] as { action: string }).action).toBe("end");
+    expect(readPendingRunSyncs()).toHaveLength(0);
+  });
+
+  it("drops oldest when queue exceeds MAX_QUEUE", () => {
+    for (let i = 0; i < MAX_QUEUE + 5; i++) {
+      queueRunSync({ action: "start", runId: `r${i}`, character: "Ironclad", ascension: 0, gameMode: "singleplayer" });
+    }
+    const q = readPendingRunSyncs();
+    expect(q).toHaveLength(MAX_QUEUE);
+    expect(q[0].runId).toBe("r5");
+  });
+
+  it("leaves items in queue if send fails, preserving order", async () => {
+    queueRunSync({ action: "start", runId: "a", character: "Ironclad", ascension: 0, gameMode: "singleplayer" });
+    queueRunSync({ action: "end", runId: "a", victory: true });
+
+    const send = vi.fn()
+      .mockResolvedValueOnce(undefined) // 'start' succeeds
+      .mockRejectedValueOnce(new Error("network down")); // 'end' fails
+
+    await drainPendingRunSyncs(send);
+
+    const remaining = readPendingRunSyncs();
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0].action).toBe("end");
+  });
+
+  it("uses the correct localStorage key", () => {
+    expect(PENDING_RUN_SYNCS_KEY).toBe("pendingRunSyncs");
+  });
+});

--- a/apps/desktop/src/lib/run-sync-queue.ts
+++ b/apps/desktop/src/lib/run-sync-queue.ts
@@ -1,0 +1,66 @@
+export const PENDING_RUN_SYNCS_KEY = "pendingRunSyncs";
+export const MAX_QUEUE = 100;
+
+export type PendingRunSync =
+  | {
+      action: "start";
+      runId: string;
+      character: string;
+      ascension: number;
+      gameMode: "singleplayer" | "multiplayer";
+      runIdSource?: "save_file" | "client_fallback" | null;
+      gameVersion?: string | null;
+    }
+  | {
+      action: "end";
+      runId: string;
+      victory?: boolean | null;
+      actReached?: number | null;
+      causeOfDeath?: string | null;
+      notes?: string | null;
+      finalFloor?: number | null;
+      runIdSource?: "save_file" | "client_fallback" | null;
+    };
+
+export function readPendingRunSyncs(): PendingRunSync[] {
+  const raw = localStorage.getItem(PENDING_RUN_SYNCS_KEY);
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? (parsed as PendingRunSync[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+function write(queue: PendingRunSync[]) {
+  localStorage.setItem(PENDING_RUN_SYNCS_KEY, JSON.stringify(queue));
+}
+
+export function queueRunSync(entry: PendingRunSync) {
+  const queue = readPendingRunSyncs();
+  queue.push(entry);
+  while (queue.length > MAX_QUEUE) queue.shift();
+  write(queue);
+}
+
+/**
+ * Try to send each queued entry. Stops on first failure to preserve ordering.
+ * Successful sends are removed from the queue.
+ */
+export async function drainPendingRunSyncs(
+  send: (entry: PendingRunSync) => Promise<void>
+) {
+  const queue = readPendingRunSyncs();
+  while (queue.length) {
+    const head = queue[0];
+    try {
+      await send(head);
+      queue.shift();
+      write(queue);
+    } catch (err) {
+      console.warn("[run-sync-queue] send failed; leaving in queue", err);
+      break;
+    }
+  }
+}

--- a/apps/desktop/src/services/evaluationApi.ts
+++ b/apps/desktop/src/services/evaluationApi.ts
@@ -279,7 +279,7 @@ export const evaluationApi = createApi({
     }),
 
     // Run API calls
-    startRun: build.mutation<void, { runId: string; character: string; ascension: number; gameMode: string; userId: string | null }>({
+    startRun: build.mutation<void, { runId: string; character: string; ascension: number; gameMode: string; userId: string | null; runIdSource?: "save_file" | "client_fallback" | null }>({
       async queryFn(args) {
         try {
           await apiFetch("/api/run", {
@@ -305,6 +305,7 @@ export const evaluationApi = createApi({
       finalDeckSize?: number | null;
       narrative?: unknown;
       notes?: string;
+      runIdSource?: "save_file" | "client_fallback" | null;
     }>({
       async queryFn(args) {
         try {

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -18,6 +18,7 @@ import { setupChoiceTrackingListener } from "../features/choice/choiceTrackingLi
 import { setupMapEvalListener } from "../features/map/mapListeners";
 import { setupEvaluationListeners } from "../features/evaluation/evaluationListeners";
 import { setupGameStateSubscription } from "../features/connection/gameStateSubscription";
+import { setupSaveFileSubscription } from "../features/run/saveFileSubscription";
 
 const rootReducer = combineSlices(
   gameStateApi,
@@ -51,6 +52,9 @@ setupMapEvalListener();
 setupEvaluationListeners();
 setupGameStateSubscription(store.dispatch).catch((err) => {
   console.error("[gameStateSubscription] setup failed", err);
+});
+setupSaveFileSubscription(store.dispatch).catch((err) => {
+  console.error("[saveFileSubscription] setup failed", err);
 });
 
 export type RootState = ReturnType<typeof store.getState>;

--- a/apps/web/src/app/api/run/route.ts
+++ b/apps/web/src/app/api/run/route.ts
@@ -10,6 +10,7 @@ const startSchema = z.object({
   ascension: z.number().int().min(0).optional(),
   gameVersion: z.string().nullable().optional(),
   gameMode: z.enum(["singleplayer", "multiplayer"]).optional(),
+  runIdSource: z.enum(["save_file", "client_fallback"]).nullable().optional(),
 });
 
 const endSchema = z.object({
@@ -25,6 +26,7 @@ const endSchema = z.object({
   actReached: z.number().int().nullable().optional(),
   causeOfDeath: z.string().nullable().optional(),
   narrative: z.unknown().nullable().optional(),
+  runIdSource: z.enum(["save_file", "client_fallback"]).nullable().optional(),
 });
 
 export async function POST(request: Request) {
@@ -51,6 +53,7 @@ export async function POST(request: Request) {
       game_version: d.gameVersion ?? null,
       game_mode: d.gameMode ?? "singleplayer",
       user_id: auth.userId,
+      run_id_source: d.runIdSource ?? null,
     });
 
     if (error) {
@@ -84,6 +87,7 @@ export async function POST(request: Request) {
     if (d.actReached !== undefined) update.act_reached = d.actReached;
     if (d.causeOfDeath !== undefined) update.cause_of_death = d.causeOfDeath;
     if (d.narrative !== undefined) update.narrative = d.narrative;
+    if (d.runIdSource !== undefined) update.run_id_source = d.runIdSource;
 
     const { error } = await supabase
       .from("runs")

--- a/supabase/migrations/027_add_run_id_source.sql
+++ b/supabase/migrations/027_add_run_id_source.sql
@@ -1,0 +1,8 @@
+-- Add run_id_source column to runs. NULL means legacy client-minted;
+-- 'save_file' means canonical (derived from STS2 save-file start_time);
+-- 'client_fallback' means the save reader was unavailable at detection time.
+ALTER TABLE public.runs
+  ADD COLUMN IF NOT EXISTS run_id_source text;
+
+COMMENT ON COLUMN public.runs.run_id_source IS
+  'Provenance of run_id: NULL=legacy client-minted, save_file=canonical (start_time), client_fallback=save reader unavailable.';


### PR DESCRIPTION
Closes #89
Unblocks #74 (SP victory detection via watcher instead of `inferRunOutcome` heuristics).

Implements Phase 1 + Phase 2 of #75. Rust reads the STS2 save directory + watches `history/` via the `notify` crate; the frontend uses the save-file `start_time` as the canonical runId and treats the history-watcher event as the authoritative SP end-of-run signal. The legacy `inferRunOutcome` path is intact for MP (Phase 3).

## What changed

**Rust:**
- `save_file.rs` — pure parser for `.run` + active-save files (`parse_run_file`, `parse_active_save`). Tolerant of schema-version drift via `#[serde(default)]` on all optional fields.
- `save_dir.rs` — path resolution. Picks the most-recently-modified numeric steam-user-id dir, falls back from `modded/profile1/saves` to `profile1/saves`.
- `save_watcher.rs` — `notify`-based `history/` watcher with supervisor (respawn on panic), emits `"run-completed"` Tauri events. `AtomicBool::compare_exchange` for idempotent arming.
- Three new Tauri commands: `get_active_run_identifier`, `list_run_history`, `start_run_history_watch`. Setup hook spawns the watcher on app boot.

**Frontend:**
- `saveFileSubscription.ts` — startup-scan + `"run-completed"` listener, POSTs each run via existing RTK mutations.
- `runAnalyticsListener.ts` — calls `invokeGetActiveRunWithRetry()` (3× retry over 9s, then `client_fallback`) BEFORE `shouldResumeRun`; canonical `start_time` becomes the new runId.
- `should-resume-run.ts` — canonical-match short-circuit, anti-false-match guard when both sides have canonical ids that disagree.
- `run-sync-queue.ts` — localStorage-backed retry queue for offline-tolerant POSTs.
- `runSlice.ts` — new `runIdSource` field on `RunData` (`save_file | client_fallback | null`).

**API + DB:**
- New `run_id_source TEXT` column on `runs` (nullable = legacy). Migration 027 already applied to prod.
- `/api/run` accepts `runIdSource` on both `start` and `end` actions.

## Test plan

- [x] Rust unit tests: 20 passing (parse fixtures, path resolution, watcher pipeline)
- [x] Frontend unit tests: 252 passing across 28 files (parseRetry, subscription, resume-canonical, sync queue)
- [x] Typecheck: `pnpm lint` clean
- [x] Manual: watcher arms and emits `"run-completed"` on new `history/*.run` (verified via logs)
- [x] Manual: SP run detected with canonical `start_time` runId + `runIdSource: 'save_file'`
- [x] Manual: backfill scan picks up runs completed while app was closed
- [x] Manual: MP run still flows through `inferRunOutcome` path (unchanged)
- [ ] SP win victory path in prod

## Known deviations from plan

- `should-resume-run.ts` uses a separate `existingRunId: string | null` arg rather than `existingRun.runId`. Functionally equivalent; both fields exist on the actual call site. Harmless.
- DB migration placed at repo-root `supabase/migrations/027_add_run_id_source.sql` to match the existing numbering convention (plan said `apps/web/supabase/migrations/` but that directory doesn't exist).

## Out of scope

- **Multiplayer tracking** — MP runs never land in local `history/`, so the save-file path can't cover them. Phase 3 of #75 will address this (likely via helper-side parallel history).
- **Backfill of historical runs** — existing 114+ SP runs with no DB twin stay orphaned on disk. Opt-in Settings action is a follow-up.
- **Retiring the legacy heuristic entirely** in `should-resume-run` — kept as a fallback for legacy (`runIdSource=null`) persisted runs.

Spec: `docs/superpowers/specs/2026-04-19-save-file-canonical-runid-design.md`
Plan: `docs/superpowers/plans/2026-04-19-save-file-canonical-runid.md`