### PR TITLE
chore(map-coach): batch B — telemetry + adapter cleanup (#76, #77, #78, #85)

### DIFF
--- a/apps/desktop/src/features/map/mapListeners.ts
+++ b/apps/desktop/src/features/map/mapListeners.ts
@@ -128,6 +128,33 @@ export function setupMapEvalListener() {
       const evalKey = computeMapEvalKey(options);
       const isRetry = evalRetryRequested.match(_action) && _action.payload === EVAL_TYPE;
 
+      // #77: populate the run-state cache eagerly so the map_node choice
+      // write path always has a non-null snapshot to persist — even on the
+      // first move of a run, or when the eval is gated off
+      // (allOptionsAreAncient, grace-skip, single-option-on-path). Cost is a
+      // synchronous buildMapPrompt call (no network); the resulting prompt
+      // is only used by the downstream eval path, which still runs when
+      // un-gated. Downstream path re-reads the cache.
+      const activeRunIdForEagerCache = state.run.activeRunId;
+      if (activeRunIdForEagerCache && options.length > 0) {
+        try {
+          const eagerDeckCards = selectActiveDeck(state);
+          const eagerPlayer = selectActivePlayer(state);
+          const eagerCtx = buildEvaluationContext(gameState, eagerDeckCards, eagerPlayer);
+          if (eagerCtx) {
+            const { runState: eagerRunState } = buildMapPrompt({
+              context: eagerCtx,
+              state: mapState,
+              cardRemovalCost: eagerPlayer?.cardRemovalCost ?? null,
+            });
+            lastMapRunState.set(activeRunIdForEagerCache, eagerRunState);
+          }
+        } catch {
+          // buildMapPrompt can throw on unusual state shapes; swallow so
+          // the cache-miss is the worst case rather than a listener crash.
+        }
+      }
+
       // --- Should we evaluate? ---
       // Check BEFORE cancelling — don't cancel an in-flight eval
       // just to decide we don't need a new one.
@@ -479,7 +506,6 @@ export function setupMapEvalListener() {
               mapPrompt,
               runId: null,
               gameVersion: null,
-              runStateSnapshot: runState,
               mapCompliance,
             })
           )
@@ -545,12 +571,18 @@ export function setupMapEvalListener() {
         }));
         logReduxSnapshot(listenerApi as unknown as { getState: () => unknown }, "after_map_eval");
 
+        // #78: stash the full parsed coach output in `raw` so phase-2
+        // calibration can recover reasoning/branches/callouts later.
+        // `allRankings` intrinsically doesn't apply to map (no per-item
+        // rankings); leaving it as [] is correct for the choice-tracker
+        // read path, which doesn't consult it for map evals.
         registerLastEvaluation("map", {
           recommendedId: bestOpt ? `${bestOpt.col},${bestOpt.row}` : null,
           recommendedTier: null,
           reasoning: parsed.headline,
           allRankings: [],
           evalType: "map",
+          raw: parsed,
         });
 
         // Backfill: if user picked a map node before eval completed

--- a/apps/desktop/src/services/evaluationApi.ts
+++ b/apps/desktop/src/services/evaluationApi.ts
@@ -54,8 +54,10 @@ interface MapPromptRequest extends EvalRequestBase {
   evalType?: string;
   mapPrompt: string;
   /**
-   * Optional run-state snapshot computed desktop-side for map coach evals.
-   * Echoed by the server and forwarded to `/api/choice` for persistence.
+   * Map coach run-state snapshot. Persisted to `/api/choice` by
+   * `mapListeners`; no longer sent to `/api/evaluate` because the server
+   * never read it (#76). Field kept on this interface only to document
+   * the data lives in `lastMapRunState` on the desktop side.
    */
   runStateSnapshot?: unknown;
   /**
@@ -211,8 +213,9 @@ export const evaluationApi = createApi({
     }),
 
     // Map coach evaluation — parses with zod then transforms snake→camel.
-    // Server also echoes the desktop-computed `runStateSnapshot` back so the
-    // caller can forward it to `/api/choice` for persistence.
+    // Desktop-computed `runStateSnapshot` is cached locally (see
+    // `lastMapRunState` in `mapListeners`) and sent directly to `/api/choice`;
+    // it is NOT round-tripped through the server (#76).
     evaluateMap: build.mutation<MapCoachEvaluation, MapPromptRequest>({
       async queryFn(args) {
         try {
@@ -224,14 +227,9 @@ export const evaluationApi = createApi({
             mapPrompt: args.mapPrompt,
             runId: args.runId,
             gameVersion: args.gameVersion,
-            runStateSnapshot: args.runStateSnapshot,
             mapCompliance: args.mapCompliance,
           });
-          // Server response is map-coach output + optional `runStateSnapshot`
-          // echo. Strip the echo before zod-parsing since the schema is strict.
-          const { runStateSnapshot: _echo, ...rest } = (raw as Record<string, unknown>) ?? {};
-          void _echo;
-          const parsed = mapCoachOutputSchema.parse(rest);
+          const parsed = mapCoachOutputSchema.parse(raw);
           return { data: adaptMapCoach(parsed) };
         } catch (err) {
           return { error: { status: "CUSTOM_ERROR", data: err instanceof Error ? err.message : "Eval failed" } };

--- a/apps/web/src/app/api/evaluate/route.ts
+++ b/apps/web/src/app/api/evaluate/route.ts
@@ -257,10 +257,12 @@ interface EvaluateRequest {
   goldBudget?: number | null;
   /**
    * Optional run-state snapshot computed desktop-side (map coach phase 1).
-   * The server doesn't currently have the raw game state in the request body,
-   * so `RunState` is computed once on the desktop inside `buildMapPrompt` and
-   * echoed back in the response here. See the task-6 DONE_WITH_CONCERNS note
-   * for the duplication trade-off.
+   * Historically this field was accepted and echoed back so the desktop
+   * could forward it to `/api/choice`. Echo removed in #76 — desktop now
+   * caches its locally-computed `RunState` directly (see `lastMapRunState`
+   * in `mapListeners.ts`) so the round-trip through the server is unused.
+   * Kept as an optional field so older clients still parse, but it's no
+   * longer read on the response path.
    */
   runStateSnapshot?: unknown;
   /**
@@ -592,10 +594,7 @@ export async function POST(request: Request) {
         // inside buildMapPrompt, and duplicating the builder on the server
         // (without raw state in the request body) would add surface area
         // without value. Noted as a known follow-up.
-        return NextResponse.json({
-          ...finalOutput,
-          runStateSnapshot: body.runStateSnapshot ?? null,
-        });
+        return NextResponse.json(finalOutput);
       }
 
       const result = isSimpleEval
@@ -646,10 +645,7 @@ export async function POST(request: Request) {
                 }
                 const sanitized = sanitizeMapCoachOutput(parsed);
                 const finalOutput = applyMapCompliance(sanitized, body.mapCompliance);
-                return NextResponse.json({
-                  ...finalOutput,
-                  runStateSnapshot: body.runStateSnapshot ?? null,
-                });
+                return NextResponse.json(finalOutput);
               }
               const schema = isSimpleEval ? simpleEvalSchema : genericEvalSchema;
               const parsed = schema.parse(repairedJson);

--- a/packages/shared/evaluation/last-evaluation-registry.ts
+++ b/packages/shared/evaluation/last-evaluation-registry.ts
@@ -9,6 +9,13 @@ interface LastEvaluation {
   reasoning: string;
   allRankings: { itemId: string; itemName: string; tier: string; recommendation: string }[];
   evalType: string;
+  /**
+   * Full raw evaluation payload for consumers that need more than the
+   * reduced-for-choice-tracking summary above. Phase-2 calibration reads
+   * this to recover the coach's full reasoning/branches/callouts for map
+   * evals where `allRankings` is intrinsically empty. See #78.
+   */
+  raw?: unknown;
 }
 
 const registry = new Map<string, LastEvaluation>();

--- a/packages/shared/evaluation/map-coach-schema.ts
+++ b/packages/shared/evaluation/map-coach-schema.ts
@@ -26,15 +26,10 @@ const nodeTypeEnum = z.enum([
 
 export type MapNodeType = z.infer<typeof nodeTypeEnum>;
 
-const repairReasonKindEnum = z.enum([
-  "empty_macro_path",
-  "unknown_node_id",
-  "first_floor_mismatch",
-  "contiguity_gap",
-  "missing_boss",
-  "walk_dead_end",
-  "starts_at_current_position",
-]);
+// Derived from REPAIR_REASON_KINDS — compliance-report.ts is the source of
+// truth. Adding a kind there automatically flows to the wire schema.
+import { REPAIR_REASON_KINDS } from "./map/compliance-report";
+const repairReasonKindEnum = z.enum(REPAIR_REASON_KINDS);
 
 /**
  * Soft caps applied post-parse. Hard limits (number range, array length) are

--- a/packages/shared/evaluation/map/compliance-report.ts
+++ b/packages/shared/evaluation/map/compliance-report.ts
@@ -6,14 +6,22 @@ import type { MapCoachOutputRaw } from "../map-coach-schema";
  * rerank-if-dominated, and the evaluate route handler.
  */
 
-export type RepairReasonKind =
-  | "empty_macro_path"
-  | "unknown_node_id"
-  | "first_floor_mismatch"
-  | "contiguity_gap"
-  | "missing_boss"
-  | "walk_dead_end"
-  | "starts_at_current_position";
+/**
+ * Source of truth for repair-reason kinds. Exported as a `const` tuple so
+ * the zod enum in `map-coach-schema.ts` can derive from it (see issue #85).
+ * Adding a new kind HERE automatically flows to the wire schema.
+ */
+export const REPAIR_REASON_KINDS = [
+  "empty_macro_path",
+  "unknown_node_id",
+  "first_floor_mismatch",
+  "contiguity_gap",
+  "missing_boss",
+  "walk_dead_end",
+  "starts_at_current_position",
+] as const;
+
+export type RepairReasonKind = (typeof REPAIR_REASON_KINDS)[number];
 
 export interface RepairReason {
   kind: RepairReasonKind;


### PR DESCRIPTION
Closes #76, #77, #78, #85, #94 (the batch tracker).

## Changes

**#76** — drop redundant \`runStateSnapshot\` echo through \`/api/evaluate\`. Server never read the field; desktop already caches locally and forwards to \`/api/choice\` directly. Removed from request body, response body, adapter strip, and the evaluateMap call site.

**#77** — populate \`lastMapRunState\` eagerly at the top of the map listener, before any gate logic. Previously the cache only wrote inside the eval-proceed path, so the first \`map_node\` choice per run (and any choice after a gated-off eval) persisted \`run_state_snapshot: null\`. Now every map-state arrival triggers a synchronous buildMapPrompt + cache-set.

**#78** — stash the parsed \`MapCoachOutputRaw\` in \`LastEvaluation.raw\` when registering a map eval. Preserves reasoning / macro_path / branches / callouts for phase-2 calibration; \`allRankings\` stays empty (correct for map).

**#85** — export \`REPAIR_REASON_KINDS\` as a source-of-truth tuple in \`compliance-report.ts\`; derive the zod enum in \`map-coach-schema.ts\` from it via \`z.enum([...REPAIR_REASON_KINDS])\`. Adding a kind automatically flows to both the TS union and the wire schema.

## Test plan

- [x] \`pnpm turbo test\` — 413 web, 268 desktop tests pass
- [x] \`pnpm -r exec tsc --noEmit\` clean
- [ ] Manual smoke: trigger a map eval with a gated first update (ancient-only row, grace-skip); verify \`choices.run_state_snapshot\` is non-null on the first \`map_node\` choice write

## Related

- Batch A (direct to main): #81, #87 docs
- Deferred to #93: #84, #86
- Coming in batch C: #80, #88 (tests)
- Coming in batch D: #79 (backtest replay)