### PR TITLE
fix: stuck ascension wins (#74) + boss-next distance on rest sites (#72)

### DIFF
--- a/apps/desktop/src/__tests__/fixtures/map-state.ts
+++ b/apps/desktop/src/__tests__/fixtures/map-state.ts
@@ -29,9 +29,12 @@ export const TEST_BOSS = { col: 1, row: 3 };
 // --- Map State Factory ---
 
 export function createMapState(
-  overrides: Partial<MapState["map"]> & { player?: MapState["player"] } = {},
+  overrides: Partial<MapState["map"]> & {
+    player?: MapState["player"];
+    run?: MapState["run"];
+  } = {},
 ): MapState & MultiplayerFields {
-  const { player, ...mapOverrides } = overrides;
+  const { player, run, ...mapOverrides } = overrides;
   return {
     state_type: "map",
     player: player ?? {
@@ -51,7 +54,7 @@ export function createMapState(
       boss: TEST_BOSS,
       ...mapOverrides,
     },
-    run: { act: 1, floor: 1, ascension: 0 },
+    run: run ?? { act: 1, floor: 1, ascension: 0 },
   };
 }
 

--- a/apps/desktop/src/lib/__tests__/build-map-context.test.ts
+++ b/apps/desktop/src/lib/__tests__/build-map-context.test.ts
@@ -165,13 +165,60 @@ describe("buildMapContext", () => {
   describe("floorsToNextBoss", () => {
     it("calculates distance from current position to boss", () => {
       const result = buildMapContext(createMapState());
-      // Default: current row 0, boss row 3
+      // Default: current row 0, boss row 3, run.floor 1 → min(17-1, 3-0) = 3
       expect(result.floorsToNextBoss).toBe(3);
     });
 
     it("uses row 0 when current_position is null", () => {
       const state = createMapState({ current_position: null });
       expect(buildMapContext(state).floorsToNextBoss).toBe(TEST_BOSS.row);
+    });
+
+    // #72: rest site on Act 1 floor 16 — boss is next floor (17) but
+    // current_position.row can still point to the last combat node. Row
+    // math returns 3+; run.floor against the boss floor table returns 1.
+    // The fixed floor table wins, correctly reporting "boss is next".
+    it("returns 1 when on floor 16 rest site even when current_position.row lags", () => {
+      const state = createMapState({
+        current_position: { col: 1, row: 12, type: "Monster" },
+        boss: { col: 1, row: 15 },
+        run: { act: 1, floor: 16, ascension: 10 },
+      });
+      expect(buildMapContext(state).floorsToNextBoss).toBe(1);
+    });
+
+    it("returns 0 when on the boss floor itself (floor 17)", () => {
+      const state = createMapState({
+        current_position: { col: 1, row: 15, type: "Boss" },
+        boss: { col: 1, row: 15 },
+        run: { act: 1, floor: 17, ascension: 10 },
+      });
+      expect(buildMapContext(state).floorsToNextBoss).toBe(0);
+    });
+
+    it("returns 14 floors to the Act 2 boss from floor 20", () => {
+      // Act 2 boss is global floor 34; current floor 20 → 14 floors away.
+      // Row math would report 14 from null current_position + bossRow 14,
+      // which coincides — either way the correct answer is 14.
+      const state = createMapState({
+        current_position: null,
+        boss: { col: 1, row: 14 },
+        run: { act: 2, floor: 20, ascension: 10 },
+      });
+      expect(buildMapContext(state).floorsToNextBoss).toBe(14);
+    });
+
+    it("prefers the smaller value when row math and floor math disagree", () => {
+      // If row math claims closer distance than floor math, trust it.
+      // This happens on maps where rows are compressed or the boss was
+      // surfaced unusually close.
+      const state = createMapState({
+        current_position: { col: 1, row: 14, type: "Monster" },
+        boss: { col: 1, row: 15 },
+        run: { act: 1, floor: 15, ascension: 10 },
+      });
+      // Floor math: 17 - 15 = 2. Row math: 15 - 14 = 1. Min = 1.
+      expect(buildMapContext(state).floorsToNextBoss).toBe(1);
     });
   });
 });

--- a/apps/desktop/src/lib/__tests__/infer-run-outcome.test.ts
+++ b/apps/desktop/src/lib/__tests__/infer-run-outcome.test.ts
@@ -68,6 +68,45 @@ describe("inferRunOutcome", () => {
         lastAct: 3,
       })).toBeNull();
     });
+
+    // #74: STS2 sometimes jumps from the final boss fight directly to
+    // menu without emitting combat_rewards. Previously this stranded
+    // ascension wins on the "Run paused" screen.
+    it("detects victory from menu transition with cleared act 3 boss", () => {
+      expect(outcome({
+        currentStateType: "menu",
+        lastWasBoss: true,
+        lastEnemiesAllDead: true,
+        lastAct: 3,
+      })).toBe("victory");
+    });
+
+    it("does NOT detect victory from menu transition after an act 2 boss", () => {
+      expect(outcome({
+        currentStateType: "menu",
+        lastWasBoss: true,
+        lastEnemiesAllDead: true,
+        lastAct: 2,
+      })).toBeNull();
+    });
+
+    it("does NOT detect victory from menu transition without boss context", () => {
+      expect(outcome({
+        currentStateType: "menu",
+        lastWasBoss: false,
+        lastEnemiesAllDead: true,
+        lastAct: 3,
+      })).toBeNull();
+    });
+
+    it("does NOT detect victory from menu transition when enemies were not all dead", () => {
+      expect(outcome({
+        currentStateType: "menu",
+        lastWasBoss: true,
+        lastEnemiesAllDead: false,
+        lastAct: 3,
+      })).toBeNull();
+    });
   });
 
   describe("defeat detection", () => {

--- a/apps/desktop/src/lib/build-map-context.ts
+++ b/apps/desktop/src/lib/build-map-context.ts
@@ -1,10 +1,39 @@
 import type { MapState, MapNode, MapNextOption } from "@sts2/shared/types/game-state";
 import type { MapContext } from "../features/run/runSlice";
 
+/**
+ * Cumulative STS2 act boss floors. Matches the pattern already used in
+ * `restSiteEvalListener.ts:57` (`[17, 34, 51]`). `run.floor` is global
+ * across acts (floor 18 = Act 2 floor 1; floor 35 = Act 3 floor 1).
+ * Used as the primary signal for `floorsToNextBoss` because `run.floor`
+ * stays in sync with the UI while `current_position.row` lags when the
+ * player is on a non-combat screen (rest site, shop, event) — see #72.
+ */
+const ACT_BOSS_FLOORS = [17, 34, 51] as const;
+
+function floorsToNextBossFloor(currentFloor: number): number | null {
+  const next = ACT_BOSS_FLOORS.find((bf) => bf >= currentFloor);
+  return next != null ? next - currentFloor : null;
+}
+
 export function buildMapContext(mapState: MapState): MapContext {
   const currentRow = mapState.map.current_position?.row ?? 0;
   const bossRow = mapState.map.boss.row;
   const nextNodeTypes = mapState.map.next_options.map((o) => o.type);
+
+  // #72: prefer `run.floor` against the known boss floors over raw row
+  // subtraction. `current_position.row` is stale on non-combat screens
+  // (rest, shop, event) — it still reflects the last combat node — so
+  // `bossRow - currentRow` can report 3+ when the boss is literally next.
+  // `run.floor` matches the UI and updates immediately. Take the min of
+  // the two signals so if the row math reports a closer distance (the
+  // player already advanced but the floor table hasn't caught up) we
+  // still surface the "boss is near" signal.
+  const runFloor = mapState.run?.floor ?? 0;
+  const floorsByFloorTable = floorsToNextBossFloor(runFloor);
+  const floorsByRow = Math.max(0, bossRow - currentRow);
+  const floorsToNextBoss =
+    floorsByFloorTable != null ? Math.min(floorsByFloorTable, floorsByRow) : floorsByRow;
 
   // Trace reachable nodes from current position's next options
   // to find rest/shop ahead on the actual path (not other branches)
@@ -43,7 +72,7 @@ export function buildMapContext(mapState: MapState): MapContext {
   }
 
   return {
-    floorsToNextBoss: bossRow - currentRow,
+    floorsToNextBoss,
     nextNodeTypes,
     hasEliteAhead: nextNodeTypes.includes("Elite") || childTypes.includes("Elite"),
     hasBossAhead: nextNodeTypes.includes("Boss") || childTypes.includes("Boss"),

--- a/apps/desktop/src/lib/infer-run-outcome.ts
+++ b/apps/desktop/src/lib/infer-run-outcome.ts
@@ -30,9 +30,13 @@ export type RunOutcome = "victory" | "defeat" | null;
  * Victory is detected from:
  * 1. Boss combat where all enemies died → combat_rewards transition
  * 2. Architect event (post-final-boss reward screen)
+ * 3. Menu transition directly from a cleared Act 3 boss (#74). STS2
+ *    sometimes jumps straight from the boss fight to menu, skipping
+ *    combat_rewards. Without this branch, confirmed Ascension wins get
+ *    stuck on the "Run paused" screen and never post to /api/run.
  *
  * Defeat is detected from:
- * 3. Overlay with NGameOverScreen (the mod's death screen)
+ * 4. Overlay with NGameOverScreen (the mod's death screen)
  */
 export function inferRunOutcome(input: RunOutcomeInput): RunOutcome {
   const {
@@ -64,6 +68,18 @@ export function inferRunOutcome(input: RunOutcomeInput): RunOutcome {
   // Final boss combat → combat_rewards with all enemies dead = victory
   if (
     currentStateType === "combat_rewards" &&
+    lastWasBoss &&
+    lastEnemiesAllDead &&
+    lastAct >= 3
+  ) {
+    return "victory";
+  }
+
+  // Menu transition from a cleared Act 3 boss (#74). The last-combat
+  // fields still reflect the boss kill at the moment of the menu
+  // transition — safe to trust them.
+  if (
+    currentStateType === "menu" &&
     lastWasBoss &&
     lastEnemiesAllDead &&
     lastAct >= 3


### PR DESCRIPTION
Closes #74. Closes #72.

Two user-reported bugs from manual smoke testing, fixed together since they both touch the desktop listener / eval-context pipeline.

## #74 — Ascension wins stuck on "Run paused"

\`inferRunOutcome\` only recognized victory via combat_rewards, Architect event, or (the defeat path) GameOver overlay. STS2 sometimes jumps from the final boss fight directly to menu — none of those paths match, so confirmed wins landed on the "paused" screen and never posted to \`/api/run\`.

**Fix:** fourth victory path — menu transition where \`lastWasBoss && lastEnemiesAllDead && lastAct >= 3\`. Last-combat fields still reflect the boss kill at the moment of the menu jump, so this is safe.

## #72 — Rest site eval says "3 remaining fights" with boss next floor

\`buildMapContext.floorsToNextBoss\` did raw \`bossRow - currentRow\`. On an Act 1 floor 16 rest site, \`current_position.row\` still pointed at the previous combat node, returning 3+ when the boss was literally the next floor. The downstream rest eval then told the LLM "boss is soon" and the LLM produced "over 3 remaining fights" reasoning.

**Fix:** prefer \`run.floor\` against cumulative boss floor table \`[17, 34, 51]\` over raw row math. Take min of the two signals so a closer signal from either side still surfaces. \`run.floor\` tracks the UI immediately; row math becomes a secondary signal for edge cases.

## Test plan

- [x] 4 new tests on \`inferRunOutcome\` (menu-transition path + 3 guard cases)
- [x] 4 new tests on \`buildMapContext.floorsToNextBoss\` (repro case + boss-at-same-floor + cross-act + row/floor disagreement)
- [x] \`pnpm turbo test\` 276 desktop tests green
- [x] \`pnpm -r exec tsc --noEmit\` clean

## Related

- #43 (choice tracker stale deck) also triaged; closed as likely-fixed by the April choice-detection rewrite. Current listener defers the skip verdict until the player has fully left the rewards screen, so the stale-deck window no longer traps false skips.