### PR TITLE
chore: small follow-up cleanup (#98, #99, #101)

### DIFF
--- a/apps/desktop/src/features/evaluation/cardRewardEvalListener.ts
+++ b/apps/desktop/src/features/evaluation/cardRewardEvalListener.ts
@@ -135,6 +135,10 @@ export function setupCardRewardEvalListener() {
             recommendation: r.recommendation,
           })),
           evalType: "card_reward",
+          // #98: preserve the full coaching block for phase-2 calibration.
+          // `allRankings` is the reduced shape the choice tracker needs;
+          // `raw` carries reasoning / headline / tradeoffs / callouts.
+          raw: data,
         });
 
         // Backfill: if user acted before eval completed, upsert recommendation data

--- a/apps/desktop/src/features/evaluation/eventEvalListener.ts
+++ b/apps/desktop/src/features/evaluation/eventEvalListener.ts
@@ -111,6 +111,7 @@ export function setupEventEvalListener() {
             recommendation: r.recommendation,
           })),
           evalType: "event",
+          raw: evaluation, // #98
         });
 
         listenerApi.dispatch(evalSucceeded({ evalType: EVAL_TYPE, evalKey, result: evaluation }));

--- a/apps/desktop/src/features/evaluation/relicSelectEvalListener.ts
+++ b/apps/desktop/src/features/evaluation/relicSelectEvalListener.ts
@@ -87,6 +87,7 @@ export function setupRelicSelectEvalListener() {
               recommendation: r.recommendation,
             })),
             evalType: "boss_relic",
+            raw: evaluation, // #98
           });
         }
 

--- a/apps/desktop/src/features/evaluation/restSiteEvalListener.ts
+++ b/apps/desktop/src/features/evaluation/restSiteEvalListener.ts
@@ -13,6 +13,7 @@ import { selectActiveRunId } from "../run/runSlice";
 import { buildEvaluationContext } from "@sts2/shared/evaluation/context-builder";
 import { getPlayer, type RestSiteState } from "@sts2/shared/types/game-state";
 import { getPromptContext, updateFromContext } from "@sts2/shared/evaluation/run-narrative";
+import { floorsToNextBossFloor } from "../../lib/act-boss-floors";
 import { registerLastEvaluation } from "@sts2/shared/evaluation/last-evaluation-registry";
 import { preEvalRestWeights, applyRestWeights } from "@sts2/shared/evaluation/post-eval-weights";
 import { buildRestContext } from "../../lib/build-rest-context";
@@ -53,9 +54,7 @@ export function setupRestSiteEvalListener() {
 
       const mapCtx = selectMapContext(state);
       const currentFloor = restState.run.floor;
-      const bossDistance = mapCtx?.floorsToNextBoss ?? Math.min(
-        ...[17, 34, 51].filter((bf) => bf > currentFloor).map((bf) => bf - currentFloor)
-      );
+      const bossDistance = mapCtx?.floorsToNextBoss ?? floorsToNextBossFloor(currentFloor) ?? 0;
 
       // Pre-eval short-circuit: skip LLM when answer is obvious
       const hpPercent = restPlayer.max_hp > 0 ? restPlayer.hp / restPlayer.max_hp : 1;
@@ -156,6 +155,7 @@ export function setupRestSiteEvalListener() {
             recommendation: r.recommendation,
           })),
           evalType: "rest_site",
+          raw: evaluation, // #98
         });
 
         listenerApi.dispatch(evalSucceeded({ evalType: EVAL_TYPE, evalKey, result: evaluation }));

--- a/apps/desktop/src/features/evaluation/shopEvalListener.ts
+++ b/apps/desktop/src/features/evaluation/shopEvalListener.ts
@@ -102,6 +102,7 @@ export function setupShopEvalListener() {
             recommendation: r.recommendation,
           })),
           evalType: "shop",
+          raw: data, // #98
         });
 
         listenerApi.dispatch(evalSucceeded({ evalType: EVAL_TYPE, evalKey, result: data }));

--- a/apps/desktop/src/lib/act-boss-floors.ts
+++ b/apps/desktop/src/lib/act-boss-floors.ts
@@ -1,0 +1,17 @@
+/**
+ * Cumulative STS2 act boss floors. `run.floor` is a global counter across
+ * the whole run (floor 18 is Act 2 floor 1; floor 35 is Act 3 floor 1).
+ * Shared so the two eval pipelines that reason about "how many floors
+ * until the next boss" (map context + rest-site fallback) agree.
+ */
+export const ACT_BOSS_FLOORS = [17, 34, 51] as const;
+
+/**
+ * Floors from `currentFloor` to the next upcoming act boss.
+ * Returns 0 when on the boss floor itself, and `null` when past floor 51
+ * (post-run — no upcoming boss).
+ */
+export function floorsToNextBossFloor(currentFloor: number): number | null {
+  const next = ACT_BOSS_FLOORS.find((bf) => bf >= currentFloor);
+  return next != null ? next - currentFloor : null;
+}

--- a/apps/desktop/src/lib/build-map-context.ts
+++ b/apps/desktop/src/lib/build-map-context.ts
@@ -1,20 +1,6 @@
 import type { MapState, MapNode, MapNextOption } from "@sts2/shared/types/game-state";
 import type { MapContext } from "../features/run/runSlice";
-
-/**
- * Cumulative STS2 act boss floors. Matches the pattern already used in
- * `restSiteEvalListener.ts:57` (`[17, 34, 51]`). `run.floor` is global
- * across acts (floor 18 = Act 2 floor 1; floor 35 = Act 3 floor 1).
- * Used as the primary signal for `floorsToNextBoss` because `run.floor`
- * stays in sync with the UI while `current_position.row` lags when the
- * player is on a non-combat screen (rest site, shop, event) — see #72.
- */
-const ACT_BOSS_FLOORS = [17, 34, 51] as const;
-
-function floorsToNextBossFloor(currentFloor: number): number | null {
-  const next = ACT_BOSS_FLOORS.find((bf) => bf >= currentFloor);
-  return next != null ? next - currentFloor : null;
-}
+import { floorsToNextBossFloor } from "./act-boss-floors";
 
 export function buildMapContext(mapState: MapState): MapContext {
   const currentRow = mapState.map.current_position?.row ?? 0;

--- a/apps/desktop/src/services/evaluationApi.ts
+++ b/apps/desktop/src/services/evaluationApi.ts
@@ -54,13 +54,6 @@ interface MapPromptRequest extends EvalRequestBase {
   evalType?: string;
   mapPrompt: string;
   /**
-   * Map coach run-state snapshot. Persisted to `/api/choice` by
-   * `mapListeners`; no longer sent to `/api/evaluate` because the server
-   * never read it (#76). Field kept on this interface only to document
-   * the data lives in `lastMapRunState` on the desktop side.
-   */
-  runStateSnapshot?: unknown;
-  /**
    * Optional inputs for the server-side phase-2 compliance pipeline (repair +
    * rerank). When omitted, the server ships the LLM output without a
    * `compliance` field. Only populated for the map coach eval.

--- a/apps/web/src/app/api/evaluate/route.ts
+++ b/apps/web/src/app/api/evaluate/route.ts
@@ -256,16 +256,6 @@ interface EvaluateRequest {
   gameVersion: string | null;
   goldBudget?: number | null;
   /**
-   * Optional run-state snapshot computed desktop-side (map coach phase 1).
-   * Historically this field was accepted and echoed back so the desktop
-   * could forward it to `/api/choice`. Echo removed in #76 — desktop now
-   * caches its locally-computed `RunState` directly (see `lastMapRunState`
-   * in `mapListeners.ts`) so the round-trip through the server is unused.
-   * Kept as an optional field so older clients still parse, but it's no
-   * longer read on the response path.
-   */
-  runStateSnapshot?: unknown;
-  /**
    * Optional inputs for the phase-2 compliance pipeline (repair + rerank).
    * Populated by the desktop map-coach call path — absent for callers that
    * haven't migrated yet, in which case the route ships the LLM output


### PR DESCRIPTION
Closes #98, #99, #101.

Three independent small items from the post-PR-#95 / post-PR-#100 follow-up list. Batched for throughput; each is tiny.

## #101 — extract ACT_BOSS_FLOORS helper

\`apps/desktop/src/lib/act-boss-floors.ts\` now holds \`ACT_BOSS_FLOORS = [17, 34, 51]\` and \`floorsToNextBossFloor()\`. \`build-map-context.ts\` (added in PR #100) and \`restSiteEvalListener.ts:57\` both import from it. Kills the duplicate literal + the slightly different filter semantics (\`>\` vs \`>=\`) between the two sites.

## #99 — delete dead runStateSnapshot? field

Field was kept on \`EvaluateRequest\` and \`MapPromptRequest\` as a compat shim after PR #95 dropped the echo. No consumer reads it; removing the TS declaration has zero runtime impact (Next.js tolerates unknown body fields). The \`logChoice\` payload still carries \`runStateSnapshot\` — that goes to \`/api/choice\` which DOES persist it. Unchanged.

## #98 — capture raw for non-map eval types

\`LastEvaluation.raw\` now populated in card_reward, shop, rest_site, event, and boss_relic listeners. Same phase-2 calibration enabler as the map version shipped in #78 — captures the full coaching / reasoning payload alongside the reduced \`allRankings\` summary the choice tracker needs.

## Test plan

- [x] \`pnpm turbo test\` — 276 desktop + 413 web tests pass
- [x] \`pnpm -r exec tsc --noEmit\` clean

## Related

- #97 (regression test for #77) explicitly punted in-thread — blocked on the same listener-test scaffolding #88 will carry forward after #93 lands.