### PR TITLE
fix(map): skip re-eval on forced-row rows

### DIFF
--- a/apps/desktop/src/lib/should-evaluate-map.test.ts
+++ b/apps/desktop/src/lib/should-evaluate-map.test.ts
@@ -15,7 +15,19 @@ function base(overrides: Partial<Parameters<typeof shouldEvaluateMap>[0]> = {}) 
   };
 }
 
-describe("shouldEvaluateMap — three triggers", () => {
+function twoTypeFork(overrides: Partial<Parameters<typeof shouldEvaluateMap>[0]> = {}) {
+  return base({
+    optionCount: 2,
+    nextOptions: [
+      { col: 0, row: 2, type: "monster" },
+      { col: 1, row: 2, type: "elite" },
+    ],
+    nextOptionSubgraphFingerprints: ["a", "b"],
+    ...overrides,
+  });
+}
+
+describe("shouldEvaluateMap — triggers", () => {
   it("returns false when there are no options", () => {
     expect(shouldEvaluateMap(base({ optionCount: 0, nextOptions: [], nextOptionSubgraphFingerprints: [] }))).toBe(false);
   });
@@ -36,23 +48,18 @@ describe("shouldEvaluateMap — three triggers", () => {
     expect(shouldEvaluateMap(base({ isStartOfAct: true, ancientHealResolved: true }))).toBe(true);
   });
 
-  it("triggers when the player is off the recommended path", () => {
-    expect(shouldEvaluateMap(base({ isOnRecommendedPath: false }))).toBe(true);
+  it("does NOT trigger off-path when the next row is forced (single option)", () => {
+    // Previously condition fired here and produced a useless re-plan because
+    // the next move is determined; issue #115 defers to the next fork.
+    expect(shouldEvaluateMap(base({ isOnRecommendedPath: false }))).toBe(false);
+  });
+
+  it("triggers off-path when the next row is a meaningful fork", () => {
+    expect(shouldEvaluateMap(twoTypeFork({ isOnRecommendedPath: false }))).toBe(true);
   });
 
   it("triggers on a fork where options differ in type", () => {
-    expect(
-      shouldEvaluateMap(
-        base({
-          optionCount: 2,
-          nextOptions: [
-            { col: 0, row: 2, type: "monster" },
-            { col: 1, row: 2, type: "elite" },
-          ],
-          nextOptionSubgraphFingerprints: ["a", "b"],
-        }),
-      ),
-    ).toBe(true);
+    expect(shouldEvaluateMap(twoTypeFork())).toBe(true);
   });
 
   it("triggers on a same-type fork when downstream subgraphs differ", () => {
@@ -85,7 +92,7 @@ describe("shouldEvaluateMap — three triggers", () => {
     ).toBe(false);
   });
 
-  it("no-op when none of the triggers fire", () => {
+  it("no-op when none of the triggers fire (single forced option, on-path)", () => {
     expect(shouldEvaluateMap(base())).toBe(false);
   });
 });

--- a/apps/desktop/src/lib/should-evaluate-map.ts
+++ b/apps/desktop/src/lib/should-evaluate-map.ts
@@ -20,14 +20,16 @@ function hasMeaningfulFork(input: ShouldEvaluateMapInput): boolean {
 /**
  * Decide whether a fresh map evaluation should fire.
  *
- * Three triggers:
- * 1. Start of act (post-ancient). First map-state of a new act; Acts 2/3
- *    wait one tick if the ancient heal hasn't resolved yet.
- * 2. Player off-path. Current node isn't on the recommended path.
+ * Triggers, in order:
+ * 1. Initial eval. No prior context exists → always evaluate so we have
+ *    a recommendation to compare against on subsequent polls.
+ * 2. Start of act. First map-state of a new act; Acts 2/3 wait one tick
+ *    if the ancient heal hasn't resolved yet.
  * 3. Meaningful fork. Multiple `next_options` that differ in type or in
- *    downstream subgraph fingerprint.
- *
- * Plus an implicit "initial eval" case: no prior context → trigger.
+ *    downstream subgraph fingerprint. Off-path status is factored into
+ *    the eval prompt but is NOT itself a trigger — re-planning at a
+ *    single-option row wastes tokens because the next move is forced;
+ *    the next fork is where a fresh recommendation actually matters.
  */
 export function shouldEvaluateMap(input: ShouldEvaluateMapInput): boolean {
   if (input.optionCount <= 0) return false;
@@ -39,9 +41,8 @@ export function shouldEvaluateMap(input: ShouldEvaluateMapInput): boolean {
     return true;
   }
 
-  if (input.currentPosition && !input.isOnRecommendedPath) return true;
-
-  if (hasMeaningfulFork(input)) return true;
-
-  return false;
+  // All remaining cases — including "player is off the recommended path" —
+  // require a meaningful fork. Forced rows produce forced plans; deferring
+  // to the next fork gives the eval a decision to actually reason about.
+  return hasMeaningfulFork(input);
 }

--- a/apps/desktop/src/views/map/__tests__/map-view.test.tsx
+++ b/apps/desktop/src/views/map/__tests__/map-view.test.tsx
@@ -280,7 +280,7 @@ describe("MapView", () => {
       });
       renderWithStore(<MapView state={state} />, { preloadedState: preloaded });
 
-      expect(screen.getByText("Evaluating paths...")).toBeTruthy();
+      expect(screen.getByText("Narrating path…")).toBeTruthy();
     });
   });
 

--- a/apps/desktop/src/views/map/map-view.tsx
+++ b/apps/desktop/src/views/map/map-view.tsx
@@ -161,14 +161,6 @@ export function MapView({ state }: MapViewProps) {
               Voting {votes.filter((v) => v.voted).length}/{votes.length}
             </span>
           )}
-          {isLoading && (
-            <div className="absolute inset-0 z-20 flex items-center justify-center bg-spire-base/50 backdrop-blur-[2px] rounded-lg pointer-events-none">
-              <div className="flex items-center gap-2 bg-spire-surface border border-spire-border rounded-lg px-4 py-2 shadow-lg pointer-events-auto">
-                <span className="w-2 h-2 rounded-full bg-emerald-400 animate-pulse" />
-                <span className="text-sm text-spire-text-secondary">Evaluating paths...</span>
-              </div>
-            </div>
-          )}
 
           <svg
             viewBox={`0 0 ${svgWidth} ${svgHeight}`}
@@ -304,8 +296,22 @@ export function MapView({ state }: MapViewProps) {
         </div>
       </div>
 
-      {/* Sidebar — Coach output */}
-      <div className="flex-1 min-w-[20rem] flex flex-col gap-2 min-h-0 overflow-y-auto overflow-x-hidden">
+      {/* Sidebar — Coach output. The loading overlay lives here (not over the
+          map) so the new recommended path — already updated from the
+          deterministic scorer before the LLM call starts — stays visible
+          while the narration refreshes. */}
+      <div className="flex-1 min-w-[20rem] flex flex-col gap-2 min-h-0 overflow-y-auto overflow-x-hidden relative">
+        {isLoading && (
+          <div className="sticky top-0 left-0 right-0 bottom-0 z-20 flex items-start justify-center pt-2 pointer-events-none">
+            <div className="flex items-center gap-2 bg-spire-surface/95 backdrop-blur-[2px] border border-spire-border rounded-lg px-3 py-1.5 shadow-lg pointer-events-auto">
+              <span className="w-2 h-2 rounded-full bg-emerald-400 animate-pulse" />
+              <span className="text-xs text-spire-text-secondary">Narrating path…</span>
+            </div>
+          </div>
+        )}
+        {isLoading && (
+          <div className="absolute inset-0 z-10 bg-spire-base/40 backdrop-blur-[1px] rounded-lg pointer-events-none" />
+        )}
         {evaluation && evalMatchesCurrentOptions && (
           <>
             {/* Headline + confidence */}


### PR DESCRIPTION
## Summary
- Map Coach was firing its re-eval overlay on forced rows (single \`next_options\`) any time the player was "off-path". The resulting re-plan was identical to the prior one — the next move is determined by the graph — so it just flashed the overlay and burned tokens.
- After the initial-eval + start-of-act triggers, \`shouldEvaluateMap\` now gates every remaining case behind \`hasMeaningfulFork\`. Off-path status still flows into the eval prompt when a real fork arrives; it's no longer a standalone trigger.

## Test plan
- [x] \`pnpm --filter @sts2/desktop test should-evaluate-map\` — 11/11 pass (previous "off-path → true" regression case is now "off-path + forced → false"; new case asserts "off-path + meaningful fork → true")
- [x] \`pnpm --filter @sts2/desktop test\` — 258/258 pass
- [x] \`pnpm --filter @sts2/desktop exec tsc --noEmit\` — clean
- [ ] Manual: play past a forced row while off-recommended-path → overlay shouldn't flash; next real fork should still trigger eval

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)