### PR TITLE
feat(map-coach): real backtest replay + persistence extension to enable it

### DIFF
--- a/apps/desktop/src/features/map/__tests__/mapListeners-cache-eager-set.test.ts
+++ b/apps/desktop/src/features/map/__tests__/mapListeners-cache-eager-set.test.ts
@@ -209,6 +209,7 @@ function seedRun(
       maxEnergy: 3,
       relics: [{ id: "burning_blood", name: "Burning Blood", description: "Heal 6 at end of combat." }],
       potions: [],
+      potionSlotCap: 2,
       cardRemovalCost: 75,
     }),
   );

--- a/apps/desktop/src/features/map/mapListeners.ts
+++ b/apps/desktop/src/features/map/mapListeners.ts
@@ -45,6 +45,16 @@ const EVAL_TYPE = "map" as const;
  * at when they decided). Good enough for phase 1 persistence; a tighter
  * guarantee would require pairing the snapshot with the evalKey.
  */
+/**
+ * Cache of the per-run compliance bundle (runState + enrichedPaths +
+ * candidate-set fingerprints) used to populate `runStateSnapshot` on
+ * `/api/choice`. Persisting the full compliance — not just the RunState —
+ * is what makes #79's backtest replay possible: with `enrichedPaths`
+ * captured at choice time, `scorePaths` can re-run on historical rows.
+ *
+ * Type is `unknown` to keep the listener decoupled from the eval-inputs
+ * type surface; runtime shape is `MapComplianceInputs`.
+ */
 const lastMapRunState = new Map<string, unknown>();
 
 /**
@@ -140,7 +150,10 @@ export function setupMapEvalListener() {
               state: mapState,
               cardRemovalCost: eagerPlayer?.cardRemovalCost ?? null,
             });
-            lastMapRunState.set(activeRunIdForEagerCache, eagerRunState);
+            // #79: persist the full compliance bundle (not just runState)
+            // so `enrichedPaths` survive into `choices.run_state_snapshot`
+            // for backtest replay.
+            lastMapRunState.set(activeRunIdForEagerCache, eagerComplianceData);
             eagerCompliance = { runState: eagerRunState, compliance: eagerComplianceData };
           }
         } catch {
@@ -397,10 +410,12 @@ export function setupMapEvalListener() {
           cardRemovalCost: player?.cardRemovalCost ?? null,
         });
 
-        // Cache the computed run-state for the map_node choice write path.
+        // Cache the full compliance bundle for the map_node choice write
+        // path. Using the bundle (not just runState) means enrichedPaths
+        // survive into the persisted snapshot — required for #79 replay.
         const activeRunIdForCache = state.run.activeRunId;
         if (activeRunIdForCache) {
-          lastMapRunState.set(activeRunIdForCache, runState);
+          lastMapRunState.set(activeRunIdForCache, mapCompliance);
         }
 
         logDevEvent("eval", "map_api_request", {
@@ -558,7 +573,8 @@ export function setupMapEvalListener() {
               chosenItemId: pendingMapNode.chosenItemId,
               offeredItemIds: [],
               userId: getUserId(),
-              runStateSnapshot: runState,
+              // #79: persist full compliance (incl. enrichedPaths) for backtest replay.
+              runStateSnapshot: mapCompliance,
             })
           );
 

--- a/apps/desktop/src/features/map/mapListeners.ts
+++ b/apps/desktop/src/features/map/mapListeners.ts
@@ -404,7 +404,7 @@ export function setupMapEvalListener() {
       listenerApi.dispatch(mapEvalUpdated({ ...preEval, bestPathNodes: preEval.recommendedNodes }));
 
       try {
-        const { prompt: mapPrompt, runState, compliance: mapCompliance } = buildMapPrompt({
+        const { prompt: mapPrompt, compliance: mapCompliance } = buildMapPrompt({
           context: ctx,
           state: mapState,
           cardRemovalCost: player?.cardRemovalCost ?? null,

--- a/apps/desktop/src/lib/eval-inputs/map.ts
+++ b/apps/desktop/src/lib/eval-inputs/map.ts
@@ -195,9 +195,14 @@ function enumerateAllPaths(
 /**
  * Build the map evaluation prompt — run-state facts block + reasoning scaffold.
  *
- * Returns both the prompt string and the computed `RunState` so the caller can
- * forward the snapshot to `/api/evaluate` (for echo into the response) and
- * ultimately to `/api/choice` for persistence in `choices.run_state_snapshot`.
+ * Returns the prompt string, the computed `RunState`, and the full
+ * `MapComplianceInputs` bundle. The caller forwards the snapshot to
+ * `/api/evaluate` (for echo into the response) and ultimately to
+ * `/api/choice` for persistence — since #79 the persisted shape in
+ * `choices.run_state_snapshot` is the full `MapComplianceInputs` bundle
+ * (not bare `RunState`), so `apps/web/scripts/map-coach-backtest.ts` can
+ * re-run `scorePaths` on historical rows to evaluate v2 vs v1 vs the
+ * user's actual pick.
  */
 export function buildMapPrompt(params: {
   context: EvaluationContext;

--- a/apps/web/scripts/map-coach-backtest.ts
+++ b/apps/web/scripts/map-coach-backtest.ts
@@ -146,6 +146,9 @@ async function main() {
   let replayable = 0;
   let unreplayableLegacy = 0;
   let unreplayableMissingId = 0;
+  // Snapshot defect — winner had no `nodeId`. Tracked separately from
+  // `scorerError` so a real scorer regression isn't drowned in noise.
+  let unreplayableMissingNodeId = 0;
   let scorerError = 0;
 
   for (const row of typedRows) {
@@ -162,6 +165,9 @@ async function main() {
     const snap = row.run_state_snapshot;
     let v2Recommendation: string | null = null;
     try {
+      // `MapComplianceInputs.cardRemovalCost` is `number` (non-nullable),
+      // so persisted bundles always carry a real value. The `?? 75` is
+      // defensive in case a row was hand-edited; should never fire.
       const scored = scorePaths(snap.enrichedPaths, snap.runState, {
         cardRemovalCost: snap.cardRemovalCost ?? 75,
       });
@@ -177,7 +183,11 @@ async function main() {
     }
 
     if (!v2Recommendation) {
-      scorerError++;
+      // Distinct from `scorerError` — the scorer ran cleanly, the winner
+      // just lacked a `nodeId`. Astronomically unlikely on real data
+      // (`enumerateAllPaths` always sets it); flagging it separately so
+      // a real scorer regression isn't drowned in noise.
+      unreplayableMissingNodeId++;
       continue;
     }
 
@@ -213,7 +223,8 @@ async function main() {
     `| Replayed (v2 score ran) | ${replayable} | ${replayPct}% |`,
     `| Unreplayable — legacy persistence (no \`enrichedPaths\`) | ${unreplayableLegacy} | ${((unreplayableLegacy / totalRows) * 100).toFixed(1)}% |`,
     `| Unreplayable — missing \`chosen_item_id\` | ${unreplayableMissingId} | ${((unreplayableMissingId / totalRows) * 100).toFixed(1)}% |`,
-    `| Scorer error / null winner | ${scorerError} | ${((scorerError / totalRows) * 100).toFixed(1)}% |`,
+    `| Unreplayable — winner had no \`nodeId\` (snapshot defect) | ${unreplayableMissingNodeId} | ${((unreplayableMissingNodeId / totalRows) * 100).toFixed(1)}% |`,
+    `| Scorer error | ${scorerError} | ${((scorerError / totalRows) * 100).toFixed(1)}% |`,
     ``,
     `## v2 buckets (over replayed rows)`,
     ``,

--- a/apps/web/scripts/map-coach-backtest.ts
+++ b/apps/web/scripts/map-coach-backtest.ts
@@ -2,33 +2,43 @@
 /**
  * Map coach backtest harness.
  *
- * Pulls historical map-type choice rows, reconstructs inputs, runs the new
- * enrichment + eval, and reports bucket counts:
- *   - v2_agrees_with_user   (new recommendation == user's actual choice)
- *   - v2_agrees_with_old    (new recommendation == old recommendation)
- *   - v2_differs_from_both  (new disagrees with both)
+ * For each historical map-type choice row, re-runs the deterministic
+ * scorer (`scorePaths`) against the persisted compliance bundle and
+ * compares the v2 winner against:
+ *   - the user's actual pick (`chosen_item_id`)
+ *   - the v1 recommendation logged at the time (`recommended_item_id`)
+ *
+ * Buckets, per-bucket win rates, and a "replayability" rate are emitted
+ * to a markdown report under `apps/web/scripts/`.
  *
  * Reads:
- *   - Supabase URL + service role key from .env.local
+ *   - Supabase URL + service role key from `.env.local`
  *
  * Usage:
  *   pnpm tsx apps/web/scripts/map-coach-backtest.ts --character=ironclad --ascension=10
  *
- * Output:
- *   Table written to apps/web/scripts/backtest-report-<iso>.md
+ * ## Replayability
  *
- * TELEMETRY NOTE (legacy data shape) — issue #87:
- * `choices` rows written BEFORE 2026-04-18 (phase-2 compliance ship) have
- * `rankings_snapshot->'compliance'` === NULL. Any filter or aggregation
- * that treats the absence of that field as a negative signal will silently
- * exclude those rows. When adding new analytics queries against
- * `rankings_snapshot->'compliance'`, COALESCE or explicitly scope by
- * `created_at >= '2026-04-18'`.
+ * Pre-#79 rows persisted only the `RunState` in `run_state_snapshot`; the
+ * candidate `enrichedPaths` were not captured, so v2 cannot be re-run on
+ * those rows — they bucket as `unreplayable_legacy`. Post-#79 rows
+ * persist the full `MapComplianceInputs`, which carries `enrichedPaths`.
+ *
+ * Detection: row has `run_state_snapshot.enrichedPaths` array → replayable.
+ *
+ * ## Telemetry note (legacy data shape) — issue #87
+ *
+ * `choices` rows written before 2026-04-18 have
+ * `rankings_snapshot->'compliance'` === NULL. Aggregations over the
+ * compliance block must COALESCE or scope by `created_at >= '2026-04-18'`.
  */
 
 import { createClient } from "@supabase/supabase-js";
 import { readFileSync, writeFileSync } from "node:fs";
 import { parseArgs } from "node:util";
+import { scorePaths, type ScoredPath } from "@sts2/shared/evaluation/map/score-paths";
+import type { EnrichedPath } from "@sts2/shared/evaluation/map/enrich-paths";
+import type { RunState } from "@sts2/shared/evaluation/map/run-state";
 
 const { values } = parseArgs({
   options: {
@@ -38,9 +48,8 @@ const { values } = parseArgs({
   },
 });
 
-const envPath = ".env.local";
 const env = Object.fromEntries(
-  readFileSync(envPath, "utf-8")
+  readFileSync(".env.local", "utf-8")
     .split("\n")
     .filter((l) => l && !l.startsWith("#"))
     .map((l) => l.split("=", 2) as [string, string]),
@@ -56,77 +65,185 @@ if (!supabaseUrl || !serviceRoleKey) {
 
 const supabase = createClient(supabaseUrl, serviceRoleKey);
 
+interface BackfillBuckets {
+  v2_agrees_with_user: number;
+  v2_agrees_with_old: number;
+  v2_differs_from_both: number;
+}
+
+interface ChoiceRow {
+  choice_type: string;
+  recommended_item_id: string | null;
+  chosen_item_id: string | null;
+  rankings_snapshot: unknown;
+  run_state_snapshot: unknown;
+  runs: { character: string; ascension_level: number; victory: boolean | null };
+}
+
+/**
+ * The persisted compliance bundle since #79. Older rows persisted just
+ * `RunState` (no `enrichedPaths` key) — we use that absence to skip
+ * replay for legacy rows.
+ */
+interface PersistedCompliance {
+  enrichedPaths?: EnrichedPath[];
+  runState?: RunState;
+  cardRemovalCost?: number | null;
+}
+
+function isReplayable(
+  snapshot: unknown,
+): snapshot is { enrichedPaths: EnrichedPath[]; runState: RunState; cardRemovalCost?: number | null } {
+  if (!snapshot || typeof snapshot !== "object") return false;
+  const s = snapshot as PersistedCompliance;
+  return Array.isArray(s.enrichedPaths) && s.enrichedPaths.length > 0 && !!s.runState;
+}
+
+/**
+ * Convert a ScoredPath winner to its `col,row` node-id for comparison
+ * with `recommended_item_id` / `chosen_item_id`. The desktop encodes
+ * map node picks as `col,row` (see `apps/desktop/src/features/map/`
+ * `mapListeners.ts`, `mapOutcome.recommendedNode` formatting). The
+ * first node of the winning path is the immediate next-pick.
+ */
+function winnerToNodeId(winner: ScoredPath): string | null {
+  const first = winner.nodes[0];
+  return first?.nodeId ?? null;
+}
+
 async function main() {
+  const character = values.character!;
+  const ascension = Number(values.ascension!);
+  const limit = Number(values.limit!);
+
   const { data: rows, error } = await supabase
     .from("choices")
-    .select("*, runs!inner(character, ascension_level, victory, final_floor)")
+    .select(
+      "choice_type, recommended_item_id, chosen_item_id, rankings_snapshot, run_state_snapshot, runs!inner(character, ascension_level, victory, final_floor)",
+    )
     .eq("choice_type", "map")
-    .eq("runs.character", values.character!)
-    .eq("runs.ascension_level", Number(values.ascension!))
-    .limit(Number(values.limit!));
+    .eq("runs.character", character)
+    .eq("runs.ascension_level", ascension)
+    .limit(limit);
   if (error) throw error;
-  if (!rows) {
+  const typedRows = (rows ?? []) as unknown as ChoiceRow[];
+  if (typedRows.length === 0) {
     console.log("No rows found.");
     return;
   }
 
-  const buckets = {
+  const buckets: BackfillBuckets = {
     v2_agrees_with_user: 0,
     v2_agrees_with_old: 0,
     v2_differs_from_both: 0,
   };
-  const wonOfUserAgree = 0;
-  let wonOfOldAgree = 0;
-  let wonOfDiffers = 0;
+  const wins: BackfillBuckets = {
+    v2_agrees_with_user: 0,
+    v2_agrees_with_old: 0,
+    v2_differs_from_both: 0,
+  };
 
-  for (const row of rows) {
-    // TODO — phase 1 stub: calling the new eval end-to-end requires
-    // rebuilding game state from game_context + rankings_snapshot.
-    // For a first pass, compare only old vs actual:
-    const oldAgreesWithUser = row.recommended_item_id === row.chosen_item_id;
-    const won = row.runs.victory;
+  let replayable = 0;
+  let unreplayableLegacy = 0;
+  let unreplayableMissingId = 0;
+  let scorerError = 0;
 
-    // Placeholder classification pending full eval-replay implementation:
-    if (oldAgreesWithUser) {
+  for (const row of typedRows) {
+    if (!row.chosen_item_id) {
+      unreplayableMissingId++;
+      continue;
+    }
+
+    if (!isReplayable(row.run_state_snapshot)) {
+      unreplayableLegacy++;
+      continue;
+    }
+
+    const snap = row.run_state_snapshot;
+    let v2Recommendation: string | null = null;
+    try {
+      const scored = scorePaths(snap.enrichedPaths, snap.runState, {
+        cardRemovalCost: snap.cardRemovalCost ?? 75,
+      });
+      const winner = scored[0];
+      v2Recommendation = winner ? winnerToNodeId(winner) : null;
+    } catch (err) {
+      scorerError++;
+      console.warn(
+        `Scorer threw on row (chosen=${row.chosen_item_id}, old=${row.recommended_item_id}):`,
+        err instanceof Error ? err.message : err,
+      );
+      continue;
+    }
+
+    if (!v2Recommendation) {
+      scorerError++;
+      continue;
+    }
+
+    replayable++;
+    const won = row.runs.victory === true;
+    const v2EqUser = v2Recommendation === row.chosen_item_id;
+    const v2EqOld = v2Recommendation === row.recommended_item_id;
+
+    if (v2EqUser) {
+      buckets.v2_agrees_with_user++;
+      if (won) wins.v2_agrees_with_user++;
+    } else if (v2EqOld) {
       buckets.v2_agrees_with_old++;
-      if (won) wonOfOldAgree++;
+      if (won) wins.v2_agrees_with_old++;
     } else {
       buckets.v2_differs_from_both++;
-      if (won) wonOfDiffers++;
+      if (won) wins.v2_differs_from_both++;
     }
   }
 
-  const total = rows.length;
+  const totalRows = typedRows.length;
+  const replayPct = ((replayable / totalRows) * 100).toFixed(1);
+
   const report = [
     `# Map Coach Backtest — ${new Date().toISOString()}`,
     ``,
-    `Character: ${values.character} | Ascension: ${values.ascension} | Rows: ${total}`,
+    `Character: ${character} | Ascension: ${ascension} | Rows pulled: ${totalRows}`,
+    ``,
+    `## Replayability`,
+    ``,
+    `| Status | Count | % |`,
+    `|---|---|---|`,
+    `| Replayed (v2 score ran) | ${replayable} | ${replayPct}% |`,
+    `| Unreplayable — legacy persistence (no \`enrichedPaths\`) | ${unreplayableLegacy} | ${((unreplayableLegacy / totalRows) * 100).toFixed(1)}% |`,
+    `| Unreplayable — missing \`chosen_item_id\` | ${unreplayableMissingId} | ${((unreplayableMissingId / totalRows) * 100).toFixed(1)}% |`,
+    `| Scorer error / null winner | ${scorerError} | ${((scorerError / totalRows) * 100).toFixed(1)}% |`,
+    ``,
+    `## v2 buckets (over replayed rows)`,
     ``,
     `| Bucket | Count | % | Wins | Win rate |`,
     `|---|---|---|---|---|`,
-    ...Object.entries(buckets).map(([k, v]) => {
-      const wins =
-        k === "v2_agrees_with_user"
-          ? wonOfUserAgree
-          : k === "v2_agrees_with_old"
-            ? wonOfOldAgree
-            : wonOfDiffers;
-      const pct = ((v / total) * 100).toFixed(1);
-      const wr = v ? ((wins / v) * 100).toFixed(1) : "—";
-      return `| ${k} | ${v} | ${pct}% | ${wins} | ${wr}% |`;
+    ...(Object.entries(buckets) as [keyof BackfillBuckets, number][]).map(([k, v]) => {
+      const w = wins[k];
+      const pct = replayable ? ((v / replayable) * 100).toFixed(1) : "—";
+      const wr = v ? ((w / v) * 100).toFixed(1) : "—";
+      return `| ${k} | ${v} | ${pct}% | ${w} | ${wr}% |`;
     }),
     ``,
     `## Notes`,
     ``,
-    `Phase 1 stub: this script does NOT yet re-run the new eval against`,
-    `historical game state — it only buckets by old-vs-actual. Extending to`,
-    `call the new eval requires a full RunStateInputs reconstruction from`,
-    `\`game_context\` + \`rankings_snapshot\`, which is a follow-up.`,
+    `- Replay calls \`scorePaths\` deterministically — no LLM round-trip.`,
+    `  The narrator step (LLM-driven in production) does not affect which`,
+    `  path is the winner.`,
+    `- "Wins" counts use \`runs.victory === true\`; rows from active runs`,
+    `  (\`victory: null\`) count as not-won.`,
+    `- Pre-#79 rows persisted only \`RunState\`, not the full compliance`,
+    `  bundle. Those bucket as \`unreplayable_legacy\` until enough new`,
+    `  data accumulates.`,
   ].join("\n");
 
   const out = `apps/web/scripts/backtest-report-${new Date().toISOString().replace(/[:.]/g, "-")}.md`;
   writeFileSync(out, report);
   console.log(`Report written: ${out}`);
+  console.log(
+    `Summary: ${replayable}/${totalRows} replayed (${replayPct}%); user=${buckets.v2_agrees_with_user} old=${buckets.v2_agrees_with_old} differs=${buckets.v2_differs_from_both}`,
+  );
 }
 
 main().catch((err) => {


### PR DESCRIPTION
Issue #79 asked for *"implement real backtest replay (currently stub)."* The phase-1 spec it cites: *"On floors where v1 disagreed with the user and the user won, does v2 now agree with the user?"*

**Blocker:** persistence. `choices.run_state_snapshot` only stored `RunState` (a derived projection). Without the candidate `enrichedPaths`, `scorePaths` cannot be re-run on historical rows. This PR fixes both halves.

## Changes

**1. Persistence** (`apps/desktop/src/features/map/mapListeners.ts`)
- `lastMapRunState` cache now holds the full `MapComplianceInputs` bundle (runState + enrichedPaths + nodes + boss + currentPosition + cardRemovalCost) instead of bare `RunState`.
- All three `lastMapRunState.set()` call sites updated.
- Backwards compat: the choice route stores `runStateSnapshot` as `Json` (`z.unknown()`); no consumer reads it as typed `RunState` in production code, so the shape change is invisible to existing readers.

**2. Backtest replay** (`apps/web/scripts/map-coach-backtest.ts`)
- Replaces the stub. For each map-type choice row:
  - Detect shape: `enrichedPaths` array present → replayable (post-#79); else → `unreplayable_legacy`.
  - When replayable, run `scorePaths(enrichedPaths, runState, options)` deterministically (no LLM round-trip), pick the winner's first-node `col,row` as the v2 recommendation.
  - Compare v2 to user's actual pick and to v1's persisted recommendation; bucket as `v2_agrees_with_user` / `v2_agrees_with_old` / `v2_differs_from_both`, with per-bucket win counts from `runs.victory`.
- Report includes a **Replayability** table so legacy-vs-new persistence ratio is visible — you can see when enough new data has accumulated to make the win-rate buckets meaningful.

**Note on legacy data:** rows from before this PR cannot be replayed (they only have `RunState`, not `enrichedPaths`). They bucket as `unreplayable_legacy` until enough new data accumulates. Going forward every choice has the bundle.

## Stale-fixture incidental fix

`apps/desktop/src/features/map/__tests__/mapListeners-cache-eager-set.test.ts` (from PR #122) is missing `potionSlotCap` on the `playerUpdated` fixture — squash-merge of #122 didn't re-typecheck against the PR #124 type tightening that landed in main. Fixed inline so this PR's CI passes.

## Test plan
- [x] `pnpm --filter @sts2/web exec tsc --noEmit` clean
- [x] `pnpm --filter @sts2/desktop exec tsc --noEmit` clean
- [x] `pnpm test` — desktop 793 tests + web 577 tests pass
- [x] `pnpm lint` clean
- [ ] Live invocation: `pnpm tsx apps/web/scripts/map-coach-backtest.ts --character=ironclad --ascension=10` (couldn't run headlessly — requires service-role Supabase access; will validate via dev dogfooding)

## Out of scope (deferred)
- Backfilling legacy rows. Possible only by replaying the desktop's eval-input builder against `game_context` if it had the gameState fully — it doesn't (only 6 summary fields). Legacy rows remain unreplayable; don't shoehorn synthetic paths.
- Generalizing the persistence wrapper to other choice types. Map is the only type whose v2 scorer is fully deterministic; card_reward / shop already persist `breakdown` per ranking via PR #124.

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)