### PR TITLE
chore(evaluation): drop unused raw field from LastEvaluation registry

### DIFF
--- a/apps/desktop/src/features/evaluation/cardRewardEvalListener.ts
+++ b/apps/desktop/src/features/evaluation/cardRewardEvalListener.ts
@@ -140,10 +140,6 @@ export function setupCardRewardEvalListener() {
               )?.breakdown ?? null,
           })),
           evalType: "card_reward",
-          // #98: preserve the full coaching block for phase-2 calibration.
-          // `allRankings` is the reduced shape the choice tracker needs;
-          // `raw` carries reasoning / headline / tradeoffs / callouts.
-          raw: data,
         });
 
         // Backfill: if user acted before eval completed, upsert recommendation data

--- a/apps/desktop/src/features/evaluation/eventEvalListener.ts
+++ b/apps/desktop/src/features/evaluation/eventEvalListener.ts
@@ -111,7 +111,6 @@ export function setupEventEvalListener() {
             recommendation: r.recommendation,
           })),
           evalType: "event",
-          raw: evaluation, // #98
         });
 
         listenerApi.dispatch(evalSucceeded({ evalType: EVAL_TYPE, evalKey, result: evaluation }));

--- a/apps/desktop/src/features/evaluation/relicSelectEvalListener.ts
+++ b/apps/desktop/src/features/evaluation/relicSelectEvalListener.ts
@@ -87,7 +87,6 @@ export function setupRelicSelectEvalListener() {
               recommendation: r.recommendation,
             })),
             evalType: "boss_relic",
-            raw: evaluation, // #98
           });
         }
 

--- a/apps/desktop/src/features/evaluation/restSiteEvalListener.ts
+++ b/apps/desktop/src/features/evaluation/restSiteEvalListener.ts
@@ -155,7 +155,6 @@ export function setupRestSiteEvalListener() {
             recommendation: r.recommendation,
           })),
           evalType: "rest_site",
-          raw: evaluation, // #98
         });
 
         listenerApi.dispatch(evalSucceeded({ evalType: EVAL_TYPE, evalKey, result: evaluation }));

--- a/apps/desktop/src/features/evaluation/shopEvalListener.ts
+++ b/apps/desktop/src/features/evaluation/shopEvalListener.ts
@@ -108,7 +108,6 @@ export function setupShopEvalListener() {
               )?.breakdown ?? null,
           })),
           evalType: "shop",
-          raw: data, // #98
         });
 
         listenerApi.dispatch(evalSucceeded({ evalType: EVAL_TYPE, evalKey, result: data }));

--- a/apps/desktop/src/features/map/choice-telemetry.test.ts
+++ b/apps/desktop/src/features/map/choice-telemetry.test.ts
@@ -1,11 +1,10 @@
 import { describe, it, expect } from "vitest";
 
-// The desktop listener registers the full parsed evaluate response via
-// `registerLastEvaluation("map", { raw: parsed, ... })`, and the
-// choice-logging path reads that raw payload into `rankingsSnapshot`
-// on /api/choice writes. Task 8 stashes `scoredPaths` in the
-// `compliance` field of the response; this test pins the shape so a
-// future schema change can't silently drop the telemetry.
+// Task 8 stashes `scoredPaths` in the `compliance` field of the map
+// evaluate response. This test pins the shape so a future schema change
+// can't silently drop the telemetry — the scorer breakdown is recoverable
+// from JSONL dev-session logs even though it no longer flows through the
+// in-memory `LastEvaluation` registry.
 
 describe("map_node choice telemetry", () => {
   it("stashes scoredPaths inside the raw response payload", () => {

--- a/apps/desktop/src/features/map/mapListeners.ts
+++ b/apps/desktop/src/features/map/mapListeners.ts
@@ -538,18 +538,12 @@ export function setupMapEvalListener() {
         }));
         logReduxSnapshot(listenerApi as unknown as { getState: () => unknown }, "after_map_eval");
 
-        // #78: stash the full parsed coach output in `raw` so phase-2
-        // calibration can recover reasoning/branches/callouts later.
-        // `allRankings` intrinsically doesn't apply to map (no per-item
-        // rankings); leaving it as [] is correct for the choice-tracker
-        // read path, which doesn't consult it for map evals.
         registerLastEvaluation("map", {
           recommendedId: bestOpt ? `${bestOpt.col},${bestOpt.row}` : null,
           recommendedTier: null,
           reasoning: parsed.headline,
           allRankings: [],
           evalType: "map",
-          raw: parsed,
         });
 
         // Backfill: if user picked a map node before eval completed

--- a/packages/shared/evaluation/last-evaluation-registry.ts
+++ b/packages/shared/evaluation/last-evaluation-registry.ts
@@ -9,13 +9,6 @@ interface LastEvaluation {
   reasoning: string;
   allRankings: { itemId: string; itemName: string; tier: string; recommendation: string }[];
   evalType: string;
-  /**
-   * Full raw evaluation payload for consumers that need more than the
-   * reduced-for-choice-tracking summary above. Phase-2 calibration reads
-   * this to recover the coach's full reasoning/branches/callouts for map
-   * evals where `allRankings` is intrinsically empty. See #78.
-   */
-  raw?: unknown;
 }
 
 const registry = new Map<string, LastEvaluation>();


### PR DESCRIPTION
## Summary

- Drops `raw: …` from all six `registerLastEvaluation()` call sites (card_reward, shop, rest_site, event, boss_relic, map). Nothing reads `.raw` at runtime — `choiceTrackingListener` only consults `recommendedId`, `recommendedTier`, and `allRankings`; the map listener reads `allRankings` (intrinsically `[]` for map) and never `raw`.
- Drops the `raw?: unknown` field and its JSDoc from the `LastEvaluation` interface in `packages/shared/evaluation/last-evaluation-registry.ts`.
- Fixes a stale comment in `apps/desktop/src/features/map/choice-telemetry.test.ts` that misstated `raw` as flowing into `rankingsSnapshot`.

The field was added speculatively for #78 (map) and extended in #98 (card_reward / event / shop / boss_relic) as a stash for "phase-2 calibration." Phase-2 is dormant — no open issues track it. The full payload remains recoverable from JSONL dev-session logs (`logDevEvent("eval", ...)`) if the work is revived later, so there's no benefit to keeping dead state in the in-memory registry today.

Supersedes #127, which only addressed card_reward / shop and would have left the field half-removed.

## Test plan

- [x] `pnpm --filter @sts2/desktop exec tsc --noEmit` — clean
- [x] `pnpm --filter @sts2/web exec tsc --noEmit` — clean
- [x] `pnpm --filter @sts2/shared exec tsc --noEmit` — clean
- [x] `pnpm --filter @sts2/desktop test` — 797/797 passing
- [x] `pnpm --filter @sts2/web test` — 582/582 passing
- [x] `grep` confirmed no remaining `.raw` consumers on the `LastEvaluation` shape

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)