### PR TITLE
fix(map-coach): re-eval immediately when off recommended path

### DIFF
--- a/apps/desktop/src/features/map/__tests__/mapListeners-cache-eager-set.test.ts
+++ b/apps/desktop/src/features/map/__tests__/mapListeners-cache-eager-set.test.ts
@@ -315,6 +315,10 @@ describe("setupMapEvalListener — eager run-state cache (#97)", () => {
     // leaking from prior tests in the same vitest worker.
     const runId = nextRunId();
     seedRun(store, runId);
+    // Pin the player on the recommended path so the off-path trigger doesn't
+    // force a re-eval. We're testing the single-option-row short-circuit, not
+    // off-path behavior.
+    store.dispatch(mapEvalUpdated({ bestPathNodes: ["0,0", "0,1"] }));
 
     // First map state: cold cache, position (0,0). Single-option row + seeded
     // hasPrevContext=true → shouldEvaluateMap returns false → gate 1 fires.

--- a/apps/desktop/src/features/map/mapListeners.ts
+++ b/apps/desktop/src/features/map/mapListeners.ts
@@ -312,7 +312,12 @@ export function setupMapEvalListener() {
         // flips don't invalidate it. The first-node check captures
         // "player is still on track" — which is what the user experience
         // actually depends on.
-        if (!actChanged && eagerCompliance && activeRunIdForEagerCache) {
+        //
+        // Off-path skip: once the player has deviated, the narrated plan
+        // is stale by definition, even if the off-branch happens to
+        // converge back to a node on the original path. The off-path
+        // trigger in shouldEvaluateMap above must not be silenced here.
+        if (!actChanged && isOnPath && eagerCompliance && activeRunIdForEagerCache) {
           const scored = scorePaths(
             eagerCompliance.compliance.enrichedPaths,
             eagerCompliance.runState,

--- a/apps/desktop/src/lib/should-evaluate-map.test.ts
+++ b/apps/desktop/src/lib/should-evaluate-map.test.ts
@@ -48,10 +48,11 @@ describe("shouldEvaluateMap — triggers", () => {
     expect(shouldEvaluateMap(base({ isStartOfAct: true, ancientHealResolved: true }))).toBe(true);
   });
 
-  it("does NOT trigger off-path when the next row is forced (single option)", () => {
-    // Previously condition fired here and produced a useless re-plan because
-    // the next move is determined; issue #115 defers to the next fork.
-    expect(shouldEvaluateMap(base({ isOnRecommendedPath: false }))).toBe(false);
+  it("triggers off-path even when the next row is forced (single option)", () => {
+    // Off-path deviation is a first-class trigger: re-plan immediately so the
+    // recommendation reflects the player's actual position rather than waiting
+    // for the next meaningful fork.
+    expect(shouldEvaluateMap(base({ isOnRecommendedPath: false }))).toBe(true);
   });
 
   it("triggers off-path when the next row is a meaningful fork", () => {

--- a/apps/desktop/src/lib/should-evaluate-map.ts
+++ b/apps/desktop/src/lib/should-evaluate-map.ts
@@ -25,11 +25,11 @@ function hasMeaningfulFork(input: ShouldEvaluateMapInput): boolean {
  *    a recommendation to compare against on subsequent polls.
  * 2. Start of act. First map-state of a new act; Acts 2/3 wait one tick
  *    if the ancient heal hasn't resolved yet.
- * 3. Meaningful fork. Multiple `next_options` that differ in type or in
- *    downstream subgraph fingerprint. Off-path status is factored into
- *    the eval prompt but is NOT itself a trigger — re-planning at a
- *    single-option row wastes tokens because the next move is forced;
- *    the next fork is where a fresh recommendation actually matters.
+ * 3. Off-path deviation. The player is no longer on the recommended path —
+ *    re-plan immediately so the recommendation reflects the actual position,
+ *    even at forced rows. Predictability beats token savings here.
+ * 4. Meaningful fork. Multiple `next_options` that differ in type or in
+ *    downstream subgraph fingerprint.
  */
 export function shouldEvaluateMap(input: ShouldEvaluateMapInput): boolean {
   if (input.optionCount <= 0) return false;
@@ -41,8 +41,7 @@ export function shouldEvaluateMap(input: ShouldEvaluateMapInput): boolean {
     return true;
   }
 
-  // All remaining cases — including "player is off the recommended path" —
-  // require a meaningful fork. Forced rows produce forced plans; deferring
-  // to the next fork gives the eval a decision to actually reason about.
+  if (!input.isOnRecommendedPath) return true;
+
   return hasMeaningfulFork(input);
 }


### PR DESCRIPTION
## Summary

- `shouldEvaluateMap` now treats off-path deviation as a first-class trigger — re-plan the moment the player leaves the recommended path, even at forced single-option rows. Previously, off-path was informational only and re-eval was deferred to the next meaningful fork.
- Narrator gate bypasses when the player is off-path so convergent off-branches don't silently suppress the re-eval.
- Existing unit test `does NOT trigger off-path when the next row is forced` was flipped to drive the fix; one integration test gained an explicit `bestPathNodes` seed since it was relying on the old off-path behavior to short-circuit the eval pipeline.

Tradeoff: walking N forced rows after a deviation now costs N evals instead of 0. Predictability over token savings; can throttle later if needed.

Closes #130

## Test plan

- [x] Unit: `pnpm --filter desktop test should-evaluate-map` (11/11)
- [x] Full desktop suite: `pnpm --filter desktop test` (797/797)
- [x] Lint + tsc: `pnpm --filter desktop lint` (0 errors, 23 pre-existing warnings)
- [ ] Manual smoke: launch app, start a run, deliberately pick a node *not* on the recommended path, watch the dev-event log for `map_should_eval` followed by `map_api_request` (not `map_skip_narrator_on_track`). Re-eval should fire on the very next poll after deviation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)