### PR TITLE
feat(eval): render deterministic recommendation before LLM/server response

### DIFF
--- a/apps/desktop/src/features/evaluation/cardRewardEvalListener.ts
+++ b/apps/desktop/src/features/evaluation/cardRewardEvalListener.ts
@@ -4,6 +4,7 @@ import { evaluationApi } from "../../services/evaluationApi";
 import {
   evalStarted,
   evalSucceeded,
+  evalPreviewReady,
   evalFailed,
   evalRetryRequested,
 } from "./evaluationSlice";
@@ -19,6 +20,7 @@ import { buildBackfillPayload } from "@sts2/shared/choice-detection/build-backfi
 import {
   computeCardRewardEvalKey,
   buildCardRewardRequest,
+  buildCardRewardPreview,
 } from "../../lib/eval-inputs/card-reward";
 import { getCardSelectSubType } from "../../lib/eval-inputs/card-select-type";
 import { logDevEvent, logReduxSnapshot } from "../../lib/dev-logger";
@@ -97,6 +99,25 @@ export function setupCardRewardEvalListener() {
       updateFromContext(ctx);
 
       listenerApi.dispatch(evalStarted({ evalType: EVAL_TYPE, evalKey }));
+
+      // Deterministic preview — show rankings + top pick before the API
+      // roundtrip lands. Community-tier and win-rate signals come from the
+      // server response and refine the tiers in `evalSucceeded` below.
+      const previewMaxHp = player?.maxHp ?? 0;
+      const previewCurrentHp = player?.hp ??
+        (previewMaxHp > 0 ? Math.round(ctx.hpPercent * previewMaxHp) : 0);
+      const preview = buildCardRewardPreview({
+        context: ctx,
+        cards,
+        deckCards,
+        relics: player?.relics ?? [],
+        hp: { current: previewCurrentHp, max: previewMaxHp },
+      });
+      if (preview) {
+        listenerApi.dispatch(
+          evalPreviewReady({ evalType: EVAL_TYPE, evalKey, result: preview })
+        );
+      }
 
       try {
         const cardRewardRequest = buildCardRewardRequest({

--- a/apps/desktop/src/features/evaluation/evaluationSlice.ts
+++ b/apps/desktop/src/features/evaluation/evaluationSlice.ts
@@ -86,6 +86,26 @@ export const evaluationSlice = createSlice({
       }
     },
 
+    /**
+     * Deterministic preview ready — stores partial result while the slow
+     * remainder (LLM narrator for map, network roundtrip for card_reward)
+     * is still in flight. `isLoading` stays true so the UI keeps showing a
+     * "loading remainder" indicator without blocking the recommendation.
+     */
+    evalPreviewReady(
+      state,
+      action: PayloadAction<{
+        evalType: EvalType;
+        evalKey: string;
+        result: unknown;
+      }>
+    ) {
+      const entry = state.evals[action.payload.evalType];
+      if (entry.evalKey === action.payload.evalKey) {
+        entry.result = action.payload.result;
+      }
+    },
+
     /** Eval failed — stores error, clears loading */
     evalFailed(
       state,
@@ -130,6 +150,7 @@ export const evaluationSlice = createSlice({
 export const {
   evalStarted,
   evalSucceeded,
+  evalPreviewReady,
   evalFailed,
   evalRetryRequested,
   evalCleared,

--- a/apps/desktop/src/features/map/mapListeners.ts
+++ b/apps/desktop/src/features/map/mapListeners.ts
@@ -17,7 +17,6 @@ import { getPromptContext, updateFromContext, appendDecision } from "@sts2/share
 import { registerLastEvaluation } from "@sts2/shared/evaluation/last-evaluation-registry";
 import { shouldEvaluateMap } from "../../lib/should-evaluate-map";
 import { computeMapEvalKey, buildMapPrompt } from "../../lib/eval-inputs/map";
-import type { RunState } from "@sts2/shared/evaluation/map/run-state";
 import { scorePaths } from "@sts2/shared/evaluation/map/score-paths";
 import { buildPreEvalPayload } from "../../lib/build-pre-eval-payload";
 import { computeSubgraphFingerprint, type FingerprintNode } from "../../lib/compute-subgraph-fingerprint";
@@ -136,9 +135,10 @@ export function setupMapEvalListener() {
       // resulting prompt is only used by the downstream eval path, which
       // still runs when un-gated. Downstream path re-reads the cache.
       const activeRunIdForEagerCache = state.run.activeRunId;
-      let eagerCompliance:
-        | { runState: RunState; compliance: ReturnType<typeof buildMapPrompt>["compliance"] }
-        | null = null;
+      // Deterministic top-ranked path computed locally so the UI can show
+      // the recommended route immediately, before the LLM narrator returns.
+      // Reused by the narrator gate below (was re-scoring on every fire).
+      let eagerWinner: ReturnType<typeof scorePaths>[number] | null = null;
       if (activeRunIdForEagerCache && options.length > 0) {
         try {
           const eagerDeckCards = selectActiveDeck(state);
@@ -154,7 +154,13 @@ export function setupMapEvalListener() {
             // so `enrichedPaths` survive into `choices.run_state_snapshot`
             // for backtest replay.
             lastMapRunState.set(activeRunIdForEagerCache, eagerComplianceData);
-            eagerCompliance = { runState: eagerRunState, compliance: eagerComplianceData };
+
+            const scored = scorePaths(
+              eagerComplianceData.enrichedPaths,
+              eagerRunState,
+              { cardRemovalCost: eagerComplianceData.cardRemovalCost },
+            );
+            eagerWinner = scored[0] ?? null;
           }
         } catch {
           // buildMapPrompt can throw on unusual state shapes; swallow so
@@ -317,16 +323,10 @@ export function setupMapEvalListener() {
         // is stale by definition, even if the off-branch happens to
         // converge back to a node on the original path. The off-path
         // trigger in shouldEvaluateMap above must not be silenced here.
-        if (!actChanged && isOnPath && eagerCompliance && activeRunIdForEagerCache) {
-          const scored = scorePaths(
-            eagerCompliance.compliance.enrichedPaths,
-            eagerCompliance.runState,
-            { cardRemovalCost: eagerCompliance.compliance.cardRemovalCost },
-          );
-          const winner = scored[0];
+        if (!actChanged && isOnPath && eagerWinner && activeRunIdForEagerCache) {
           const prevNarrated = lastNarratedPathByRun.get(activeRunIdForEagerCache);
-          if (winner && prevNarrated) {
-            const firstNodeId = winner.nodes[0]?.nodeId;
+          if (prevNarrated) {
+            const firstNodeId = eagerWinner.nodes[0]?.nodeId;
             const onTrack = typeof firstNodeId === "string" && prevNarrated.has(firstNodeId);
             if (onTrack) {
               logDevEvent("eval", "map_skip_narrator_on_track", {
@@ -404,9 +404,30 @@ export function setupMapEvalListener() {
       // API call fails, shouldEvaluateMap still detects the act change and
       // retries. The post-API dispatch sets the correct act on success.
       preEval.lastEvalContext.act = prevContext?.act ?? 0;
-      // Pre-eval: set bestPathNodes to all options — can't know best until API completes.
-      // This prevents false deviation detection during the API window.
-      listenerApi.dispatch(mapEvalUpdated({ ...preEval, bestPathNodes: preEval.recommendedNodes }));
+
+      // Pre-eval: dispatch the deterministic winner's path immediately so
+      // the UI can highlight the recommended route while the LLM narrator
+      // is still loading. Falls back to "all options' paths" only when the
+      // local scorer didn't produce a winner (e.g. eager-compute failed).
+      const eagerWinnerCoords = eagerWinner?.nodes
+        .map((n) => (n.nodeId ? parseNodeId(n.nodeId) : null))
+        .filter((p): p is { col: number; row: number } => p !== null) ?? [];
+      const currentPosForPre = mapState.map?.current_position ?? null;
+      const eagerFullPath = currentPosForPre &&
+        (eagerWinnerCoords.length === 0 ||
+          eagerWinnerCoords[0].col !== currentPosForPre.col ||
+          eagerWinnerCoords[0].row !== currentPosForPre.row)
+        ? [{ col: currentPosForPre.col, row: currentPosForPre.row }, ...eagerWinnerCoords]
+        : eagerWinnerCoords;
+      const eagerBestPathNodes = eagerWinnerCoords.length > 0
+        ? eagerFullPath.map((p) => `${p.col},${p.row}`)
+        : preEval.recommendedNodes;
+
+      listenerApi.dispatch(mapEvalUpdated({
+        ...preEval,
+        recommendedPath: eagerFullPath,
+        bestPathNodes: eagerBestPathNodes,
+      }));
 
       try {
         const { prompt: mapPrompt, compliance: mapCompliance } = buildMapPrompt({

--- a/apps/desktop/src/lib/eval-inputs/card-reward.ts
+++ b/apps/desktop/src/lib/eval-inputs/card-reward.ts
@@ -1,4 +1,17 @@
-import type { EvaluationContext } from "@sts2/shared/evaluation/types";
+import type { CardEvaluation, CardRewardEvaluation, EvaluationContext } from "@sts2/shared/evaluation/types";
+import type { CombatCard } from "@sts2/shared/types/game-state";
+import type { CommunityTierSignal } from "@sts2/shared/evaluation/community-tier";
+import type { WinRateInput } from "@sts2/shared/evaluation/card-reward/modifier-stack";
+import { computeDeckState } from "@sts2/shared/evaluation/card-reward/deck-state";
+import { tagCard } from "@sts2/shared/evaluation/card-reward/card-tags";
+import { scoreCardOffers } from "@sts2/shared/evaluation/card-reward/score-offers";
+
+/**
+ * Slimmer relic shape than `GameRelic` — desktop-tracked relics drop the
+ * runtime `counter` field, but the deck-state computation never reads it.
+ * Cast through `unknown` mirrors the server short-circuit.
+ */
+type PreviewRelic = { id: string; name: string; description: string };
 
 interface OfferedCard {
   id: string;
@@ -44,5 +57,107 @@ export function buildCardRewardRequest(params: {
     runId: params.runId,
     userId: params.userId,
     gameVersion: null,
+  };
+}
+
+/**
+ * Compute a deterministic preview of the card reward evaluation client-side
+ * so the UI can render rankings + the recommendation immediately, before
+ * the API roundtrip lands.
+ *
+ * Mirrors the server short-circuit at `apps/web/src/app/api/evaluate/route.ts`
+ * (the `card_reward` branch). Community tier + win-rate signals live only on
+ * the server (DB-backed), so we run the scorer with empty maps. The full
+ * server response — which includes those signals plus templated coaching —
+ * overwrites the preview when it arrives, refining the tiers.
+ *
+ * Returns null when the deck/relic state isn't yet populated (e.g. first
+ * card_reward fires before the run is fully hydrated).
+ */
+export function buildCardRewardPreview(params: {
+  context: EvaluationContext;
+  cards: OfferedCard[];
+  deckCards: readonly CombatCard[];
+  relics: readonly PreviewRelic[];
+  hp: { current: number; max: number };
+}): CardRewardEvaluation | null {
+  if (params.cards.length === 0) return null;
+
+  const actRaw = params.context.act;
+  const act = (actRaw >= 1 && actRaw <= 3 ? actRaw : 1) as 1 | 2 | 3;
+
+  let deckState: ReturnType<typeof computeDeckState>;
+  try {
+    deckState = computeDeckState({
+      deck: params.deckCards as unknown as Parameters<typeof computeDeckState>[0]["deck"],
+      relics: params.relics as unknown as Parameters<typeof computeDeckState>[0]["relics"],
+      act,
+      floor: params.context.floor,
+      ascension: params.context.ascension,
+      hp: params.hp,
+    });
+  } catch {
+    return null;
+  }
+
+  const siblings = params.cards.map((c) => ({ name: c.name }));
+  const taggedOffers = params.cards.map((card, i) => ({
+    index: i + 1,
+    name: card.name,
+    rarity: card.rarity,
+    type: card.type,
+    cost: typeof card.cost === "string" ? parseInt(card.cost, 10) || null : card.cost,
+    description: card.description,
+    tags: tagCard(
+      { name: card.name },
+      deckState,
+      siblings.filter((s) => s.name !== card.name),
+      params.deckCards.map((c) => ({ name: c.name })),
+    ),
+  }));
+
+  const itemIdsByIndex = new Map<number, string>();
+  params.cards.forEach((c, i) => itemIdsByIndex.set(i + 1, c.id));
+
+  const scored = scoreCardOffers({
+    offers: taggedOffers,
+    deckState,
+    communityTierById: new Map<string, CommunityTierSignal>(),
+    winRatesById: new Map<string, WinRateInput>(),
+    itemIdsByIndex,
+  });
+
+  const rankings: CardEvaluation[] = scored.offers.map((o) => ({
+    itemId: o.itemId,
+    itemName: o.itemName,
+    itemIndex: o.itemIndex,
+    rank: o.rank,
+    tier: o.tier,
+    tierValue: o.tierValue,
+    synergyScore: 50,
+    confidence: 50,
+    recommendation:
+      o.rank === 1 && !scored.skipRecommended
+        ? "strong_pick"
+        : scored.skipRecommended
+          ? "skip"
+          : "situational",
+    reasoning: o.reasoning,
+    source: "claude",
+  }));
+
+  return {
+    rankings,
+    skipRecommended: scored.skipRecommended,
+    skipReasoning: scored.skipReason,
+    compliance: {
+      scoredOffers: scored.offers.map((o) => ({
+        itemId: o.itemId,
+        rank: o.rank,
+        tier: o.tier,
+        tierValue: o.tierValue,
+        breakdown: o.breakdown,
+      })),
+    },
   };
 }


### PR DESCRIPTION
## Summary

- Map UI now highlights the recommended route immediately. The narrator panel populates when the LLM call resolves.
- Card-reward UI now shows rankings + Top Pick badge immediately via a client-side mirror of the server's deterministic scorer; community-tier-refined tiers replace the preview when the server response lands.
- New \`evalPreviewReady\` action on \`evaluationSlice\` sets \`result\` while keeping \`isLoading: true\`, so existing loading indicators continue to convey "remainder still streaming".

Closes #132

## Test plan

- [x] \`pnpm exec tsc --noEmit\` clean
- [x] \`pnpm test\` — 797 tests pass
- [x] \`pnpm lint\` — 0 errors (23 pre-existing warnings, none from PR changes)
- [ ] Browser smoke: enter map state → recommended route highlights immediately, narrator panel fills in shortly after
- [ ] Browser smoke: hit a card reward → Top Pick badge + rank tiers visible immediately, full coaching panel renders when server response lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)