### PR TITLE
chore(desktop): bump STS2MCP required version to 0.4.0

### DIFF
--- a/apps/desktop/src-tauri/src/mods/detect.rs
+++ b/apps/desktop/src-tauri/src/mods/detect.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use super::{Conflict, ConflictSeverity, InstalledMod, RequiredModStatus};
 
-pub const STS2MCP_REQUIRED_VERSION: &str = "0.3.2";
+pub const STS2MCP_REQUIRED_VERSION: &str = "0.4.0";
 
 /// Scan the mods directory and return all installed mods.
 pub fn list_installed_mods(mods_dir: &Path) -> Vec<InstalledMod> {


### PR DESCRIPTION
Closes #141

Bumps `STS2MCP_REQUIRED_VERSION` from `0.3.2` → `0.4.0`. On next app launch the mod installer will detect the version mismatch and re-download `STS2_MCP.dll` + `STS2_MCP.json` from the [v0.4.0 release](https://github.com/Gennadiyev/STS2MCP/releases/tag/0.4.0).

Three releases bridged (all post-STS2 v0.104.0):
- 0.3.3 Fake Merchant Update (likely the shop fix)
- 0.3.4 multiplayer consistency
- 0.4.0 menu navigation + improved macOS support

## Test plan
- [ ] Launch app → confirm `Installing STS2MCP v0.4.0...` log line
- [ ] Verify `STS2_MCP.json` on disk reports `"version": "0.4.0"`
- [ ] Play through a shop event without the disconnect banner firing
- [ ] Verify combat polls still work (regression on PR #120's fix)