### PR TITLE
fix(map-coach): suppress on-path re-eval until the player advances

### DIFF
--- a/apps/desktop/src/__tests__/integration/map-eval-flow.test.tsx
+++ b/apps/desktop/src/__tests__/integration/map-eval-flow.test.tsx
@@ -325,4 +325,116 @@ describe("map-eval flow — listener → /api/evaluate → adapter → slice →
     );
     expect(bestBadges).toHaveLength(1);
   });
+
+  describe("on-path re-eval suppression (#143)", () => {
+    /** Drain microtasks + a few macrotasks so the listener effect runs to completion. */
+    const settle = () => new Promise<void>((r) => setTimeout(r, 50));
+
+    /** Build a state in which the player has moved to the given option node. */
+    function buildPostMoveMapState(
+      pos: { col: number; row: number; type: "Elite" | "Shop" },
+      nextOption: { col: number; row: number; type: "RestSite" | "Monster" },
+    ): MapState & MultiplayerFields {
+      const startCol = 1, startRow = 0;
+      return {
+        state_type: "map",
+        player: { character: "Ironclad", hp: 70, max_hp: 80, gold: 99 },
+        map: {
+          current_position: pos,
+          visited: [
+            { col: startCol, row: startRow, type: "Monster" },
+            { col: pos.col, row: pos.row, type: pos.type },
+          ],
+          next_options: [
+            {
+              index: 0,
+              col: nextOption.col,
+              row: nextOption.row,
+              type: nextOption.type,
+              leads_to: [{ col: 1, row: 3, type: "Boss" }],
+            },
+          ],
+          nodes: TEST_NODES,
+          boss: TEST_BOSS,
+        },
+        run: { act: 1, floor: pos.row + 1, ascension: 0 },
+      };
+    }
+
+    it("does not re-eval on a repeat poll with identical state (standing still)", async () => {
+      const store = createIntegrationStore();
+      setupMapEvalListener();
+      seedRun(store);
+
+      const mapState = buildHappyPathMapState();
+      store.dispatch(gameStateReceived(mapState));
+      await waitFor(() => {
+        expect(selectEvals(store.getState()).map.result).not.toBeNull();
+      });
+      expect(
+        apiFetchMock.mock.calls.filter(([p]) => p === "/api/evaluate"),
+      ).toHaveLength(1);
+
+      // Second poll, exact same state — the player hasn't moved.
+      store.dispatch(gameStateReceived(mapState));
+      await settle();
+
+      expect(
+        apiFetchMock.mock.calls.filter(([p]) => p === "/api/evaluate"),
+      ).toHaveLength(1);
+    });
+
+    it("does not re-eval when the player picks the recommended on-path node (first move)", async () => {
+      const store = createIntegrationStore();
+      setupMapEvalListener();
+      seedRun(store);
+
+      store.dispatch(gameStateReceived(buildHappyPathMapState()));
+      await waitFor(() => {
+        expect(selectEvals(store.getState()).map.result).not.toBeNull();
+      });
+      expect(
+        apiFetchMock.mock.calls.filter(([p]) => p === "/api/evaluate"),
+      ).toHaveLength(1);
+
+      // Player advances to the recommended Elite at (0,1).
+      const postMove = buildPostMoveMapState(
+        { col: 0, row: 1, type: "Elite" },
+        { col: 0, row: 2, type: "RestSite" },
+      );
+      store.dispatch(gameStateReceived(postMove));
+      await settle();
+
+      expect(
+        apiFetchMock.mock.calls.filter(([p]) => p === "/api/evaluate"),
+      ).toHaveLength(1);
+    });
+
+    it("DOES re-eval when the player goes off the recommended path (regression on #131)", async () => {
+      const store = createIntegrationStore();
+      setupMapEvalListener();
+      seedRun(store);
+
+      store.dispatch(gameStateReceived(buildHappyPathMapState()));
+      await waitFor(() => {
+        expect(selectEvals(store.getState()).map.result).not.toBeNull();
+      });
+      expect(
+        apiFetchMock.mock.calls.filter(([p]) => p === "/api/evaluate"),
+      ).toHaveLength(1);
+
+      // Player picks the Shop at (2,1) — not on the recommended path.
+      const offPath = buildPostMoveMapState(
+        { col: 2, row: 1, type: "Shop" },
+        { col: 2, row: 2, type: "Monster" },
+      );
+      store.dispatch(gameStateReceived(offPath));
+
+      await waitFor(() => {
+        expect(
+          apiFetchMock.mock.calls.filter(([p]) => p === "/api/evaluate"),
+        ).toHaveLength(2);
+      });
+    });
+  });
 });

--- a/apps/desktop/src/features/map/__tests__/mapListeners-cache-eager-set.test.ts
+++ b/apps/desktop/src/features/map/__tests__/mapListeners-cache-eager-set.test.ts
@@ -221,6 +221,7 @@ function seedRun(
         act: 1,
         gold: 99,
         ascension: 0,
+        position: null,
       },
     }),
   );
@@ -474,6 +475,7 @@ describe("setupMapEvalListener — eager run-state cache (#97)", () => {
           act: 1,
           gold: 99,
           ascension: 0,
+          position: null,
         },
       }),
     );

--- a/apps/desktop/src/features/map/mapListeners.ts
+++ b/apps/desktop/src/features/map/mapListeners.ts
@@ -88,10 +88,9 @@ export function parseNodeId(nodeId: string): { col: number; row: number } | null
  * Map evaluation listener.
  *
  * Watches game state changes on the map. Decides whether to evaluate
- * (via shouldEvaluateMap — three structural triggers: new map, moved
- * onto off-path node, or fork with distinct downstream subgraphs), then
- * owns the full eval pipeline: API call, path derivation, recommended
- * nodes, and Redux persistence.
+ * (via shouldEvaluateMap — see its JSDoc for the full trigger list),
+ * then owns the full eval pipeline: API call, path derivation,
+ * recommended nodes, and Redux persistence.
  */
 export function setupMapEvalListener() {
   let prevMapPosition: { col: number; row: number } | null = null;

--- a/apps/desktop/src/features/map/mapListeners.ts
+++ b/apps/desktop/src/features/map/mapListeners.ts
@@ -286,6 +286,14 @@ export function setupMapEvalListener() {
           computeSubgraphFingerprint(allNodesForFp, { col: o.col, row: o.row }, bossRow - 1),
         );
 
+        const lastPos = prevContext?.position ?? null;
+        const currentPosUnchanged = !!(
+          lastPos && currentPos &&
+          lastPos.col === currentPos.col && lastPos.row === currentPos.row
+        );
+        const floorsSinceLastEvalPosition =
+          lastPos && currentPos ? currentPos.row - lastPos.row : null;
+
         const input = {
           optionCount: options.length,
           hasPrevContext: !!prevContext,
@@ -295,6 +303,8 @@ export function setupMapEvalListener() {
           isOnRecommendedPath: isOnPath,
           nextOptions: options.map((o) => ({ col: o.col, row: o.row, type: o.type.toLowerCase() })),
           nextOptionSubgraphFingerprints: fingerprints,
+          currentPosUnchanged,
+          floorsSinceLastEvalPosition,
         };
 
         const shouldEval = shouldEvaluateMap(input);
@@ -399,6 +409,12 @@ export function setupMapEvalListener() {
         maxHp: mapPlayer?.max_hp ?? 80,
         currentRemovalCost: player?.cardRemovalCost ?? 75,
         nodePreferences: storedPrefs,
+        currentPosition: mapState.map?.current_position
+          ? {
+              col: mapState.map.current_position.col,
+              row: mapState.map.current_position.row,
+            }
+          : null,
       });
       // Preserve the PREVIOUS act in the pre-eval context so that if the
       // API call fails, shouldEvaluateMap still detects the act change and
@@ -594,6 +610,7 @@ export function setupMapEvalListener() {
             act,
             gold: mapPlayer?.gold ?? 0,
             ascension: run.ascension,
+            position: currentPos ? { col: currentPos.col, row: currentPos.row } : null,
           },
         }));
         logReduxSnapshot(listenerApi as unknown as { getState: () => unknown }, "after_map_eval");

--- a/apps/desktop/src/features/run/runSlice.ts
+++ b/apps/desktop/src/features/run/runSlice.ts
@@ -27,6 +27,8 @@ export interface MapEvalState {
     act: number;
     gold: number;
     ascension: number;
+    /** Player's map position when this eval ran. Used to suppress on-path re-eval. */
+    position: { col: number; row: number } | null;
   } | null;
   nodePreferences: {
     monster: number;

--- a/apps/desktop/src/lib/__tests__/build-pre-eval-payload.test.ts
+++ b/apps/desktop/src/lib/__tests__/build-pre-eval-payload.test.ts
@@ -44,6 +44,7 @@ const baseParams = {
   maxHp: 80,
   currentRemovalCost: 75,
   nodePreferences: null,
+  currentPosition: { col: 1, row: 0 },
 };
 
 describe("buildPreEvalPayload", () => {
@@ -77,6 +78,7 @@ describe("buildPreEvalPayload", () => {
       act: 2,
       gold: 50,
       ascension: 5,
+      position: { col: 1, row: 0 },
     });
   });
 

--- a/apps/desktop/src/lib/build-pre-eval-payload.ts
+++ b/apps/desktop/src/lib/build-pre-eval-payload.ts
@@ -24,15 +24,24 @@ export function buildPreEvalPayload(params: {
   maxHp: number;
   currentRemovalCost: number;
   nodePreferences: NodePreferences | null;
+  currentPosition: { col: number; row: number } | null;
 }): {
   recommendedNodes: string[];
-  lastEvalContext: { hpPercent: number; deckSize: number; act: number; gold: number; ascension: number };
+  lastEvalContext: {
+    hpPercent: number;
+    deckSize: number;
+    act: number;
+    gold: number;
+    ascension: number;
+    position: { col: number; row: number } | null;
+  };
 } {
   const {
     options, allNodes, bossPos,
     hpPercent, gold, act, deckSize,
     ascension, maxHp, currentRemovalCost,
     nodePreferences,
+    currentPosition,
   } = params;
 
   const recommendedNodes = new Set<string>();
@@ -59,6 +68,13 @@ export function buildPreEvalPayload(params: {
 
   return {
     recommendedNodes: [...recommendedNodes],
-    lastEvalContext: { hpPercent, deckSize, act, gold, ascension },
+    lastEvalContext: {
+      hpPercent,
+      deckSize,
+      act,
+      gold,
+      ascension,
+      position: currentPosition,
+    },
   };
 }

--- a/apps/desktop/src/lib/should-evaluate-map.test.ts
+++ b/apps/desktop/src/lib/should-evaluate-map.test.ts
@@ -11,6 +11,8 @@ function base(overrides: Partial<Parameters<typeof shouldEvaluateMap>[0]> = {}) 
     isOnRecommendedPath: true,
     nextOptions: [{ col: 0, row: 2, type: "monster" }],
     nextOptionSubgraphFingerprints: ["x"],
+    currentPosUnchanged: false,
+    floorsSinceLastEvalPosition: null as number | null,
     ...overrides,
   };
 }
@@ -95,5 +97,48 @@ describe("shouldEvaluateMap — triggers", () => {
 
   it("no-op when none of the triggers fire (single forced option, on-path)", () => {
     expect(shouldEvaluateMap(base())).toBe(false);
+  });
+
+  describe("on-path suppression", () => {
+    it("suppresses re-eval when the player hasn't moved since the last eval", () => {
+      // Repeated poll on the ancient row: same currentPosition, on-path,
+      // meaningful fork ahead. The initial eval already analyzed it.
+      expect(
+        shouldEvaluateMap(twoTypeFork({ currentPosUnchanged: true })),
+      ).toBe(false);
+    });
+
+    it("suppresses re-eval on the first on-path move (one floor advance)", () => {
+      // Drew's stated repro: player just picked the recommended first-floor
+      // node. The initial eval already analyzed this fork.
+      expect(
+        shouldEvaluateMap(twoTypeFork({ floorsSinceLastEvalPosition: 1 })),
+      ).toBe(false);
+    });
+
+    it("still re-evals on a meaningful fork after multiple on-path floors", () => {
+      // Backstop: if several floors elapsed without a re-eval, a fresh fork
+      // analysis is useful.
+      expect(
+        shouldEvaluateMap(twoTypeFork({ floorsSinceLastEvalPosition: 3 })),
+      ).toBe(true);
+    });
+
+    it("off-path beats the standing-still guard", () => {
+      // Off-path is a first-class trigger and runs before the new guards.
+      expect(
+        shouldEvaluateMap(
+          twoTypeFork({ isOnRecommendedPath: false, currentPosUnchanged: true }),
+        ),
+      ).toBe(true);
+    });
+
+    it("does not suppress when floorsSinceLastEvalPosition is null", () => {
+      // Null means no prior eval position recorded — fall through to the
+      // existing fork logic so we don't lose the backstop.
+      expect(
+        shouldEvaluateMap(twoTypeFork({ floorsSinceLastEvalPosition: null })),
+      ).toBe(true);
+    });
   });
 });

--- a/apps/desktop/src/lib/should-evaluate-map.ts
+++ b/apps/desktop/src/lib/should-evaluate-map.ts
@@ -7,6 +7,10 @@ export interface ShouldEvaluateMapInput {
   isOnRecommendedPath: boolean;
   nextOptions: { col: number; row: number; type: string }[];
   nextOptionSubgraphFingerprints: string[];
+  /** True when currentPosition matches the position recorded at the last eval. */
+  currentPosUnchanged: boolean;
+  /** Rows advanced since the last eval, or null if no prior eval position is known. */
+  floorsSinceLastEvalPosition: number | null;
 }
 
 function hasMeaningfulFork(input: ShouldEvaluateMapInput): boolean {
@@ -28,8 +32,13 @@ function hasMeaningfulFork(input: ShouldEvaluateMapInput): boolean {
  * 3. Off-path deviation. The player is no longer on the recommended path —
  *    re-plan immediately so the recommendation reflects the actual position,
  *    even at forced rows. Predictability beats token savings here.
- * 4. Meaningful fork. Multiple `next_options` that differ in type or in
- *    downstream subgraph fingerprint.
+ * 4. On-path suppression. Skip re-eval when the player is on-path AND
+ *    either (a) hasn't moved since the last eval, or (b) just advanced
+ *    one floor along the recommended path. The initial eval already
+ *    analyzed this fork — no new information to add.
+ * 5. Meaningful fork (backstop). Multiple `next_options` that differ in
+ *    type or in downstream subgraph fingerprint, when several on-path
+ *    floors have elapsed without a fresh analysis.
  */
 export function shouldEvaluateMap(input: ShouldEvaluateMapInput): boolean {
   if (input.optionCount <= 0) return false;
@@ -42,6 +51,12 @@ export function shouldEvaluateMap(input: ShouldEvaluateMapInput): boolean {
   }
 
   if (!input.isOnRecommendedPath) return true;
+
+  // On-path: the initial eval already analyzed the full downstream tree
+  // from the last-eval position. Suppress re-eval until the player has
+  // advanced far enough that a fresh analysis adds information.
+  if (input.currentPosUnchanged) return false;
+  if (input.floorsSinceLastEvalPosition === 1) return false;
 
   return hasMeaningfulFork(input);
 }


### PR DESCRIPTION
Closes #143

## Repro

1. Start a run
2. Pick first ancient relic
3. Land on map → initial eval runs (correct)
4. Sit on the ancient row → re-eval fires every poll
5. Select first node following recommendation → re-eval fires again

## Root cause

Dev-session JSONL captured five consecutive \`map_should_eval\` events with identical \`currentPosition\` and \`isOnRecommendedPath: true\` all returning \`shouldEval: true\` because the row-1 options had distinct downstream subgraph fingerprints — \`hasMeaningfulFork()\` was firing on a fork the initial eval already analyzed.

## Fix

Track \`position\` in \`lastEvalContext\` and add two guards before the meaningful-fork backstop in \`shouldEvaluateMap\`:

- \`currentPosUnchanged\` → return false (standing still)
- \`floorsSinceLastEvalPosition === 1\` → return false (first on-path move)

Off-path (\`!isOnRecommendedPath\`) re-evals untouched. \`hasMeaningfulFork\` stays as the backstop for cases where several on-path floors elapse.

## Test plan
- [x] \`pnpm --filter @sts2/desktop test\` — 811 pass (76 files)
- [x] \`pnpm --filter @sts2/desktop lint\` — 0 errors
- [x] 4 new unit tests in \`should-evaluate-map.test.ts\` (standing-still, one-floor advance, multi-floor backstop, off-path beats the guard)
- [x] 3 new integration tests in \`map-eval-flow.test.tsx\` (repeat poll, on-path move, off-path move regression on #131)
- [ ] Live verify: \`cd apps/desktop && pnpm tauri dev\`, reproduce the floor-1 repro, tail \`~/Library/Logs/com.sts2replay.desktop/dev-session-*.jsonl | grep map_should_eval\` and confirm \`shouldEval: false\` after the initial eval