### PR TITLE
feat(tier-lists): refresh action + multi-character split + 4-week staleness

### DIFF
--- a/apps/web/src/app/admin/tier-lists/page.tsx
+++ b/apps/web/src/app/admin/tier-lists/page.tsx
@@ -44,6 +44,17 @@ function deriveSourceId(author: string, sourceType: SourceType): string {
   return `${slug || "unknown"}-${sourceType}`;
 }
 
+// Thresholds intentionally inlined (mirrors AGING_DAYS/STALE_DAYS from
+// shared/evaluation/community-tier.ts). Keeps the UI free of cross-package
+// runtime imports for a 4-line helper.
+function classifyRowStaleness(publishedAt: string): "fresh" | "aging" | "excluded" {
+  const ageDays = (Date.now() - new Date(publishedAt).getTime()) / 86_400_000;
+  if (Number.isNaN(ageDays)) return "fresh";
+  if (ageDays < 28) return "fresh";
+  if (ageDays < 84) return "aging";
+  return "excluded";
+}
+
 interface ExtractedCard {
   name: string;
   tier: string;
@@ -767,6 +778,22 @@ function IngestedListsTable({ onRefresh }: { onRefresh: (row: IngestedRow) => vo
   const visible = lists
     .filter((l) => (showInactive ? true : l.is_active))
     .filter((l) => !authorFilter || l.source.author === authorFilter);
+
+  const sortedRows = useMemo(() => {
+    const rank: Record<"fresh" | "aging" | "excluded", number> = {
+      excluded: 0,
+      aging: 1,
+      fresh: 2,
+    };
+    return [...visible].sort((a, b) => {
+      const sa = rank[classifyRowStaleness(a.published_at)];
+      const sb = rank[classifyRowStaleness(b.published_at)];
+      if (sa !== sb) return sa - sb;
+      // Tiebreaker: most-recently-ingested first
+      return new Date(b.ingested_at).getTime() - new Date(a.ingested_at).getTime();
+    });
+  }, [visible]);
+
   const activeCount = lists.filter((l) => l.is_active).length;
   const inactiveCount = lists.length - activeCount;
 
@@ -816,7 +843,7 @@ function IngestedListsTable({ onRefresh }: { onRefresh: (row: IngestedRow) => vo
         <div className="px-4 py-6 text-sm text-red-400">
           Failed to load: {error instanceof Error ? error.message : String(error)}
         </div>
-      ) : !isLoading && visible.length === 0 ? (
+      ) : !isLoading && sortedRows.length === 0 ? (
         <div className="px-4 py-6 text-sm text-zinc-500">
           No tier lists ingested yet.
         </div>
@@ -838,7 +865,7 @@ function IngestedListsTable({ onRefresh }: { onRefresh: (row: IngestedRow) => vo
               </tr>
             </thead>
             <tbody className="divide-y divide-zinc-900">
-              {visible.map((row) => (
+              {sortedRows.map((row) => (
                 <tr
                   key={row.id}
                   className={`${row.is_active ? "text-zinc-200" : "text-zinc-600"} hover:bg-zinc-900/40 transition-colors`}
@@ -860,7 +887,24 @@ function IngestedListsTable({ onRefresh }: { onRefresh: (row: IngestedRow) => vo
                   <Td className="text-zinc-500">{row.source.source_type}</Td>
                   <Td>{row.character ?? "any"}</Td>
                   <Td className="text-zinc-500">{row.game_version ?? "—"}</Td>
-                  <Td className="text-zinc-500">{formatDate(row.published_at)}</Td>
+                  <Td className="text-zinc-500">
+                    <div className="flex items-center gap-2">
+                      {formatDate(row.published_at)}
+                      {(() => {
+                        const status = classifyRowStaleness(row.published_at);
+                        const chipClasses = {
+                          fresh: "bg-emerald-900/40 text-emerald-300",
+                          aging: "bg-amber-900/40 text-amber-300",
+                          excluded: "bg-rose-900/40 text-rose-300",
+                        }[status];
+                        return (
+                          <span className={`inline-block rounded px-1.5 py-0.5 text-xs ${chipClasses}`}>
+                            {status}
+                          </span>
+                        );
+                      })()}
+                    </div>
+                  </Td>
                   <Td className="text-right font-mono">{row.entry_count}</Td>
                   <Td className="text-right font-mono text-zinc-500">
                     {row.source.trust_weight.toFixed(1)}

--- a/apps/web/src/app/admin/tier-lists/page.tsx
+++ b/apps/web/src/app/admin/tier-lists/page.tsx
@@ -316,6 +316,14 @@ function TierListContent() {
         return { ...s, include: true, cardIdMap };
       });
 
+      // Check if scrape adapter found any sections — empty response means
+      // the adapter couldn't extract the tier list.
+      if (sections.length === 0) {
+        setError("No tier list data found. Check the URL and HTML.");
+        setSubmitting(false);
+        return;
+      }
+
       setPreviewSections(sections);
       setActiveSectionIdx(0);
       // Keep extractResult minimal for scrape — imageUrl comes from the
@@ -332,8 +340,9 @@ function TierListContent() {
       setCards([]);
 
       // Pre-populate tier mapping from the first section's scale type.
-      // tierMapping is global — per-section mapping is a follow-up improvement.
       // TODO: make tierMapping per-section so mixed-scale lists map correctly.
+      // (cardIdMap is already per-section by necessity — each PreviewSection has
+      // its own matched[] pool, so the lookup table is built per-section.)
       if (sections.length > 0) {
         const firstSection = sections[0];
         const orderedLabels = Array.from(
@@ -473,7 +482,9 @@ function TierListContent() {
     // Build scale_config.map from the admin's tier mapping. Merges with any
     // adapter-provided scale_config (e.g. tiermaker's 7-letter override) so
     // both descriptive-label and letter-scale cases co-exist.
-    // TODO: per-section tierMapping for mixed-scale lists.
+    // TODO: make tierMapping per-section so mixed-scale lists map correctly.
+    // (cardIdMap is already per-section by necessity — each PreviewSection has
+    // its own matched[] pool, so the lookup table is built per-section.)
     const mappingEntries = Object.entries(tierMapping);
     const adapterMap = extractResult.scaleConfig?.map ?? {};
     const mergedMap: Record<string, number> = { ...adapterMap };

--- a/apps/web/src/app/admin/tier-lists/page.tsx
+++ b/apps/web/src/app/admin/tier-lists/page.tsx
@@ -26,6 +26,11 @@ interface SourceMeta {
   published_at: string;
 }
 
+interface RefreshContext {
+  sourceId: string;
+  sourceMeta: SourceMeta;
+}
+
 /**
  * Derive a stable source_id slug from author + source_type.
  * Same author + type always maps to the same row, so re-uploads hit
@@ -54,6 +59,36 @@ interface ScrapedCardInfo {
   imageUrl: string;
   name?: string;
   source?: "alt" | "filename" | "phash" | "none";
+}
+
+/** Card entry from the scrape route's sections[].matched[] response. */
+interface MatchedCard {
+  externalId?: string;
+  tier: string;
+  imageUrl: string;
+  name: string;
+  cardId: string | null;
+  confidence: number;
+  source: "alt" | "filename" | "phash" | "none";
+  distance: number | null;
+  error?: string;
+}
+
+/** One character/section from the scrape response, enriched for preview UI. */
+interface PreviewSection {
+  detectedCharacter: string | null;
+  scaleType: ScaleType;
+  scaleConfig?: { map: Record<string, number> } | null;
+  matched: MatchedCard[];
+  unmatched: MatchedCard[];
+  warnings: string[];
+  /** Per-section opt-out checkbox state, default true. */
+  include: boolean;
+  /**
+   * Name → cardId map rebuilt from matched[]. Used by confirm to resolve
+   * entries and by the inline combobox to look up IDs.
+   */
+  cardIdMap: Record<string, string>;
 }
 
 interface ExtractResult {
@@ -205,10 +240,17 @@ function TierListContent() {
   const [tierMapping, setTierMapping] = useState<Record<string, LetterOption>>(
     draft?.tierMapping ?? {},
   );
+  // Multi-section preview state (populated from scrape sections[] response).
+  // Image-upload path creates a single synthetic PreviewSection from the
+  // vision-LLM ExtractResult so the same confirm logic handles both modes.
+  const [previewSections, setPreviewSections] = useState<PreviewSection[]>([]);
+  const [activeSectionIdx, setActiveSectionIdx] = useState(0);
+
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [savedCount, setSavedCount] = useState(0);
   const [refreshWarning, setRefreshWarning] = useState<string | null>(null);
+  const [refreshing, setRefreshing] = useState<RefreshContext | null>(null);
 
   // ── Step 1: Extract ─────────────────────────────────────────────────────────
 
@@ -217,8 +259,8 @@ function TierListContent() {
     setSubmitting(true);
     setError(null);
 
-    let result: ExtractResult;
     if (ingestMode === "scrape") {
+      // ── Scrape path: API returns sections[] ─────────────────────────────────
       if (!scrapeUrl || !scrapeHtml) {
         setError("Paste the source URL and the tier list HTML before extracting.");
         setSubmitting(false);
@@ -253,8 +295,62 @@ function TierListContent() {
         setSubmitting(false);
         return;
       }
-      result = data as ExtractResult;
+
+      // Build PreviewSection[] from API sections. Each section's cardIdMap is
+      // reconstructed from matched[].cardId so confirm can resolve entries
+      // without a global cardIdMap.
+      const sections: PreviewSection[] = (
+        data.sections as Array<{
+          detectedCharacter: string | null;
+          scaleType: ScaleType;
+          scaleConfig?: { map: Record<string, number> } | null;
+          matched: MatchedCard[];
+          unmatched: MatchedCard[];
+          warnings: string[];
+        }>
+      ).map((s) => {
+        const cardIdMap: Record<string, string> = {};
+        for (const m of s.matched) {
+          if (m.cardId) cardIdMap[m.name] = m.cardId;
+        }
+        return { ...s, include: true, cardIdMap };
+      });
+
+      setPreviewSections(sections);
+      setActiveSectionIdx(0);
+      // Keep extractResult minimal for scrape — imageUrl comes from the
+      // section cards, not a top-level upload. We only need imageUrl=null
+      // and ingestionMethod for the confirm payload.
+      setExtractResult({
+        imageUrl: null,
+        extraction: { tiers: [], detected_scale: null, detected_character: null, warnings: [] },
+        cardIdMap: {},
+        ingestionMethod: "scraped",
+        sourceUrl: scrapeUrl,
+      });
+      // Scrape cards are held in previewSections; clear the legacy cards state.
+      setCards([]);
+
+      // Pre-populate tier mapping from the first section's scale type.
+      // tierMapping is global — per-section mapping is a follow-up improvement.
+      // TODO: make tierMapping per-section so mixed-scale lists map correctly.
+      if (sections.length > 0) {
+        const firstSection = sections[0];
+        const orderedLabels = Array.from(
+          new Set(firstSection.matched.map((m) => m.tier)),
+        );
+        const nonStandard = orderedLabels.filter(
+          (l) => !isStandardTierLabel(l, firstSection.scaleType),
+        );
+        if (nonStandard.length > 0) {
+          setTierMapping((prev) => ({
+            ...inferLetterMapping(orderedLabels),
+            ...prev,
+          }));
+        }
+      }
     } else {
+      // ── Image path: vision LLM returns old ExtractResult shape ──────────────
       if (!imageFile) {
         setSubmitting(false);
         return;
@@ -279,58 +375,87 @@ function TierListContent() {
         setSubmitting(false);
         return;
       }
-      result = data as ExtractResult;
-    }
-    setExtractResult(result);
+      const result = data as ExtractResult;
+      setExtractResult(result);
 
-    // Build a normalized lookup so we can auto-match common variants
-    // (case differences, trailing "+", whitespace) without bothering the admin.
-    const normalizedLookup = new Map<string, string>();
-    for (const canonical of Object.keys(result.cardIdMap)) {
-      normalizedLookup.set(normalizeCardName(canonical), canonical);
-    }
-
-    // Flatten tiers → card rows. Auto-populate matchedName for fuzzy matches
-    // so the admin only has to resolve truly unknown cards. For scraped lists,
-    // zip in per-card source metadata (sourceImageUrl) so the preview can
-    // render a thumbnail next to each row.
-    const flat: ExtractedCard[] = [];
-    let sourceIdx = 0;
-    for (const tier of result.extraction.tiers ?? []) {
-      for (const card of tier.cards) {
-        const matched = resolveExtractedName(card.name, result.cardIdMap, normalizedLookup);
-        const scraped = result.scrapedCards?.[sourceIdx];
-        flat.push({
-          name: card.name,
-          tier: tier.label,
-          confidence: card.confidence,
-          matchedName: matched && matched !== card.name ? matched : undefined,
-          sourceImageUrl: scraped?.imageUrl,
-        });
-        sourceIdx++;
+      // Build a normalized lookup so we can auto-match common variants
+      // (case differences, trailing "+", whitespace) without bothering the admin.
+      const normalizedLookup = new Map<string, string>();
+      for (const canonical of Object.keys(result.cardIdMap)) {
+        normalizedLookup.set(normalizeCardName(canonical), canonical);
       }
-    }
-    setCards(flat);
 
-    // Detect non-standard tier labels and pre-populate a letter mapping so
-    // the confirm payload can set source.scale_config.map. Keeps descriptive
-    // scales like "Premium / Want in most decks / Bad" first-class.
-    const orderedLabels: string[] = [];
-    const seen = new Set<string>();
-    for (const tier of result.extraction.tiers ?? []) {
-      if (!seen.has(tier.label)) {
-        seen.add(tier.label);
-        orderedLabels.push(tier.label);
+      // Flatten tiers → card rows. Auto-populate matchedName for fuzzy matches
+      // so the admin only has to resolve truly unknown cards.
+      const flat: ExtractedCard[] = [];
+      let sourceIdx = 0;
+      for (const tier of result.extraction.tiers ?? []) {
+        for (const card of tier.cards) {
+          const matched = resolveExtractedName(card.name, result.cardIdMap, normalizedLookup);
+          const scraped = result.scrapedCards?.[sourceIdx];
+          flat.push({
+            name: card.name,
+            tier: tier.label,
+            confidence: card.confidence,
+            matchedName: matched && matched !== card.name ? matched : undefined,
+            sourceImageUrl: scraped?.imageUrl,
+          });
+          sourceIdx++;
+        }
       }
-    }
-    const nonStandard = orderedLabels.filter(
-      (l) => !isStandardTierLabel(l, meta.scale_type),
-    );
-    if (nonStandard.length > 0) {
-      setTierMapping((prev) => ({
-        ...inferLetterMapping(orderedLabels),
-        ...prev, // preserve any admin overrides already in the draft
-      }));
+      setCards(flat);
+
+      // Detect non-standard tier labels and pre-populate a letter mapping.
+      const orderedLabels: string[] = [];
+      const seen = new Set<string>();
+      for (const tier of result.extraction.tiers ?? []) {
+        if (!seen.has(tier.label)) {
+          seen.add(tier.label);
+          orderedLabels.push(tier.label);
+        }
+      }
+      const nonStandard = orderedLabels.filter(
+        (l) => !isStandardTierLabel(l, meta.scale_type),
+      );
+      if (nonStandard.length > 0) {
+        setTierMapping((prev) => ({
+          ...inferLetterMapping(orderedLabels),
+          ...prev, // preserve any admin overrides already in the draft
+        }));
+      }
+
+      // Wrap the image extraction result into a single synthetic PreviewSection
+      // so the confirm path is uniform across both ingest modes.
+      const imageSection: PreviewSection = {
+        detectedCharacter: result.extraction.detected_character ?? null,
+        scaleType: meta.scale_type,
+        scaleConfig: result.scaleConfig ?? null,
+        matched: flat.map((c) => ({
+          tier: c.tier,
+          imageUrl: c.sourceImageUrl ?? result.imageUrl ?? "",
+          name: c.matchedName ?? c.name,
+          cardId: result.cardIdMap[c.matchedName ?? c.name] ?? null,
+          confidence: c.confidence,
+          source: "none" as const,
+          distance: null,
+        })),
+        unmatched: flat
+          .filter((c) => !result.cardIdMap[c.matchedName ?? c.name])
+          .map((c) => ({
+            tier: c.tier,
+            imageUrl: c.sourceImageUrl ?? result.imageUrl ?? "",
+            name: c.matchedName ?? c.name,
+            cardId: null,
+            confidence: c.confidence,
+            source: "none" as const,
+            distance: null,
+          })),
+        warnings: result.extraction.warnings ?? [],
+        include: true,
+        cardIdMap: result.cardIdMap,
+      };
+      setPreviewSections([imageSection]);
+      setActiveSectionIdx(0);
     }
 
     setStep("preview");
@@ -340,37 +465,15 @@ function TierListContent() {
   // ── Step 2: Confirm ─────────────────────────────────────────────────────────
 
   const handleConfirm = async () => {
-    if (!extractResult) return;
+    if (!extractResult || previewSections.length === 0) return;
 
     setSubmitting(true);
     setError(null);
 
-    const { cardIdMap, imageUrl } = extractResult;
-    const skipped: string[] = [];
-
-    const entries = cards
-      .map((c) => {
-        const resolvedName = c.matchedName ?? c.name;
-        const card_id = cardIdMap[resolvedName];
-        if (!card_id) {
-          skipped.push(c.name);
-          return null;
-        }
-        return {
-          card_id,
-          raw_tier: c.tier,
-          extraction_confidence: c.confidence,
-        };
-      })
-      .filter((e): e is NonNullable<typeof e> => e !== null);
-
-    if (skipped.length > 0) {
-      console.warn("[TierListIngestion] Skipped unresolved cards:", skipped);
-    }
-
     // Build scale_config.map from the admin's tier mapping. Merges with any
     // adapter-provided scale_config (e.g. tiermaker's 7-letter override) so
     // both descriptive-label and letter-scale cases co-exist.
+    // TODO: per-section tierMapping for mixed-scale lists.
     const mappingEntries = Object.entries(tierMapping);
     const adapterMap = extractResult.scaleConfig?.map ?? {};
     const mergedMap: Record<string, number> = { ...adapterMap };
@@ -380,11 +483,54 @@ function TierListContent() {
     const scaleConfig =
       Object.keys(mergedMap).length > 0 ? { map: mergedMap } : null;
 
+    // Build sections payload from checked sections only.
+    const includedSections = previewSections.filter((s) => s.include);
+    if (includedSections.length === 0) {
+      setError("Select at least one section to confirm.");
+      setSubmitting(false);
+      return;
+    }
+
+    const skipped: string[] = [];
+    const sectionsPayload = includedSections.map((section) => {
+      const entries = section.matched
+        .map((m) => {
+          if (!m.cardId) {
+            skipped.push(m.name);
+            return null;
+          }
+          return {
+            card_id: m.cardId,
+            raw_tier: m.tier,
+            extraction_confidence: m.confidence,
+          };
+        })
+        .filter((e): e is NonNullable<typeof e> => e !== null);
+
+      return {
+        list: {
+          // Use section's detected character; fall back to wizard meta when
+          // the section didn't detect one (single-section paste, user selected
+          // character explicitly in the wizard).
+          character:
+            section.detectedCharacter ??
+            (meta.character === "any" ? null : meta.character),
+          game_version: meta.game_version || null,
+          published_at: meta.published_at,
+        },
+        entries,
+      };
+    });
+
+    if (skipped.length > 0) {
+      console.warn("[TierListIngestion] Skipped unresolved cards:", skipped);
+    }
+
     const body = {
-      imageUrl,
+      imageUrl: extractResult.imageUrl,
       ingestionMethod: extractResult.ingestionMethod ?? "vision_llm",
       source: {
-        id: deriveSourceId(meta.author, meta.source_type),
+        id: refreshing ? refreshing.sourceId : deriveSourceId(meta.author, meta.source_type),
         author: meta.author,
         source_type: meta.source_type,
         source_url: meta.source_url || extractResult.sourceUrl || null,
@@ -393,12 +539,7 @@ function TierListContent() {
         scale_config: scaleConfig,
         notes: null,
       },
-      list: {
-        game_version: meta.game_version || null,
-        published_at: meta.published_at,
-        character: meta.character === "any" ? null : meta.character,
-      },
-      entries,
+      sections: sectionsPayload,
     };
 
     const res = await fetch("/api/admin/tier-lists/confirm", {
@@ -415,10 +556,12 @@ function TierListContent() {
       return;
     }
 
-    setSavedCount(data.entry_count ?? entries.length);
+    const totalEntries = sectionsPayload.reduce((s, sec) => s + sec.entries.length, 0);
+    setSavedCount(data.entry_count ?? totalEntries);
     setRefreshWarning(data.refreshWarning ?? null);
     setStep("success");
     setSubmitting(false);
+    setRefreshing(null);
     clearDraft();
   };
 
@@ -434,9 +577,45 @@ function TierListContent() {
     setExtractResult(null);
     setCards([]);
     setTierMapping({});
+    setPreviewSections([]);
+    setActiveSectionIdx(0);
     setError(null);
     setSavedCount(0);
     setRefreshWarning(null);
+    setRefreshing(null);
+    clearDraft();
+  };
+
+  // ── Refresh: pre-fill wizard from an existing ingested row ──────────────────
+
+  const beginRefresh = (row: IngestedRow) => {
+    const ctx: RefreshContext = {
+      sourceId: row.source.id,
+      sourceMeta: {
+        author: row.source.author,
+        source_type: row.source.source_type,
+        source_url: row.source.source_url ?? "",
+        trust_weight: row.source.trust_weight,
+        scale_type: row.source.scale_type,
+        character: (row.character as Character) ?? "any",
+        game_version: row.game_version ?? "",
+        published_at: row.published_at,
+      },
+    };
+    setRefreshing(ctx);
+    setMeta(ctx.sourceMeta);
+    setIngestMode(row.source.source_type === "image" ? "image" : "scrape");
+    if (row.source.source_url) {
+      setScrapeUrl(row.source.source_url);
+    }
+    // Reset any leftover extraction state so the wizard starts fresh
+    setExtractResult(null);
+    setCards([]);
+    setTierMapping({});
+    setPreviewSections([]);
+    setActiveSectionIdx(0);
+    setError(null);
+    setStep("upload");
     clearDraft();
   };
 
@@ -477,7 +656,7 @@ function TierListContent() {
 
         {step === "upload" && (
           <>
-            <IngestedListsTable />
+            <IngestedListsTable onRefresh={beginRefresh} />
             <UploadStep
               meta={meta}
               ingestMode={ingestMode}
@@ -485,6 +664,8 @@ function TierListContent() {
               scrapeUrl={scrapeUrl}
               scrapeHtml={scrapeHtml}
               submitting={submitting}
+              sourceLocked={refreshing !== null}
+              refreshingAuthor={refreshing?.sourceMeta.author ?? null}
               onMetaChange={setMeta}
               onIngestModeChange={setIngestMode}
               onImageChange={setImageFile}
@@ -495,15 +676,19 @@ function TierListContent() {
           </>
         )}
 
-        {step === "preview" && extractResult && (
+        {step === "preview" && extractResult && previewSections.length > 0 && (
           <PreviewStep
             meta={meta}
             result={extractResult}
             cards={cards}
             tierMapping={tierMapping}
+            previewSections={previewSections}
+            activeSectionIdx={activeSectionIdx}
             submitting={submitting}
             onCardsChange={setCards}
             onTierMappingChange={setTierMapping}
+            onSectionsChange={setPreviewSections}
+            onActiveSectionChange={setActiveSectionIdx}
             onBack={() => setStep("upload")}
             onDiscard={handleReset}
             onConfirm={handleConfirm}
@@ -536,6 +721,8 @@ interface IngestedRow {
     source_type: SourceType;
     source_url: string | null;
     trust_weight: number;
+    scale_type: ScaleType;
+    scale_config: Record<string, unknown> | null;
   };
 }
 
@@ -545,7 +732,7 @@ const fetcher = async (url: string): Promise<{ lists: IngestedRow[] }> => {
   return res.json();
 };
 
-function IngestedListsTable() {
+function IngestedListsTable({ onRefresh }: { onRefresh: (row: IngestedRow) => void }) {
   const { data, error, isLoading, mutate } = useSWR<{ lists: IngestedRow[] }>(
     "/api/admin/tier-lists",
     fetcher,
@@ -681,13 +868,22 @@ function IngestedListsTable() {
                     )}
                   </Td>
                   <Td className="text-right">
-                    <button
-                      type="button"
-                      onClick={() => setEditing(row)}
-                      className="text-[11px] text-zinc-400 hover:text-emerald-400 hover:underline underline-offset-2"
-                    >
-                      Edit
-                    </button>
+                    <div className="flex items-center justify-end gap-3">
+                      <button
+                        type="button"
+                        onClick={() => setEditing(row)}
+                        className="text-[11px] text-zinc-400 hover:text-emerald-400 hover:underline underline-offset-2"
+                      >
+                        Edit
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => onRefresh(row)}
+                        className="text-[11px] text-zinc-400 hover:text-amber-400 hover:underline underline-offset-2"
+                      >
+                        Refresh
+                      </button>
+                    </div>
                   </Td>
                 </tr>
               ))}
@@ -1056,6 +1252,8 @@ function UploadStep({
   scrapeUrl,
   scrapeHtml,
   submitting,
+  sourceLocked,
+  refreshingAuthor,
   onMetaChange,
   onIngestModeChange,
   onImageChange,
@@ -1069,6 +1267,8 @@ function UploadStep({
   scrapeUrl: string;
   scrapeHtml: string;
   submitting: boolean;
+  sourceLocked: boolean;
+  refreshingAuthor: string | null;
   onMetaChange: (m: SourceMeta) => void;
   onIngestModeChange: (m: IngestMode) => void;
   onImageChange: (f: File | null) => void;
@@ -1081,6 +1281,8 @@ function UploadStep({
 
   const inputCls =
     "w-full rounded-md border border-zinc-800 bg-zinc-900 px-3 py-2 text-sm text-zinc-200 placeholder-zinc-600 focus:outline-none focus:border-zinc-600";
+  const disabledInputCls =
+    "w-full rounded-md border border-zinc-800 bg-zinc-900/50 px-3 py-2 text-sm text-zinc-500 placeholder-zinc-700 cursor-not-allowed opacity-60";
   const labelCls = "text-sm text-zinc-400";
 
   const canSubmit =
@@ -1090,8 +1292,15 @@ function UploadStep({
     <form onSubmit={onSubmit} className="space-y-6">
       <h2 className="text-lg font-semibold text-zinc-100">Ingest Tier List</h2>
 
+      {sourceLocked && refreshingAuthor && (
+        <div className="rounded border border-amber-500 bg-amber-950/40 p-3 text-sm text-amber-200">
+          Refreshing existing source <strong>{refreshingAuthor}</strong>.
+          Source fields are locked. Upload a new image / paste fresh HTML below.
+        </div>
+      )}
+
       {/* Mode toggle */}
-      <div className="inline-flex rounded-md border border-zinc-800 p-0.5 bg-zinc-950">
+      <div className={`inline-flex rounded-md border border-zinc-800 p-0.5 bg-zinc-950 ${sourceLocked ? "opacity-50 pointer-events-none" : ""}`}>
         <ModeTab
           active={ingestMode === "image"}
           label="Upload image"
@@ -1139,7 +1348,8 @@ function UploadStep({
                 value={scrapeUrl}
                 onChange={(e) => onScrapeUrlChange(e.target.value)}
                 placeholder="https://tiermaker.com/…"
-                className={`mt-1 ${inputCls}`}
+                disabled={sourceLocked}
+                className={`mt-1 ${sourceLocked ? disabledInputCls : inputCls}`}
               />
             </div>
             <div>
@@ -1160,8 +1370,13 @@ function UploadStep({
       </section>
 
       {/* Source metadata */}
-      <section className="rounded-lg border border-zinc-800 bg-zinc-950 p-4 space-y-4">
-        <h3 className="text-sm font-medium text-zinc-300">Source Metadata</h3>
+      <section className={`rounded-lg border border-zinc-800 bg-zinc-950 p-4 space-y-4 ${sourceLocked ? "opacity-70" : ""}`}>
+        <h3 className="text-sm font-medium text-zinc-300">
+          Source Metadata
+          {sourceLocked && (
+            <span className="ml-2 text-[10px] font-normal text-amber-400 uppercase tracking-wide">Locked</span>
+          )}
+        </h3>
 
         <div className="grid grid-cols-2 gap-4">
           <div>
@@ -1172,7 +1387,8 @@ function UploadStep({
               value={meta.author}
               onChange={(e) => set("author", e.target.value)}
               placeholder="e.g. alphabetical"
-              className={`mt-1 ${inputCls}`}
+              disabled={sourceLocked}
+              className={`mt-1 ${sourceLocked ? disabledInputCls : inputCls}`}
             />
             {meta.author && (
               <p className="mt-1 text-[11px] text-zinc-600">
@@ -1185,7 +1401,8 @@ function UploadStep({
             <select
               value={meta.source_type}
               onChange={(e) => set("source_type", e.target.value as SourceType)}
-              className={`mt-1 ${inputCls}`}
+              disabled={sourceLocked}
+              className={`mt-1 ${sourceLocked ? disabledInputCls : inputCls}`}
             >
               <option value="image">Image</option>
               <option value="spreadsheet">Spreadsheet</option>
@@ -1203,7 +1420,8 @@ function UploadStep({
             value={meta.source_url}
             onChange={(e) => set("source_url", e.target.value)}
             placeholder="https://..."
-            className={`mt-1 ${inputCls}`}
+            disabled={sourceLocked}
+            className={`mt-1 ${sourceLocked ? disabledInputCls : inputCls}`}
           />
         </div>
 
@@ -1217,7 +1435,8 @@ function UploadStep({
               step={0.1}
               value={meta.trust_weight}
               onChange={(e) => set("trust_weight", parseFloat(e.target.value))}
-              className={`mt-1 ${inputCls}`}
+              disabled={sourceLocked}
+              className={`mt-1 ${sourceLocked ? disabledInputCls : inputCls}`}
             />
           </div>
           <div>
@@ -1225,7 +1444,8 @@ function UploadStep({
             <select
               value={meta.scale_type}
               onChange={(e) => set("scale_type", e.target.value as ScaleType)}
-              className={`mt-1 ${inputCls}`}
+              disabled={sourceLocked}
+              className={`mt-1 ${sourceLocked ? disabledInputCls : inputCls}`}
             >
               <option value="letter_6">Letter 6 (S/A/B/C/D/F)</option>
               <option value="letter_5">Letter 5 (S/A/B/C/D)</option>
@@ -1333,9 +1553,13 @@ function PreviewStep({
   result,
   cards,
   tierMapping,
+  previewSections,
+  activeSectionIdx,
   submitting,
   onCardsChange,
   onTierMappingChange,
+  onSectionsChange,
+  onActiveSectionChange,
   onBack,
   onDiscard,
   onConfirm,
@@ -1344,25 +1568,50 @@ function PreviewStep({
   result: ExtractResult;
   cards: ExtractedCard[];
   tierMapping: Record<string, LetterOption>;
+  previewSections: PreviewSection[];
+  activeSectionIdx: number;
   submitting: boolean;
   onCardsChange: (cards: ExtractedCard[]) => void;
   onTierMappingChange: (m: Record<string, LetterOption>) => void;
+  onSectionsChange: (sections: PreviewSection[]) => void;
+  onActiveSectionChange: (idx: number) => void;
   onBack: () => void;
   onDiscard: () => void;
   onConfirm: () => void;
 }) {
-  const { extraction, imageUrl, cardIdMap } = result;
+  // Active section drives the preview body for scrape mode (N sections).
+  // For image mode there's always exactly 1 section; we fall back to the
+  // legacy cards/cardIdMap from result so inline card edits still work.
+  const activeSection = previewSections[activeSectionIdx];
+  const isScrapeMode = result.ingestionMethod === "scraped";
+
+  // For the image-upload path we still render from the legacy cards state
+  // (supports inline card edits / combobox). For scrape, render from section.
+  const displayCards: ExtractedCard[] = isScrapeMode
+    ? (activeSection?.matched ?? []).map((m) => ({
+        name: m.name,
+        tier: m.tier,
+        confidence: m.confidence,
+        sourceImageUrl: m.imageUrl || undefined,
+        matchedName: m.cardId ? m.name : undefined,
+      }))
+    : cards;
+  const displayCardIdMap: Record<string, string> = isScrapeMode
+    ? (activeSection?.cardIdMap ?? {})
+    : result.cardIdMap;
+
+  const { extraction, imageUrl } = result;
 
   const removeCard = (idx: number) =>
-    onCardsChange(cards.filter((_, i) => i !== idx));
+    onCardsChange(displayCards.filter((_, i) => i !== idx));
 
   const updateCard = (idx: number, patch: Partial<ExtractedCard>) =>
-    onCardsChange(cards.map((c, i) => (i === idx ? { ...c, ...patch } : c)));
+    onCardsChange(displayCards.map((c, i) => (i === idx ? { ...c, ...patch } : c)));
 
   // Group ALL cards (matched + unmatched) by tier so unmatched cards stay
   // in their extracted position — admin can match them inline while
   // comparing against the source image.
-  const allByTier = cards
+  const allByTier = displayCards
     .map((c, i) => ({ card: c, idx: i }))
     .reduce<Record<string, Array<{ card: ExtractedCard; idx: number }>>>(
       (acc, entry) => {
@@ -1373,13 +1622,23 @@ function PreviewStep({
       {},
     );
 
-  const saveableCount = cards.filter((c) => cardIdMap[c.matchedName ?? c.name]).length;
-  const unmatchedCount = cards.length - saveableCount;
-  const totalScraped = result.scrapedCards?.length ?? cards.length;
-  const droppedFromScrape = totalScraped - cards.length;
+  const saveableCount = displayCards.filter(
+    (c) => displayCardIdMap[c.matchedName ?? c.name],
+  ).length;
+  const unmatchedCount = displayCards.length - saveableCount;
+  const totalScraped = isScrapeMode
+    ? (activeSection?.matched.length ?? 0)
+    : (result.scrapedCards?.length ?? displayCards.length);
+  const droppedFromScrape = totalScraped - displayCards.length;
 
-  const detectedScale = extraction.detected_scale;
-  const detectedCharacter = extraction.detected_character;
+  // For the active section, use its detected metadata; fall back to extraction
+  // values for image-upload mode which still populates extraction.
+  const detectedScale = isScrapeMode
+    ? (activeSection?.scaleType ?? null)
+    : extraction.detected_scale;
+  const detectedCharacter = isScrapeMode
+    ? (activeSection?.detectedCharacter ?? null)
+    : extraction.detected_character;
   const scaleMismatch = detectedScale && detectedScale !== meta.scale_type;
   const characterMismatch =
     detectedCharacter &&
@@ -1392,13 +1651,14 @@ function PreviewStep({
   // shows the card's real tier instead of falling back to the first letter.
   const detectedTiers: string[] = [];
   const seenTiers = new Set<string>();
-  for (const c of cards) {
+  for (const c of displayCards) {
     if (!seenTiers.has(c.tier)) {
       seenTiers.add(c.tier);
       detectedTiers.push(c.tier);
     }
   }
-  const standardOptions = getTierOptions(meta.scale_type);
+  const sectionScaleType = isScrapeMode ? (activeSection?.scaleType ?? meta.scale_type) : meta.scale_type;
+  const standardOptions = getTierOptions(sectionScaleType);
   const tierOptions = [
     ...detectedTiers,
     ...standardOptions.filter((o) => !seenTiers.has(o)),
@@ -1406,6 +1666,14 @@ function PreviewStep({
 
   const inputCls =
     "rounded border border-zinc-700 bg-zinc-900 px-2 py-1 text-xs text-zinc-200 focus:outline-none focus:border-zinc-500";
+
+  // Total saveable count across ALL included sections (for the confirm button).
+  const totalSaveableAllSections = previewSections
+    .filter((s) => s.include)
+    .reduce(
+      (sum, s) => sum + s.matched.filter((m) => m.cardId !== null).length,
+      0,
+    );
 
   return (
     <div className="space-y-6">
@@ -1434,23 +1702,57 @@ function PreviewStep({
           </button>
           <button
             onClick={onConfirm}
-            disabled={submitting || saveableCount === 0}
+            disabled={submitting || totalSaveableAllSections === 0}
             className="rounded-md bg-emerald-600 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-500 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
           >
             {submitting
               ? "Saving..."
-              : `Confirm & Save (${saveableCount} cards${saveableCount < cards.length ? `, ${cards.length - saveableCount} unmatched` : ""})`}
+              : `Confirm & Save (${totalSaveableAllSections} cards)`}
           </button>
         </div>
       </div>
+
+      {/* Section tabs — only shown when scrape returned multiple sections. */}
+      {previewSections.length > 1 && (
+        <div className="flex gap-1 border-b border-zinc-700 mb-3">
+          {previewSections.map((s, i) => (
+            <button
+              key={i}
+              type="button"
+              onClick={() => onActiveSectionChange(i)}
+              className={
+                "px-3 py-2 text-sm flex items-center gap-2 " +
+                (i === activeSectionIdx
+                  ? "border-b-2 border-amber-400 text-amber-200"
+                  : "text-zinc-400 hover:text-zinc-200")
+              }
+            >
+              <span className="capitalize">{s.detectedCharacter ?? "Unknown"}</span>
+              <input
+                type="checkbox"
+                checked={s.include}
+                onChange={(e) =>
+                  onSectionsChange(
+                    previewSections.map((p, j) =>
+                      j === i ? { ...p, include: e.target.checked } : p,
+                    ),
+                  )
+                }
+                onClick={(e) => e.stopPropagation()}
+                aria-label={`Include ${s.detectedCharacter ?? "section"} in confirm`}
+              />
+            </button>
+          ))}
+        </div>
+      )}
 
       {/* Tier label mapping — only shown when a raw tier label isn't a
           standard letter/number, e.g. "Premium", "Want in most decks", "Bad".
           Auto-inferred by position; admin can override. */}
       {(() => {
-        const rawLabels = Array.from(new Set(cards.map((c) => c.tier)));
+        const rawLabels = Array.from(new Set(displayCards.map((c) => c.tier)));
         const nonStandard = rawLabels.filter(
-          (l) => !isStandardTierLabel(l, meta.scale_type),
+          (l) => !isStandardTierLabel(l, sectionScaleType),
         );
         if (nonStandard.length === 0) return null;
         return (
@@ -1466,7 +1768,7 @@ function PreviewStep({
             </div>
             <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-2">
               {rawLabels.map((raw) => {
-                const isStd = isStandardTierLabel(raw, meta.scale_type);
+                const isStd = isStandardTierLabel(raw, sectionScaleType);
                 const value = isStd
                   ? (raw.toUpperCase() as LetterOption)
                   : (tierMapping[raw] ?? "C");
@@ -1504,19 +1806,25 @@ function PreviewStep({
         );
       })()}
 
-      {/* Warnings */}
-      {extraction.warnings && extraction.warnings.length > 0 && (
-        <div className="rounded-md border border-yellow-500/30 bg-yellow-500/10 px-4 py-3 space-y-1">
-          <p className="text-xs font-medium text-yellow-400 uppercase tracking-wide">
-            Extraction Warnings
-          </p>
-          {extraction.warnings.map((w, i) => (
-            <p key={i} className="text-sm text-yellow-300">
-              {w}
+      {/* Warnings — use active section's warnings for scrape, extraction for image */}
+      {(() => {
+        const warnings = isScrapeMode
+          ? (activeSection?.warnings ?? [])
+          : (extraction.warnings ?? []);
+        if (warnings.length === 0) return null;
+        return (
+          <div className="rounded-md border border-yellow-500/30 bg-yellow-500/10 px-4 py-3 space-y-1">
+            <p className="text-xs font-medium text-yellow-400 uppercase tracking-wide">
+              Extraction Warnings
             </p>
-          ))}
-        </div>
-      )}
+            {warnings.map((w, i) => (
+              <p key={i} className="text-sm text-yellow-300">
+                {w}
+              </p>
+            ))}
+          </div>
+        );
+      })()}
 
       {/* Scale / character mismatch notices */}
       {(scaleMismatch || characterMismatch) && (
@@ -1581,7 +1889,7 @@ function PreviewStep({
             </p>
             <p>
               <span className="text-zinc-400">Total extracted:</span>{" "}
-              {cards.length} cards
+              {displayCards.length} cards
             </p>
             {droppedFromScrape > 0 && (
               <p className="text-orange-400">
@@ -1621,7 +1929,7 @@ function PreviewStep({
               <div className="divide-y divide-zinc-900">
                 {entries.map(({ card, idx }) => {
                   const resolvedName = card.matchedName ?? card.name;
-                  const isMatched = !!cardIdMap[resolvedName];
+                  const isMatched = !!displayCardIdMap[resolvedName];
                   return (
                     <div
                       key={`${tier}-${idx}`}
@@ -1660,7 +1968,7 @@ function PreviewStep({
                             <span className="text-xs text-orange-500/60 shrink-0">→</span>
                             <CardCombobox
                               value={card.matchedName ?? ""}
-                              cardIdMap={cardIdMap}
+                              cardIdMap={displayCardIdMap}
                               defaultQuery={card.name}
                               onChange={(name) =>
                                 updateCard(idx, { matchedName: name ?? undefined })
@@ -1707,7 +2015,7 @@ function PreviewStep({
             </div>
           ))}
 
-          {cards.length === 0 && (
+          {displayCards.length === 0 && (
             <div className="rounded-lg border border-zinc-800 bg-zinc-950 px-4 py-8 text-center">
               <p className="text-sm text-zinc-500">No cards remaining.</p>
             </div>

--- a/apps/web/src/app/api/admin/tier-lists/confirm/route.test.ts
+++ b/apps/web/src/app/api/admin/tier-lists/confirm/route.test.ts
@@ -1,0 +1,171 @@
+/**
+ * @vitest-environment node
+ *
+ * Schema-level tests for `/api/admin/tier-lists/confirm`.
+ * The full route handler depends on auth + Supabase which are out of scope
+ * here — these tests cover the zod contract for the sections[] payload shape
+ * and backwards-compat with the legacy { list, entries } single-section shape.
+ */
+import { describe, it, expect } from "vitest";
+import { confirmSchema } from "./route";
+
+const baseSource = {
+  id: "src-1",
+  author: "TestAuthor",
+  source_type: "website" as const,
+  source_url: "https://example.com",
+  trust_weight: 1.0,
+  scale_type: "letter_6" as const,
+};
+
+const baseList = {
+  game_version: "v1.0",
+  published_at: "2024-01-01",
+  character: null,
+};
+
+const baseEntries = [
+  { card_id: "strike_r", raw_tier: "A" },
+  { card_id: "defend_r", raw_tier: "B" },
+];
+
+const baseSection = { list: baseList, entries: baseEntries };
+
+describe("confirmSchema — sections[] payload", () => {
+  it("accepts a multi-section payload with 3 sections", () => {
+    const sections = [
+      { list: { ...baseList, character: "ironclad" }, entries: baseEntries },
+      { list: { ...baseList, character: "silent" }, entries: baseEntries },
+      { list: { ...baseList, character: "defect" }, entries: baseEntries },
+    ];
+    const result = confirmSchema.safeParse({
+      imageUrl: null,
+      ingestionMethod: "scraped",
+      source: baseSource,
+      sections,
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.sections).toHaveLength(3);
+    }
+  });
+
+  it("accepts a single-section sections[] payload", () => {
+    const result = confirmSchema.safeParse({
+      imageUrl: null,
+      ingestionMethod: "scraped",
+      source: baseSource,
+      sections: [baseSection],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects a payload with neither sections[] nor (list + entries)", () => {
+    const result = confirmSchema.safeParse({
+      imageUrl: null,
+      ingestionMethod: "scraped",
+      source: baseSource,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a payload with sections[] where an entry is missing card_id", () => {
+    const result = confirmSchema.safeParse({
+      imageUrl: null,
+      ingestionMethod: "scraped",
+      source: baseSource,
+      sections: [
+        {
+          list: baseList,
+          entries: [{ raw_tier: "A" }], // missing card_id
+        },
+      ],
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("confirmSchema — legacy { list, entries } payload (backwards-compat)", () => {
+  it("accepts the legacy single-shape payload", () => {
+    const result = confirmSchema.safeParse({
+      imageUrl: null,
+      ingestionMethod: "scraped",
+      source: baseSource,
+      list: baseList,
+      entries: baseEntries,
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.list).toEqual(baseList);
+      expect(result.data.entries).toHaveLength(2);
+      // sections is not present in legacy shape
+      expect(result.data.sections).toBeUndefined();
+    }
+  });
+
+  it("accepts a payload with both sections[] and legacy fields (sections takes precedence in handler)", () => {
+    const result = confirmSchema.safeParse({
+      imageUrl: null,
+      ingestionMethod: "scraped",
+      source: baseSource,
+      sections: [baseSection],
+      list: baseList,
+      entries: baseEntries,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects a payload with list but no entries", () => {
+    const result = confirmSchema.safeParse({
+      imageUrl: null,
+      ingestionMethod: "scraped",
+      source: baseSource,
+      list: baseList,
+      // entries omitted
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a payload with entries but no list", () => {
+    const result = confirmSchema.safeParse({
+      imageUrl: null,
+      ingestionMethod: "scraped",
+      source: baseSource,
+      entries: baseEntries,
+      // list omitted
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("confirmSchema — imageUrl refinement", () => {
+  it("requires imageUrl for vision_llm ingestion", () => {
+    const result = confirmSchema.safeParse({
+      imageUrl: null,
+      ingestionMethod: "vision_llm",
+      source: baseSource,
+      sections: [baseSection],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("allows null imageUrl for scraped ingestion", () => {
+    const result = confirmSchema.safeParse({
+      imageUrl: null,
+      ingestionMethod: "scraped",
+      source: baseSource,
+      sections: [baseSection],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts a non-null imageUrl for vision_llm ingestion", () => {
+    const result = confirmSchema.safeParse({
+      imageUrl: "https://example.com/img.png",
+      ingestionMethod: "vision_llm",
+      source: baseSource,
+      sections: [baseSection],
+    });
+    expect(result.success).toBe(true);
+  });
+});

--- a/apps/web/src/app/api/admin/tier-lists/confirm/route.ts
+++ b/apps/web/src/app/api/admin/tier-lists/confirm/route.ts
@@ -8,7 +8,27 @@ import {
 } from "@sts2/shared/evaluation/tier-normalize";
 import type { Json } from "@sts2/shared/types/database.types";
 
-const confirmSchema = z
+const sectionListSchema = z.object({
+  game_version: z.string().nullable(),
+  published_at: z.string(),
+  character: z.string().nullable(),
+});
+
+const sectionEntriesSchema = z.array(
+  z.object({
+    card_id: z.string(),
+    raw_tier: z.string(),
+    note: z.string().nullable().optional(),
+    extraction_confidence: z.number().min(0).max(1).nullable().optional(),
+  }),
+);
+
+const sectionSchema = z.object({
+  list: sectionListSchema,
+  entries: sectionEntriesSchema,
+});
+
+export const confirmSchema = z
   .object({
     imageUrl: z.string().url().nullable(),
     ingestionMethod: z
@@ -36,19 +56,11 @@ const confirmSchema = z
       scale_config: z.record(z.string(), z.unknown()).nullable().optional(),
       notes: z.string().nullable().optional(),
     }),
-    list: z.object({
-      game_version: z.string().nullable(),
-      published_at: z.string(),
-      character: z.string().nullable(),
-    }),
-    entries: z.array(
-      z.object({
-        card_id: z.string(),
-        raw_tier: z.string(),
-        note: z.string().nullable().optional(),
-        extraction_confidence: z.number().min(0).max(1).nullable().optional(),
-      }),
-    ),
+    // New multi-section payload: sections: [{ list, entries }]
+    sections: z.array(sectionSchema).optional(),
+    // Legacy single-section payload (backwards-compat)
+    list: sectionListSchema.optional(),
+    entries: sectionEntriesSchema.optional(),
   })
   // vision_llm and manual_confirm always have a Supabase-Storage imageUrl;
   // scraped lists don't (source lives at source.source_url instead). This
@@ -57,6 +69,11 @@ const confirmSchema = z
   .refine(
     (d) => (d.ingestionMethod === "scraped" ? true : d.imageUrl !== null),
     { message: "imageUrl is required for non-scraped ingestion methods" },
+  )
+  // Backwards-compat: accept either sections[] or the legacy list+entries pair.
+  .refine(
+    (b) => Boolean(b.sections) || (Boolean(b.list) && Boolean(b.entries)),
+    { message: "Must include sections[] or (list + entries)" },
   );
 
 export const POST = withAdmin(async (request) => {
@@ -68,11 +85,16 @@ export const POST = withAdmin(async (request) => {
       { status: 400 },
     );
   }
-  const { imageUrl, ingestionMethod, source, list, entries } = parsed.data;
+  const { imageUrl, ingestionMethod, source } = parsed.data;
+
+  // Normalize legacy { list, entries } into sections[] so the loop is uniform.
+  const sections = parsed.data.sections ?? [
+    { list: parsed.data.list!, entries: parsed.data.entries! },
+  ];
 
   const supabase = createServiceClient();
 
-  // 1. Upsert source
+  // 1. Upsert source (once, outside the per-section loop)
   const { error: sourceError } = await supabase
     .from("tier_list_sources")
     .upsert(
@@ -94,71 +116,18 @@ export const POST = withAdmin(async (request) => {
     return NextResponse.json({ error: "Source upsert failed" }, { status: 500 });
   }
 
-  // 2. Mark prior active lists inactive for the SAME (source, game_version, character)
-  // scope only. Deactivating across versions would hide legitimate historical
-  // snapshots (e.g. a v0.3.5 list when uploading a v0.4.0 list).
+  // 2–5. Per-section: deactivate prior, insert tier_lists row, dedup, insert entries.
   //
   // NOTE: steps 2–5 are NOT wrapped in a transaction. If step 4 fails, step 3
   // leaves an orphan tier_lists row with entry_count > 0 but no entries, and
   // step 2 has already deactivated the prior list. Monitor logs for partial
   // failures and clean up manually. Moving to a single RPC is a follow-up.
-  {
-    let q = supabase
-      .from("tier_lists")
-      .update({ is_active: false })
-      .eq("source_id", source.id)
-      .eq("is_active", true);
-    q = list.game_version === null
-      ? q.is("game_version", null)
-      : q.eq("game_version", list.game_version);
-    q = list.character === null
-      ? q.is("character", null)
-      : q.eq("character", list.character);
-    const { error: deactivateError } = await q;
-    if (deactivateError) {
-      console.error("[Tier Lists Confirm] Deactivation failed:", deactivateError);
-      return NextResponse.json(
-        { error: "Failed to deactivate prior lists", detail: deactivateError.message },
-        { status: 500 },
-      );
-    }
-  }
+  const inserted: Array<{
+    sectionIndex: number;
+    listId: string;
+    entryCount: number;
+  }> = [];
 
-  // 3. Insert new tier_lists row
-  const { data: newList, error: listError } = await supabase
-    .from("tier_lists")
-    .insert({
-      source_id: source.id,
-      game_version: list.game_version,
-      published_at: list.published_at,
-      character: list.character,
-      is_active: true,
-      source_image_url: imageUrl,
-      ingestion_method: ingestionMethod,
-      entry_count: entries.length,
-    })
-    .select("id")
-    .single();
-
-  if (listError || !newList) {
-    console.error("[Tier Lists Confirm] List insert failed:", listError);
-    // Postgres unique_violation — same (source_id, game_version, published_at, character)
-    // tuple already exists. Tell the admin how to fix it.
-    if (listError && (listError as { code?: string }).code === "23505") {
-      return NextResponse.json(
-        {
-          error: "Tier list already exists for this source, version, date, and character. Change the published_at date or use a different source ID to create a new snapshot.",
-        },
-        { status: 409 },
-      );
-    }
-    return NextResponse.json({ error: "List insert failed" }, { status: 500 });
-  }
-
-  // 4. Normalize tiers, dedupe by card_id (fuzzy client-side matching can
-  // collapse variants like "Pacts End" + "Pact's End" to the same card_id),
-  // and insert entries. When a card appears multiple times, keep the entry
-  // with the highest extraction_confidence — ties go to the first seen.
   const normSource = {
     scale_type: source.scale_type as ScaleType,
     scale_config: (source.scale_config ?? null) as {
@@ -166,70 +135,154 @@ export const POST = withAdmin(async (request) => {
     } | null,
   };
 
-  type EntryRow = {
-    tier_list_id: string;
-    card_id: string;
-    raw_tier: string;
-    normalized_tier: number;
-    note: string | null;
-    extraction_confidence: number | null;
-  };
-  const byCardId = new Map<string, EntryRow>();
-  const duplicates: string[] = [];
+  for (let sectionIndex = 0; sectionIndex < sections.length; sectionIndex++) {
+    const section = sections[sectionIndex];
+    const { list, entries } = section;
 
-  for (const e of entries) {
-    const { normalizedTier } = normalizeTier(e.raw_tier, normSource);
-    const row: EntryRow = {
-      tier_list_id: newList.id,
-      card_id: e.card_id,
-      raw_tier: e.raw_tier,
-      normalized_tier: normalizedTier,
-      note: e.note ?? null,
-      extraction_confidence: e.extraction_confidence ?? null,
-    };
-    const existing = byCardId.get(e.card_id);
-    if (!existing) {
-      byCardId.set(e.card_id, row);
-      continue;
+    // 2. Mark prior active lists inactive for the SAME (source, game_version, character)
+    // scope only. Deactivating across versions would hide legitimate historical
+    // snapshots (e.g. a v0.3.5 list when uploading a v0.4.0 list).
+    {
+      let q = supabase
+        .from("tier_lists")
+        .update({ is_active: false })
+        .eq("source_id", source.id)
+        .eq("is_active", true);
+      q = list.game_version === null
+        ? q.is("game_version", null)
+        : q.eq("game_version", list.game_version);
+      q = list.character === null
+        ? q.is("character", null)
+        : q.eq("character", list.character);
+      const { error: deactivateError } = await q;
+      if (deactivateError) {
+        console.error(
+          `[Tier Lists Confirm] Deactivation failed (section ${sectionIndex}):`,
+          deactivateError,
+        );
+        return NextResponse.json(
+          {
+            error: "Failed to deactivate prior lists",
+            detail: deactivateError.message,
+            sectionIndex,
+          },
+          { status: 500 },
+        );
+      }
     }
-    duplicates.push(e.card_id);
-    if ((row.extraction_confidence ?? 0) > (existing.extraction_confidence ?? 0)) {
-      byCardId.set(e.card_id, row);
-    }
-  }
-  const entryRows = Array.from(byCardId.values());
 
-  if (duplicates.length > 0) {
-    console.warn(
-      "[Tier Lists Confirm] Collapsed duplicate card_ids (kept highest confidence):",
-      duplicates,
-    );
-  }
-
-  const { error: entriesError } = await supabase
-    .from("tier_list_entries")
-    .insert(entryRows);
-  if (entriesError) {
-    console.error("[Tier Lists Confirm] Entries insert failed:", entriesError);
-    return NextResponse.json(
-      { error: "Entries insert failed" },
-      { status: 500 },
-    );
-  }
-
-  // Update entry_count on the list to reflect post-dedup count
-  if (duplicates.length > 0) {
-    await supabase
+    // 3. Insert new tier_lists row
+    const { data: newList, error: listError } = await supabase
       .from("tier_lists")
-      .update({ entry_count: entryRows.length })
-      .eq("id", newList.id);
+      .insert({
+        source_id: source.id,
+        game_version: list.game_version,
+        published_at: list.published_at,
+        character: list.character,
+        is_active: true,
+        source_image_url: imageUrl,
+        ingestion_method: ingestionMethod,
+        entry_count: entries.length,
+      })
+      .select("id")
+      .single();
+
+    if (listError || !newList) {
+      console.error(
+        `[Tier Lists Confirm] List insert failed (section ${sectionIndex}):`,
+        listError,
+      );
+      // Postgres unique_violation — same (source_id, game_version, published_at, character)
+      // tuple already exists. Tell the admin how to fix it.
+      if (listError && (listError as { code?: string }).code === "23505") {
+        return NextResponse.json(
+          {
+            error:
+              "Tier list already exists for this source, version, date, and character. Change the published_at date or use a different source ID to create a new snapshot.",
+            sectionIndex,
+          },
+          { status: 409 },
+        );
+      }
+      return NextResponse.json(
+        { error: "List insert failed", sectionIndex },
+        { status: 500 },
+      );
+    }
+
+    // 4. Normalize tiers, dedupe by card_id (scoped to this section — two sections
+    // for different characters can both have the same card_id without colliding),
+    // and insert entries. When a card appears multiple times within the same section,
+    // keep the entry with the highest extraction_confidence — ties go to the first seen.
+    type EntryRow = {
+      tier_list_id: string;
+      card_id: string;
+      raw_tier: string;
+      normalized_tier: number;
+      note: string | null;
+      extraction_confidence: number | null;
+    };
+    const byCardId = new Map<string, EntryRow>();
+    const duplicates: string[] = [];
+
+    for (const e of entries) {
+      const { normalizedTier } = normalizeTier(e.raw_tier, normSource);
+      const row: EntryRow = {
+        tier_list_id: newList.id,
+        card_id: e.card_id,
+        raw_tier: e.raw_tier,
+        normalized_tier: normalizedTier,
+        note: e.note ?? null,
+        extraction_confidence: e.extraction_confidence ?? null,
+      };
+      const existing = byCardId.get(e.card_id);
+      if (!existing) {
+        byCardId.set(e.card_id, row);
+        continue;
+      }
+      duplicates.push(e.card_id);
+      if ((row.extraction_confidence ?? 0) > (existing.extraction_confidence ?? 0)) {
+        byCardId.set(e.card_id, row);
+      }
+    }
+    const entryRows = Array.from(byCardId.values());
+
+    if (duplicates.length > 0) {
+      console.warn(
+        `[Tier Lists Confirm] Section ${sectionIndex}: collapsed duplicate card_ids (kept highest confidence):`,
+        duplicates,
+      );
+    }
+
+    const { error: entriesError } = await supabase
+      .from("tier_list_entries")
+      .insert(entryRows);
+    if (entriesError) {
+      console.error(
+        `[Tier Lists Confirm] Entries insert failed (section ${sectionIndex}):`,
+        entriesError,
+      );
+      return NextResponse.json(
+        { error: "Entries insert failed", sectionIndex },
+        { status: 500 },
+      );
+    }
+
+    // Update entry_count on the list to reflect post-dedup count
+    if (duplicates.length > 0) {
+      await supabase
+        .from("tier_lists")
+        .update({ entry_count: entryRows.length })
+        .eq("id", newList.id);
+    }
+
+    inserted.push({ sectionIndex, listId: newList.id, entryCount: entryRows.length });
   }
 
-  // 5. Refresh materialized view (best-effort). The RPC uses REFRESH MATERIALIZED
-  // VIEW CONCURRENTLY which requires an exclusive lock — concurrent admin
-  // submissions can collide. Surface the error to the client so the UI can
-  // prompt a retry rather than silently serving stale consensus.
-  //
+  // 5. Refresh materialized view (best-effort, once after all sections are inserted).
+  // The RPC uses REFRESH MATERIALIZED VIEW CONCURRENTLY which requires an exclusive
+  // lock — concurrent admin submissions can collide. Surface the error to the client
+  // so the UI can prompt a retry rather than silently serving stale consensus.
   const { error: refreshError } = await supabase.rpc(
     "refresh_community_tier_consensus",
   );
@@ -244,8 +297,10 @@ export const POST = withAdmin(async (request) => {
 
   return NextResponse.json({
     success: true,
-    tier_list_id: newList.id,
-    entry_count: entryRows.length,
+    inserted,
+    // Legacy single-section convenience fields (backwards-compat for existing callers)
+    tier_list_id: inserted[0]?.listId ?? null,
+    entry_count: inserted[0]?.entryCount ?? 0,
     refreshWarning,
   });
 });

--- a/apps/web/src/app/api/admin/tier-lists/confirm/route.ts
+++ b/apps/web/src/app/api/admin/tier-lists/confirm/route.ts
@@ -299,6 +299,8 @@ export const POST = withAdmin(async (request) => {
     success: true,
     inserted,
     // Legacy single-section convenience fields (backwards-compat for existing callers)
+    // Backwards-compat legacy single-section response. These fields reflect
+    // inserted[0] only — multi-section callers should read `inserted` instead.
     tier_list_id: inserted[0]?.listId ?? null,
     entry_count: inserted[0]?.entryCount ?? 0,
     refreshWarning,

--- a/apps/web/src/app/api/admin/tier-lists/route.ts
+++ b/apps/web/src/app/api/admin/tier-lists/route.ts
@@ -30,7 +30,9 @@ export const GET = withAdmin(async () => {
          author,
          source_type,
          source_url,
-         trust_weight
+         trust_weight,
+         scale_type,
+         scale_config
        )`,
     )
     .order("ingested_at", { ascending: false })

--- a/apps/web/src/app/api/admin/tier-lists/scrape/route.ts
+++ b/apps/web/src/app/api/admin/tier-lists/scrape/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import { z } from "zod";
 import { withAdmin } from "@/lib/api-admin-auth";
 import { createServiceClient } from "@/lib/supabase/server";
-import { resolveAdapter } from "@sts2/shared/tier-sources";
+import { resolveAdapter, type ScrapedSection } from "@sts2/shared/tier-sources";
 import {
   fetchAndHashAll,
   filenameHint,
@@ -53,66 +53,64 @@ const scrapeSchema = z.object({
 // Kept separate so the character filter still includes neutral cards.
 const NEUTRAL_COLORS = ["colorless", "curse"] as const;
 
+type CharacterParam =
+  | "ironclad"
+  | "silent"
+  | "defect"
+  | "regent"
+  | "necrobinder"
+  | null
+  | undefined;
+
 interface CardWithHash {
   id: string;
   name: string;
   hash: string;
 }
 
-export const POST = withAdmin(async (request) => {
-  const body = await request.json();
-  const parsed = scrapeSchema.safeParse(body);
-  if (!parsed.success) {
-    return NextResponse.json(
-      { error: "Invalid request body", detail: parsed.error.format() },
-      { status: 400 },
-    );
-  }
-  const { url, html, character } = parsed.data;
+type CardRow = { id: string; name: string; color: string | null; phash: string | null };
 
-  const adapter = resolveAdapter(url);
-  if (!adapter) {
-    return NextResponse.json(
-      { error: `No tier-list adapter supports ${url}` },
-      { status: 400 },
-    );
-  }
+type MatchedCard = {
+  externalId?: string;
+  tier: string;
+  imageUrl: string;
+  name: string;
+  cardId: string | null;
+  confidence: number;
+  source: "alt" | "filename" | "phash" | "none";
+  distance: number | null;
+  error?: string;
+};
 
-  const scraped = adapter.parse(html, url);
-  if (scraped.cards.length === 0) {
-    return NextResponse.json(
-      {
-        error: "No cards found in pasted HTML",
-        warnings: scraped.warnings,
-      },
-      { status: 422 },
-    );
-  }
+const normName = (s: string) => s.toLowerCase().replace(/[^a-z0-9]/g, "");
 
-  const supabase = createServiceClient();
+// When all matchers miss, preserve the strongest name hint we have so the
+// admin sees something actionable in the preview rather than an empty
+// combobox. Priority: adapter-declared name > filename-derived hint.
+const unmatchedName = (card: { name?: string; imageUrl: string }) =>
+  card.name && card.name.trim().length > 0 ? card.name : filenameHint(card.imageUrl);
 
-  const { data: cardsData, error: cardsError } = await supabase
-    .from("cards")
-    .select("id, name, color, phash");
-  if (cardsError) {
-    console.error("[Tier Lists Scrape] Card fetch failed:", cardsError);
-    return NextResponse.json({ error: "Card fetch failed" }, { status: 500 });
-  }
-
-  type CardRow = { id: string; name: string; color: string | null; phash: string | null };
-  const cards = (cardsData ?? []) as CardRow[];
-
-  const cardIdMap: Record<string, string> = {};
-  for (const c of cards) cardIdMap[c.name] = c.id;
-
-  const allowedColors = character
-    ? new Set<string>([character, ...NEUTRAL_COLORS])
-    : null;
+/**
+ * Run candidate matching for a single section. The section's detectedCharacter
+ * is used as the primary scope hint; fallbackCharacter (the request param) is
+ * used only when the section doesn't declare one.
+ */
+async function matchSection(
+  section: ScrapedSection,
+  fallbackCharacter: CharacterParam,
+  candidates: CardRow[],
+  scrapeHost: string,
+): Promise<{ matched: MatchedCard[]; warnings: string[] }> {
+  const sectionCharacter = section.detectedCharacter ?? fallbackCharacter ?? null;
 
   // Character-scoped candidate pool. Filename + hash matchers both draw
   // from this same pool so cross-character collisions (e.g. a Silent card's
   // hash happening to match an Ironclad card) are eliminated up front.
-  const scopedCards = cards.filter(
+  const allowedColors = sectionCharacter
+    ? new Set<string>([sectionCharacter, ...NEUTRAL_COLORS])
+    : null;
+
+  const scopedCards = candidates.filter(
     (c) => !allowedColors || (c.color !== null && allowedColors.has(c.color)),
   );
 
@@ -122,21 +120,23 @@ export const POST = withAdmin(async (request) => {
   }));
 
   const hashCandidates: CardWithHash[] = scopedCards
-    .filter((c): c is { id: string; name: string; color: string | null; phash: string } =>
-      typeof c.phash === "string" && c.phash.length > 0,
+    .filter(
+      (c): c is { id: string; name: string; color: string | null; phash: string } =>
+        typeof c.phash === "string" && c.phash.length > 0,
     )
     .map((c) => ({ id: c.id, name: c.name, hash: c.phash }));
+
+  // Build a normalized name → candidate lookup for fast alt-text matches.
+  // Drops apostrophes/punctuation so "Pact's End" → "pactsend" collides
+  // with source variants like "Pacts End".
+  const normalizedNameLookup = new Map<string, NamedCandidate>();
+  for (const c of nameCandidates) normalizedNameLookup.set(normName(c.name), c);
 
   // Fetch + hash every scraped card image in parallel. The filename matcher
   // catches ~everything for tiermaker's doubled-name convention; hashes are
   // a fallback for adapters whose filenames aren't reliable.
-  // Adapter owns the host allowlist: only URLs matching the same site that
-  // handled the scrape are eligible. Tightening this from the route would
-  // couple us to adapter internals; the adapter sets it via canHandle's host.
-  // Extract the scrape URL's host as the allowlist entry.
-  const { hostname: scrapeHost } = new URL(url);
   const hashResults = await fetchAndHashAll(
-    scraped.cards.map((c) => c.imageUrl),
+    section.cards.map((c) => c.imageUrl),
     8,
     {
       allowedHosts: [scrapeHost],
@@ -145,32 +145,7 @@ export const POST = withAdmin(async (request) => {
     },
   );
 
-  type MatchedCard = {
-    externalId?: string;
-    tier: string;
-    imageUrl: string;
-    name: string;
-    cardId: string | null;
-    confidence: number;
-    source: "alt" | "filename" | "phash" | "none";
-    distance: number | null;
-    error?: string;
-  };
-
-  // Build a normalized name → candidate lookup for fast alt-text matches.
-  // Drops apostrophes/punctuation so "Pact's End" → "pactsend" collides
-  // with source variants like "Pacts End".
-  const normalizedNameLookup = new Map<string, NamedCandidate>();
-  const normName = (s: string) => s.toLowerCase().replace(/[^a-z0-9]/g, "");
-  for (const c of nameCandidates) normalizedNameLookup.set(normName(c.name), c);
-
-  // When all matchers miss, preserve the strongest name hint we have so the
-  // admin sees something actionable in the preview rather than an empty
-  // combobox. Priority: adapter-declared name > filename-derived hint.
-  const unmatchedName = (card: { name?: string; imageUrl: string }) =>
-    card.name && card.name.trim().length > 0 ? card.name : filenameHint(card.imageUrl);
-
-  const matched: MatchedCard[] = scraped.cards.map((card, i) => {
+  const matched: MatchedCard[] = section.cards.map((card, i) => {
     // Tier 0: adapter-declared alt/name — the strongest signal when present.
     if (card.name) {
       const byAlt = normalizedNameLookup.get(normName(card.name));
@@ -243,43 +218,79 @@ export const POST = withAdmin(async (request) => {
     };
   });
 
-  // Collapse into the same `tiers[]` shape the existing preview UI consumes.
-  const tiersByLabel = new Map<string, MatchedCard[]>();
-  for (const m of matched) {
-    const bucket = tiersByLabel.get(m.tier) ?? [];
-    bucket.push(m);
-    tiersByLabel.set(m.tier, bucket);
+  const warnings = matched
+    .filter((m) => m.error)
+    .map((m) => `${m.imageUrl}: ${m.error}`);
+
+  return { matched, warnings };
+}
+
+export const POST = withAdmin(async (request) => {
+  const body = await request.json();
+  const parsed = scrapeSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Invalid request body", detail: parsed.error.format() },
+      { status: 400 },
+    );
   }
-  const tiers = Array.from(tiersByLabel.entries()).map(([label, cards]) => ({
-    label,
-    cards: cards.map((c) => ({ name: c.name, confidence: c.confidence })),
-  }));
+  const { url, html, character } = parsed.data;
+
+  const adapter = resolveAdapter(url);
+  if (!adapter) {
+    return NextResponse.json(
+      { error: `No tier-list adapter supports ${url}` },
+      { status: 400 },
+    );
+  }
+
+  const adapterResult = adapter.parse(html, url);
+  const totalCards = adapterResult.sections.reduce(
+    (sum, s) => sum + s.cards.length,
+    0,
+  );
+  if (totalCards === 0) {
+    return NextResponse.json(
+      {
+        error: "No cards found in pasted HTML",
+        warnings: adapterResult.warnings,
+      },
+      { status: 422 },
+    );
+  }
+
+  const supabase = createServiceClient();
+
+  const { data: cardsData, error: cardsError } = await supabase
+    .from("cards")
+    .select("id, name, color, phash");
+  if (cardsError) {
+    console.error("[Tier Lists Scrape] Card fetch failed:", cardsError);
+    return NextResponse.json({ error: "Card fetch failed" }, { status: 500 });
+  }
+
+  const candidates = (cardsData ?? []) as CardRow[];
+
+  // Adapter owns the host allowlist: only URLs matching the same site that
+  // handled the scrape are eligible.
+  const { hostname: scrapeHost } = new URL(url);
+
+  const sectionsOut = await Promise.all(
+    adapterResult.sections.map(async (section) => {
+      const result = await matchSection(section, character, candidates, scrapeHost);
+      return {
+        detectedCharacter: section.detectedCharacter,
+        scaleType: section.scaleType,
+        scaleConfig: section.scaleConfig ?? null,
+        matched: result.matched,
+        unmatched: result.matched.filter((m) => !m.cardId),
+        warnings: [...section.warnings, ...result.warnings],
+      };
+    }),
+  );
 
   return NextResponse.json({
-    adapterId: scraped.adapterId,
-    sourceUrl: url,
-    imageUrl: null,
-    ingestionMethod: "scraped" as const,
-    scaleType: scraped.scaleType,
-    scaleConfig: scraped.scaleConfig ?? null,
-    detectedCharacter: scraped.detectedCharacter,
-    extraction: {
-      tiers,
-      warnings: [
-        ...scraped.warnings,
-        ...matched
-          .filter((m) => m.error)
-          .map((m) => `${m.imageUrl}: ${m.error}`),
-      ],
-    },
-    cardIdMap,
-    // Per-card metadata for the preview UI: lets us show the tiermaker image
-    // alongside the matched card (or empty combobox) for visual verification.
-    scrapedCards: matched,
-    stats: {
-      total: matched.length,
-      matched: matched.filter((m) => m.cardId).length,
-      unmatched: matched.filter((m) => !m.cardId).length,
-    },
+    sections: sectionsOut,
+    warnings: adapterResult.warnings,
   });
 });

--- a/packages/shared/evaluation/community-tier.test.ts
+++ b/packages/shared/evaluation/community-tier.test.ts
@@ -204,28 +204,20 @@ describe("classifyByTime", () => {
     expect(classifyByTime(daysAgo(0))).toBe("fresh");
   });
 
-  it("published 100 days ago → 'fresh'", () => {
-    expect(classifyByTime(daysAgo(100))).toBe("fresh");
+  it("published 27 days ago → 'fresh' (just under AGING_DAYS threshold)", () => {
+    expect(classifyByTime(daysAgo(27))).toBe("fresh");
   });
 
-  it("published 179 days ago → 'fresh' (just under AGING_DAYS threshold)", () => {
-    expect(classifyByTime(daysAgo(179))).toBe("fresh");
+  it("published 28 days ago → 'aging'", () => {
+    expect(classifyByTime(daysAgo(28))).toBe("aging");
   });
 
-  it("published 200 days ago → 'aging'", () => {
-    expect(classifyByTime(daysAgo(200))).toBe("aging");
+  it("published 83 days ago → 'aging' (just under STALE_DAYS threshold)", () => {
+    expect(classifyByTime(daysAgo(83))).toBe("aging");
   });
 
-  it("published 364 days ago → 'aging' (just under STALE_DAYS threshold)", () => {
-    expect(classifyByTime(daysAgo(364))).toBe("aging");
-  });
-
-  it("published 400 days ago → 'excluded'", () => {
-    expect(classifyByTime(daysAgo(400))).toBe("excluded");
-  });
-
-  it("published 366 days ago → 'excluded'", () => {
-    expect(classifyByTime(daysAgo(366))).toBe("excluded");
+  it("published 84 days ago → 'excluded'", () => {
+    expect(classifyByTime(daysAgo(84))).toBe("excluded");
   });
 });
 
@@ -451,7 +443,7 @@ describe("computeStaleness", () => {
   });
 
   it("time aging + version fresh → 'aging'", () => {
-    const row = makeRow({ most_recent_published: daysAgo(200) });
+    const row = makeRow({ most_recent_published: daysAgo(50) });
     expect(computeStaleness(row, null, emptyMeta)).toBe("aging");
   });
 
@@ -472,7 +464,7 @@ describe("getCommunityTierSignals – end-to-end", () => {
 
   it("full flow: character-specific wins, version-aware staleness applied", async () => {
     const versionDate = daysAgo(10);
-    const listDate = daysAgo(90);
+    const listDate = daysAgo(20);
 
     const supabase = makeSupabaseMock({
       consensusRows: [

--- a/packages/shared/evaluation/community-tier.test.ts
+++ b/packages/shared/evaluation/community-tier.test.ts
@@ -535,7 +535,7 @@ describe("normalizeCharacter", () => {
     expect(normalizeCharacter("  The Ironclad  ")).toBe("ironclad");
   });
 
-  it("excludes card when time-based staleness is excluded (>365 days)", async () => {
+  it("excludes card when time-based staleness is excluded (>84 days)", async () => {
     const supabase = makeSupabaseMock({
       consensusRows: [
         {

--- a/packages/shared/evaluation/community-tier.ts
+++ b/packages/shared/evaluation/community-tier.ts
@@ -23,8 +23,8 @@ export interface GameVersionMeta {
 }
 
 const DAY_MS = 1000 * 60 * 60 * 24;
-const AGING_DAYS = 180;
-const STALE_DAYS = 365;
+const AGING_DAYS = 28;
+const STALE_DAYS = 84;
 
 /**
  * Load community tier signals for the given card IDs and character.

--- a/packages/shared/evaluation/community-tier.ts
+++ b/packages/shared/evaluation/community-tier.ts
@@ -204,7 +204,7 @@ export function classifyByTime(
   const ageDays = (now - published) / DAY_MS;
   if (ageDays < AGING_DAYS) return "fresh";
   if (ageDays < STALE_DAYS) return "aging";
-  return "excluded"; // > 365 days: excluded
+  return "excluded"; // > 84 days (STALE_DAYS): excluded
 }
 
 export function classifyByVersion(

--- a/packages/shared/tier-sources/__fixtures__/mobalytics-all-characters.html
+++ b/packages/shared/tier-sources/__fixtures__/mobalytics-all-characters.html
@@ -1,0 +1,156 @@
+<!-- Mobalytics All Characters Tier List Fixture -->
+<!-- This fixture contains minimal structure for all 5 characters: Ironclad, Silent, Regent, Necrobinder, Defect -->
+<!-- Each character has a tier list section with S/A/B/C/D tiers and sample card images -->
+
+<html>
+<head><title>Slay the Spire 2 Card Tier List - Mobalytics</title></head>
+<body>
+<!-- Overview and methodology sections (simplified) -->
+<section>
+<h1>Slay the Spire 2 Card Tier List</h1>
+<div>Preliminary Card tier list for Slay the Spire 2</div>
+</section>
+
+<!-- Ironclad Tier List Section -->
+<section data-character="ironclad">
+<h2>Ironclad Tier List</h2>
+<div class="x78zum5 xdt5ytf x98rzlu x1amik6e x1c1vhfx">
+  <div class="x18d9i69">
+    <div class="x14rh7hd" style="--x-backgroundColor:var(--x4hom3a)">S</div>
+    <img src="https://cdn.mobalytics.gg/cdn-cgi/image/format=auto,width=128,height=128/assets/sts2/images/cards/new/pummel.webp" alt="">
+    <img src="https://cdn.mobalytics.gg/cdn-cgi/image/format=auto,width=128,height=128/assets/sts2/images/cards/new/uppercut.webp" alt="">
+  </div>
+  <div class="x18d9i69">
+    <div class="x14rh7hd" style="--x-backgroundColor:var(--xul75ck)">A</div>
+    <img src="https://cdn.mobalytics.gg/cdn-cgi/image/format=auto,width=128,height=128/assets/sts2/images/cards/new/armaments.webp" alt="">
+    <img src="https://cdn.mobalytics.gg/cdn-cgi/image/format=auto,width=128,height=128/assets/sts2/images/cards/new/bash.webp" alt="">
+  </div>
+  <div class="x18d9i69">
+    <div class="x14rh7hd" style="--x-backgroundColor:var(--xnm9u4h)">B</div>
+    <img src="https://cdn.mobalytics.gg/cdn-cgi/image/format=auto,width=128,height=128/assets/sts2/images/cards/new/flex.webp" alt="">
+  </div>
+  <div class="x18d9i69">
+    <div class="x14rh7hd" style="--x-backgroundColor:var(--x1234)">C</div>
+    <img src="https://cdn.mobalytics.gg/cdn-cgi/image/format=auto,width=128,height=128/assets/sts2/images/cards/new/wild-strike.webp" alt="">
+  </div>
+  <div class="x18d9i69">
+    <div class="x14rh7hd" style="--x-backgroundColor:var(--x5678)">D</div>
+    <img src="https://cdn.mobalytics.gg/cdn-cgi/image/format=auto,width=128,height=128/assets/sts2/images/cards/new/sword-boomerang.webp" alt="">
+  </div>
+</div>
+</section>
+
+<!-- Silent Tier List Section -->
+<section data-character="silent">
+<h2>Silent Tier List</h2>
+<div class="x78zum5 xdt5ytf x98rzlu x1amik6e x1c1vhfx">
+  <div class="x18d9i69">
+    <div class="x14rh7hd" style="--x-backgroundColor:var(--x4hom3a)">S</div>
+    <img src="https://cdn.mobalytics.gg/cdn-cgi/image/format=auto,width=128,height=128/assets/sts2/images/cards/new/adrenaline.webp" alt="">
+    <img src="https://cdn.mobalytics.gg/cdn-cgi/image/format=auto,width=128,height=128/assets/sts2/images/cards/new/well-laid-plans.webp" alt="">
+  </div>
+  <div class="x18d9i69">
+    <div class="x14rh7hd" style="--x-backgroundColor:var(--xul75ck)">A</div>
+    <img src="https://cdn.mobalytics.gg/cdn-cgi/image/format=auto,width=128,height=128/assets/sts2/images/cards/new/acrobatics.webp" alt="">
+  </div>
+  <div class="x18d9i69">
+    <div class="x14rh7hd" style="--x-backgroundColor:var(--xnm9u4h)">B</div>
+    <img src="https://cdn.mobalytics.gg/cdn-cgi/image/format=auto,width=128,height=128/assets/sts2/images/cards/new/afterimage.webp" alt="">
+  </div>
+  <div class="x18d9i69">
+    <div class="x14rh7hd" style="--x-backgroundColor:var(--x1234)">C</div>
+    <img src="https://cdn.mobalytics.gg/cdn-cgi/image/format=auto,width=128,height=128/assets/sts2/images/cards/new/tracking.webp" alt="">
+  </div>
+  <div class="x18d9i69">
+    <div class="x14rh7hd" style="--x-backgroundColor:var(--x5678)">D</div>
+    <img src="https://cdn.mobalytics.gg/cdn-cgi/image/format=auto,width=128,height=128/assets/sts2/images/cards/new/grand-finale.webp" alt="">
+  </div>
+</div>
+</section>
+
+<!-- Regent Tier List Section -->
+<section data-character="regent">
+<h2>Regent Tier List</h2>
+<div class="x78zum5 xdt5ytf x98rzlu x1amik6e x1c1vhfx">
+  <div class="x18d9i69">
+    <div class="x14rh7hd" style="--x-backgroundColor:var(--x4hom3a)">S</div>
+    <img src="https://cdn.mobalytics.gg/cdn-cgi/image/format=auto,width=128,height=128/assets/sts2/images/cards/new/bolt.webp" alt="">
+    <img src="https://cdn.mobalytics.gg/cdn-cgi/image/format=auto,width=128,height=128/assets/sts2/images/cards/new/amplify.webp" alt="">
+  </div>
+  <div class="x18d9i69">
+    <div class="x14rh7hd" style="--x-backgroundColor:var(--xul75ck)">A</div>
+    <img src="https://cdn.mobalytics.gg/cdn-cgi/image/format=auto,width=128,height=128/assets/sts2/images/cards/new/emit-spark.webp" alt="">
+  </div>
+  <div class="x18d9i69">
+    <div class="x14rh7hd" style="--x-backgroundColor:var(--xnm9u4h)">B</div>
+    <img src="https://cdn.mobalytics.gg/cdn-cgi/image/format=auto,width=128,height=128/assets/sts2/images/cards/new/conduit.webp" alt="">
+  </div>
+  <div class="x18d9i69">
+    <div class="x14rh7hd" style="--x-backgroundColor:var(--x1234)">C</div>
+    <img src="https://cdn.mobalytics.gg/cdn-cgi/image/format=auto,width=128,height=128/assets/sts2/images/cards/new/electrodynamics.webp" alt="">
+  </div>
+  <div class="x18d9i69">
+    <div class="x14rh7hd" style="--x-backgroundColor:var(--x5678)">D</div>
+    <img src="https://cdn.mobalytics.gg/cdn-cgi/image/format=auto,width=128,height=128/assets/sts2/images/cards/new/spark.webp" alt="">
+  </div>
+</div>
+</section>
+
+<!-- Necrobinder Tier List Section -->
+<section data-character="necrobinder">
+<h2>Necrobinder Tier List</h2>
+<div class="x78zum5 xdt5ytf x98rzlu x1amik6e x1c1vhfx">
+  <div class="x18d9i69">
+    <div class="x14rh7hd" style="--x-backgroundColor:var(--x4hom3a)">S</div>
+    <img src="https://cdn.mobalytics.gg/cdn-cgi/image/format=auto,width=128,height=128/assets/sts2/images/cards/new/drain.webp" alt="">
+    <img src="https://cdn.mobalytics.gg/cdn-cgi/image/format=auto,width=128,height=128/assets/sts2/images/cards/new/pummel.webp" alt="">
+  </div>
+  <div class="x18d9i69">
+    <div class="x14rh7hd" style="--x-backgroundColor:var(--xul75ck)">A</div>
+    <img src="https://cdn.mobalytics.gg/cdn-cgi/image/format=auto,width=128,height=128/assets/sts2/images/cards/new/decimate.webp" alt="">
+  </div>
+  <div class="x18d9i69">
+    <div class="x14rh7hd" style="--x-backgroundColor:var(--xnm9u4h)">B</div>
+    <img src="https://cdn.mobalytics.gg/cdn-cgi/image/format=auto,width=128,height=128/assets/sts2/images/cards/new/deathgrip.webp" alt="">
+  </div>
+  <div class="x18d9i69">
+    <div class="x14rh7hd" style="--x-backgroundColor:var(--x1234)">C</div>
+    <img src="https://cdn.mobalytics.gg/cdn-cgi/image/format=auto,width=128,height=128/assets/sts2/images/cards/new/siphon.webp" alt="">
+  </div>
+  <div class="x18d9i69">
+    <div class="x14rh7hd" style="--x-backgroundColor:var(--x5678)">D</div>
+    <img src="https://cdn.mobalytics.gg/cdn-cgi/image/format=auto,width=128,height=128/assets/sts2/images/cards/new/lash.webp" alt="">
+  </div>
+</div>
+</section>
+
+<!-- Defect Tier List Section -->
+<section data-character="defect">
+<h2>Defect Tier List</h2>
+<div class="x78zum5 xdt5ytf x98rzlu x1amik6e x1c1vhfx">
+  <div class="x18d9i69">
+    <div class="x14rh7hd" style="--x-backgroundColor:var(--x4hom3a)">S</div>
+    <img src="https://cdn.mobalytics.gg/cdn-cgi/image/format=auto,width=128,height=128/assets/sts2/images/cards/new/claw.webp" alt="">
+    <img src="https://cdn.mobalytics.gg/cdn-cgi/image/format=auto,width=128,height=128/assets/sts2/images/cards/new/bludgeon.webp" alt="">
+  </div>
+  <div class="x18d9i69">
+    <div class="x14rh7hd" style="--x-backgroundColor:var(--xul75ck)">A</div>
+    <img src="https://cdn.mobalytics.gg/cdn-cgi/image/format=auto,width=128,height=128/assets/sts2/images/cards/new/cooldown.webp" alt="">
+  </div>
+  <div class="x18d9i69">
+    <div class="x14rh7hd" style="--x-backgroundColor:var(--xnm9u4h)">B</div>
+    <img src="https://cdn.mobalytics.gg/cdn-cgi/image/format=auto,width=128,height=128/assets/sts2/images/cards/new/dualcast.webp" alt="">
+  </div>
+  <div class="x18d9i69">
+    <div class="x14rh7hd" style="--x-backgroundColor:var(--x1234)">C</div>
+    <img src="https://cdn.mobalytics.gg/cdn-cgi/image/format=auto,width=128,height=128/assets/sts2/images/cards/new/consume.webp" alt="">
+  </div>
+  <div class="x18d9i69">
+    <div class="x14rh7hd" style="--x-backgroundColor:var(--x5678)">D</div>
+    <img src="https://cdn.mobalytics.gg/cdn-cgi/image/format=auto,width=128,height=128/assets/sts2/images/cards/new/boot-sequence.webp" alt="">
+  </div>
+</div>
+</section>
+
+</body>
+</html>

--- a/packages/shared/tier-sources/index.ts
+++ b/packages/shared/tier-sources/index.ts
@@ -4,4 +4,4 @@ export { slaythetierlistAdapter } from "./slaythetierlist";
 export { mobalyticsAdapter } from "./mobalytics";
 export { sts2companionAdapter } from "./sts2companion";
 export { listAdapters, resolveAdapter } from "./registry";
-export type { ScrapedCard, ScrapedTierList, TierListSourceAdapter } from "./types";
+export type { ScrapedCard, ScrapedSection, ScrapedTierList, TierListSourceAdapter } from "./types";

--- a/packages/shared/tier-sources/mobalytics.test.ts
+++ b/packages/shared/tier-sources/mobalytics.test.ts
@@ -30,23 +30,32 @@ describe("resolveAdapter", () => {
 describe("mobalyticsAdapter.parse", () => {
   const result = mobalyticsAdapter.parse(FIXTURE_HTML, FIXTURE_URL);
 
+  it("parses single-character section into sections[0]", () => {
+    expect(result.adapterId).toBe("mobalytics");
+    expect(result.sections).toHaveLength(1);
+    expect(result.sections[0].detectedCharacter).toBe(null);
+    expect(result.sections[0].scaleType).toBe("letter_6");
+    expect(result.sections[0].cards.length).toBeGreaterThan(0);
+    expect(result.warnings).toEqual([]);
+  });
+
   it("buckets each image under its preceding tier label", () => {
-    const sCards = result.cards.filter((c) => c.tier === "S");
-    const aCards = result.cards.filter((c) => c.tier === "A");
-    const dCards = result.cards.filter((c) => c.tier === "D");
+    const sCards = result.sections[0].cards.filter((c) => c.tier === "S");
+    const aCards = result.sections[0].cards.filter((c) => c.tier === "A");
+    const dCards = result.sections[0].cards.filter((c) => c.tier === "D");
     expect(sCards).toHaveLength(3);
     expect(aCards).toHaveLength(2);
     expect(dCards).toHaveLength(2);
   });
 
   it("derives a human-readable name hint from the slug", () => {
-    const wlp = result.cards.find((c) => c.name === "Well Laid Plans");
+    const wlp = result.sections[0].cards.find((c) => c.name === "Well Laid Plans");
     expect(wlp?.tier).toBe("S");
     expect(wlp?.imageUrl).toContain("well-laid-plans.webp");
   });
 
   it("keeps raw CDN URLs (so the preview can render the thumbnail)", () => {
-    for (const c of result.cards) {
+    for (const c of result.sections[0].cards) {
       expect(c.imageUrl).toMatch(/^https:\/\/cdn\.mobalytics\.gg/);
     }
   });
@@ -58,13 +67,14 @@ describe("mobalyticsAdapter.parse", () => {
        <img src="https://cdn.mobalytics.gg/ok.webp">`,
       FIXTURE_URL,
     );
-    expect(extra.cards).toHaveLength(1);
-    expect(extra.cards[0].imageUrl).toContain("cdn.mobalytics.gg");
+    expect(extra.sections).toHaveLength(1);
+    expect(extra.sections[0].cards).toHaveLength(1);
+    expect(extra.sections[0].cards[0].imageUrl).toContain("cdn.mobalytics.gg");
   });
 
   it("warns when no mobalytics images are present", () => {
     const empty = mobalyticsAdapter.parse("<div>nope</div>", FIXTURE_URL);
-    expect(empty.cards).toHaveLength(0);
-    expect(empty.warnings.length).toBeGreaterThan(0);
+    expect(empty.sections[0].cards).toHaveLength(0);
+    expect(empty.sections[0].warnings.length).toBeGreaterThan(0);
   });
 });

--- a/packages/shared/tier-sources/mobalytics.test.ts
+++ b/packages/shared/tier-sources/mobalytics.test.ts
@@ -9,6 +9,10 @@ const FIXTURE_HTML = readFileSync(
   join(__dirname, "__fixtures__/mobalytics-silent.html"),
   "utf8",
 );
+const ALL_CHARS_FIXTURE = readFileSync(
+  join(__dirname, "__fixtures__/mobalytics-all-characters.html"),
+  "utf8",
+);
 
 describe("mobalyticsAdapter.canHandle", () => {
   it("accepts mobalytics.gg URLs", () => {
@@ -76,5 +80,27 @@ describe("mobalyticsAdapter.parse", () => {
     const empty = mobalyticsAdapter.parse("<div>nope</div>", FIXTURE_URL);
     expect(empty.sections[0].cards).toHaveLength(0);
     expect(empty.sections[0].warnings.length).toBeGreaterThan(0);
+  });
+});
+
+describe("mobalyticsAdapter.parse — multi-character", () => {
+  it("splits a multi-character page into one section per character", () => {
+    const result = mobalyticsAdapter.parse(
+      ALL_CHARS_FIXTURE,
+      "https://mobalytics.gg/slay-the-spire-2/tier-lists/cards",
+    );
+    expect(result.sections).toHaveLength(5);
+    const chars = result.sections.map((s) => s.detectedCharacter).sort();
+    expect(chars).toEqual(["defect", "ironclad", "necrobinder", "regent", "silent"]);
+    for (const section of result.sections) {
+      expect(section.cards.length).toBeGreaterThan(2);
+      expect(section.scaleType).toBe("letter_6");
+    }
+  });
+
+  it("single-section HTML still parses as one section with character=null", () => {
+    const result = mobalyticsAdapter.parse(FIXTURE_HTML, FIXTURE_URL);
+    expect(result.sections).toHaveLength(1);
+    expect(result.sections[0].detectedCharacter).toBe(null);
   });
 });

--- a/packages/shared/tier-sources/mobalytics.ts
+++ b/packages/shared/tier-sources/mobalytics.ts
@@ -78,10 +78,15 @@ export const mobalyticsAdapter: TierListSourceAdapter = {
 
     return {
       adapterId: "mobalytics",
-      scaleType: "letter_6",
-      detectedCharacter: null,
-      cards,
-      warnings,
+      sections: [
+        {
+          detectedCharacter: null,
+          scaleType: "letter_6",
+          cards,
+          warnings,
+        },
+      ],
+      warnings: [],
     };
   },
 };

--- a/packages/shared/tier-sources/mobalytics.ts
+++ b/packages/shared/tier-sources/mobalytics.ts
@@ -15,6 +15,74 @@ import type { ScrapedCard, ScrapedTierList, TierListSourceAdapter } from "./type
 const TIER_LETTER_RE = /^[SABCDEF]$/;
 const CDN_HOST_RE = /^https:\/\/cdn\.mobalytics\.gg\//;
 
+const CHARACTER_HEADER_RE =
+  /^(ironclad|silent|regent|necrobinder|defect)\s+tier\s*list$/i;
+
+function walkForCards(
+  node: HTMLElement | ReturnType<typeof parseHtml>,
+  onCard: (card: ScrapedCard) => void,
+): void {
+  let currentTier: string | null = null;
+
+  function walk(n: HTMLElement | ReturnType<typeof parseHtml>): void {
+    if (n.nodeType === NodeType.ELEMENT_NODE) {
+      const el = n as HTMLElement;
+      const style = el.getAttribute("style") ?? "";
+
+      // Tier label: single-letter text + the branded CSS var.
+      if (style.includes("--x-backgroundColor")) {
+        const text = el.text.trim();
+        if (TIER_LETTER_RE.test(text)) {
+          currentTier = text;
+          return; // label has no card descendants
+        }
+      }
+
+      // Card image.
+      if (el.tagName === "IMG") {
+        const src = el.getAttribute("src");
+        if (src && CDN_HOST_RE.test(src)) {
+          if (currentTier) {
+            onCard({
+              tier: currentTier,
+              imageUrl: src,
+              name: nameFromUrl(src),
+            });
+          }
+        }
+        return;
+      }
+    }
+    for (const child of n.childNodes) {
+      walk(child as HTMLElement);
+    }
+  }
+
+  walk(node);
+}
+
+function findCharacterSections(root: HTMLElement): Array<{
+  character: string;
+  rootEl: HTMLElement;
+}> {
+  const sections: Array<{ character: string; rootEl: HTMLElement }> = [];
+  const headers = root.querySelectorAll("h2");
+  for (const h of headers) {
+    const text = h.text.trim();
+    const m = text.match(CHARACTER_HEADER_RE);
+    if (!m) continue;
+    // Walk up to the nearest <section> ancestor.
+    let cur: HTMLElement | null = h as HTMLElement;
+    while (cur && cur.tagName !== "SECTION") {
+      cur = cur.parentNode as HTMLElement | null;
+    }
+    if (cur) {
+      sections.push({ character: m[1].toLowerCase(), rootEl: cur });
+    }
+  }
+  return sections;
+}
+
 export const mobalyticsAdapter: TierListSourceAdapter = {
   id: "mobalytics",
   label: "mobalytics.gg",
@@ -29,62 +97,38 @@ export const mobalyticsAdapter: TierListSourceAdapter = {
   },
 
   parse(html) {
-    const warnings: string[] = [];
-    const cards: ScrapedCard[] = [];
     const root = parseHtml(html);
+    const characterSections = findCharacterSections(root as unknown as HTMLElement);
 
-    let currentTier: string | null = null;
-
-    function walk(node: HTMLElement | ReturnType<typeof parseHtml>): void {
-      if (node.nodeType === NodeType.ELEMENT_NODE) {
-        const el = node as HTMLElement;
-        const style = el.getAttribute("style") ?? "";
-
-        // Tier label: single-letter text + the branded CSS var.
-        if (style.includes("--x-backgroundColor")) {
-          const text = el.text.trim();
-          if (TIER_LETTER_RE.test(text)) {
-            currentTier = text;
-            return; // label has no card descendants
-          }
-        }
-
-        // Card image.
-        if (el.tagName === "IMG") {
-          const src = el.getAttribute("src");
-          if (src && CDN_HOST_RE.test(src)) {
-            if (currentTier) {
-              cards.push({
-                tier: currentTier,
-                imageUrl: src,
-                name: nameFromUrl(src),
-              });
-            }
-          }
-          return;
-        }
-      }
-      for (const child of node.childNodes) {
-        walk(child as HTMLElement);
-      }
+    if (characterSections.length > 0) {
+      const sections = characterSections.map(({ character, rootEl }) => {
+        const cards: ScrapedCard[] = [];
+        walkForCards(rootEl, (card) => cards.push(card));
+        return {
+          detectedCharacter: character,
+          scaleType: "letter_6" as const,
+          cards,
+          warnings: cards.length === 0
+            ? [`No cards found in ${character} section`]
+            : [],
+        };
+      });
+      return { adapterId: "mobalytics", sections, warnings: [] };
     }
-    walk(root);
 
+    // Fallback: whole-DOM walk → single section with detectedCharacter: null.
+    const cards: ScrapedCard[] = [];
+    walkForCards(root, (card) => cards.push(card));
+    const warnings: string[] = [];
     if (cards.length === 0) {
       warnings.push(
         "No mobalytics CDN images found. Paste the outerHTML of the tier container.",
       );
     }
-
     return {
       adapterId: "mobalytics",
       sections: [
-        {
-          detectedCharacter: null,
-          scaleType: "letter_6",
-          cards,
-          warnings,
-        },
+        { detectedCharacter: null, scaleType: "letter_6", cards, warnings },
       ],
       warnings: [],
     };

--- a/packages/shared/tier-sources/mobalytics.ts
+++ b/packages/shared/tier-sources/mobalytics.ts
@@ -71,7 +71,8 @@ function findCharacterSections(root: HTMLElement): Array<{
     const text = h.text.trim();
     const m = text.match(CHARACTER_HEADER_RE);
     if (!m) continue;
-    // Walk up to the nearest <section> ancestor.
+    // Walk up to the nearest <section> ancestor. Mobalytics wraps each character's
+    // tier list in a <section>; ascend to isolate it.
     let cur: HTMLElement | null = h as HTMLElement;
     while (cur && cur.tagName !== "SECTION") {
       cur = cur.parentNode as HTMLElement | null;
@@ -98,7 +99,9 @@ export const mobalyticsAdapter: TierListSourceAdapter = {
 
   parse(html) {
     const root = parseHtml(html);
-    const characterSections = findCharacterSections(root as unknown as HTMLElement);
+    // parseHtml returns the document root; cast to HTMLElement is safe because
+    // we only call querySelectorAll and parentNode traversal on it.
+    const characterSections = findCharacterSections(root as HTMLElement);
 
     if (characterSections.length > 0) {
       const sections = characterSections.map(({ character, rootEl }) => {

--- a/packages/shared/tier-sources/nat1gaming.test.ts
+++ b/packages/shared/tier-sources/nat1gaming.test.ts
@@ -31,41 +31,46 @@ describe("resolveAdapter", () => {
 describe("nat1gamingAdapter.parse", () => {
   const result = nat1gamingAdapter.parse(FIXTURE_HTML, FIXTURE_URL);
 
+  it("returns single section", () => {
+    expect(result.sections).toHaveLength(1);
+    expect(result.sections[0].cards.length).toBeGreaterThan(0);
+  });
+
   it("extracts tier rows in top-to-bottom order", () => {
-    const tierOrder = [...new Set(result.cards.map((c) => c.tier))];
+    const tierOrder = [...new Set(result.sections[0].cards.map((c) => c.tier))];
     expect(tierOrder).toEqual(["S", "A", "F"]);
   });
 
   it("extracts card name from the img alt attribute", () => {
-    const adrenaline = result.cards.find((c) => c.name === "Adrenaline");
+    const adrenaline = result.sections[0].cards.find((c) => c.name === "Adrenaline");
     expect(adrenaline).toBeDefined();
     expect(adrenaline?.tier).toBe("S");
     expect(adrenaline?.imageUrl).toMatch(/Adrenaline\.png/);
   });
 
   it("prefers data-src over placeholder SVG src for lazy-loaded images", () => {
-    const pinpoint = result.cards.find((c) => c.name === "Pinpoint");
+    const pinpoint = result.sections[0].cards.find((c) => c.name === "Pinpoint");
     expect(pinpoint?.imageUrl).toMatch(/^https:\/\/nat1gaming\.com/);
     expect(pinpoint?.imageUrl).not.toContain("data:image");
   });
 
   it("preserves underscores and hyphens in image URLs", () => {
-    const wraith = result.cards.find((c) => c.name === "Wraith Form");
+    const wraith = result.sections[0].cards.find((c) => c.name === "Wraith Form");
     expect(wraith?.imageUrl).toContain("Wraith_Form-1.png");
   });
 
   it("applies 7-letter scale override when E and F coexist with S", () => {
     // The bundled fixture has S/A/F but no E — override should NOT trigger.
-    expect(result.scaleConfig).toBeUndefined();
+    expect(result.sections[0].scaleConfig).toBeUndefined();
   });
 
   it("always returns null detectedCharacter", () => {
-    expect(result.detectedCharacter).toBeNull();
+    expect(result.sections[0].detectedCharacter).toBeNull();
   });
 
   it("warns when no tier sections are present", () => {
     const empty = nat1gamingAdapter.parse("<div>nope</div>", FIXTURE_URL);
-    expect(empty.cards).toHaveLength(0);
-    expect(empty.warnings.length).toBeGreaterThan(0);
+    expect(empty.sections[0].cards).toHaveLength(0);
+    expect(empty.sections[0].warnings.length).toBeGreaterThan(0);
   });
 });

--- a/packages/shared/tier-sources/nat1gaming.ts
+++ b/packages/shared/tier-sources/nat1gaming.ts
@@ -71,11 +71,16 @@ export const nat1gamingAdapter: TierListSourceAdapter = {
 
     return {
       adapterId: "nat1gaming",
-      scaleType: "letter_6",
-      scaleConfig,
-      detectedCharacter: null,
-      cards,
-      warnings,
+      sections: [
+        {
+          detectedCharacter: null,
+          scaleType: "letter_6",
+          ...(scaleConfig ? { scaleConfig } : {}),
+          cards,
+          warnings,
+        },
+      ],
+      warnings: [],
     };
   },
 };

--- a/packages/shared/tier-sources/slaythetierlist.test.ts
+++ b/packages/shared/tier-sources/slaythetierlist.test.ts
@@ -30,17 +30,22 @@ describe("resolveAdapter", () => {
 describe("slaythetierlistAdapter.parse", () => {
   const result = slaythetierlistAdapter.parse(FIXTURE_HTML, FIXTURE_URL);
 
-  it("detects the character from the panel id", () => {
-    expect(result.detectedCharacter).toBe("silent");
+  it("returns single section", () => {
+    expect(result.sections).toHaveLength(1);
+    expect(result.sections[0].cards.length).toBeGreaterThan(0);
+  });
+
+  it("detects the character from the panel id in section", () => {
+    expect(result.sections[0].detectedCharacter).toBe("silent");
   });
 
   it("extracts tier rows using data-tier attribute", () => {
-    const tierOrder = [...new Set(result.cards.map((c) => c.tier))];
+    const tierOrder = [...new Set(result.sections[0].cards.map((c) => c.tier))];
     expect(tierOrder).toEqual(["S", "A", "D"]);
   });
 
   it("extracts name, slug, and imageUrl per card", () => {
-    const adrenaline = result.cards.find((c) => c.name === "Adrenaline");
+    const adrenaline = result.sections[0].cards.find((c) => c.name === "Adrenaline");
     expect(adrenaline).toMatchObject({
       tier: "S",
       name: "Adrenaline",
@@ -50,13 +55,13 @@ describe("slaythetierlistAdapter.parse", () => {
   });
 
   it("preserves hyphenated alt text (Well-Laid Plans)", () => {
-    const wlp = result.cards.find((c) => c.name === "Well-Laid Plans");
+    const wlp = result.sections[0].cards.find((c) => c.name === "Well-Laid Plans");
     expect(wlp?.imageUrl).toContain("well_laid_plans.png");
   });
 
   it("warns when no tier rows are present", () => {
     const empty = slaythetierlistAdapter.parse("<div>nope</div>", FIXTURE_URL);
-    expect(empty.cards).toHaveLength(0);
-    expect(empty.warnings.length).toBeGreaterThan(0);
+    expect(empty.sections[0].cards).toHaveLength(0);
+    expect(empty.sections[0].warnings.length).toBeGreaterThan(0);
   });
 });

--- a/packages/shared/tier-sources/slaythetierlist.ts
+++ b/packages/shared/tier-sources/slaythetierlist.ts
@@ -86,10 +86,15 @@ export const slaythetierlistAdapter: TierListSourceAdapter = {
 
     return {
       adapterId: "slaythetierlist",
-      scaleType: "letter_6",
-      detectedCharacter,
-      cards,
-      warnings,
+      sections: [
+        {
+          detectedCharacter,
+          scaleType: "letter_6",
+          cards,
+          warnings,
+        },
+      ],
+      warnings: [],
     };
   },
 };

--- a/packages/shared/tier-sources/sts2companion.test.ts
+++ b/packages/shared/tier-sources/sts2companion.test.ts
@@ -30,13 +30,18 @@ describe("resolveAdapter", () => {
 describe("sts2companionAdapter.parse", () => {
   const result = sts2companionAdapter.parse(FIXTURE_HTML, FIXTURE_URL);
 
-  it("detects character from URL path", () => {
-    expect(result.detectedCharacter).toBe("defect");
+  it("returns single section", () => {
+    expect(result.sections).toHaveLength(1);
+    expect(result.sections[0].cards.length).toBeGreaterThan(0);
+  });
+
+  it("detects character from URL path in section", () => {
+    expect(result.sections[0].detectedCharacter).toBe("defect");
   });
 
   it("extracts every card with canonical id + name", () => {
-    expect(result.cards).toHaveLength(4);
-    const zap = result.cards.find((c) => c.externalId === "ZAP");
+    expect(result.sections[0].cards).toHaveLength(4);
+    const zap = result.sections[0].cards.find((c) => c.externalId === "ZAP");
     expect(zap).toMatchObject({
       tier: "A",
       name: "Zap",
@@ -45,23 +50,23 @@ describe("sts2companionAdapter.parse", () => {
   });
 
   it("absolutizes relative image URLs against spire-codex.com", () => {
-    const zap = result.cards.find((c) => c.externalId === "ZAP");
+    const zap = result.sections[0].cards.find((c) => c.externalId === "ZAP");
     expect(zap?.imageUrl).toBe("https://spire-codex.com/static/images/cards/zap.webp");
   });
 
   it("groups cards under their source tier label", () => {
-    const tiers = [...new Set(result.cards.map((c) => c.tier))];
+    const tiers = [...new Set(result.sections[0].cards.map((c) => c.tier))];
     expect(tiers).toEqual(["S", "A", "D"]);
   });
 
   it("warns when no flight-stream chunks are present", () => {
     const empty = sts2companionAdapter.parse("<div>just dom</div>", FIXTURE_URL);
-    expect(empty.cards).toHaveLength(0);
-    expect(empty.warnings.length).toBeGreaterThan(0);
+    expect(empty.sections[0].cards).toHaveLength(0);
+    expect(empty.sections[0].warnings.length).toBeGreaterThan(0);
   });
 
   it("returns null character for URLs that don't match /tier-lists/<char>", () => {
     const other = sts2companionAdapter.parse(FIXTURE_HTML, "https://sts2companion.com/");
-    expect(other.detectedCharacter).toBeNull();
+    expect(other.sections[0].detectedCharacter).toBeNull();
   });
 });

--- a/packages/shared/tier-sources/sts2companion.ts
+++ b/packages/shared/tier-sources/sts2companion.ts
@@ -67,10 +67,15 @@ export const sts2companionAdapter: TierListSourceAdapter = {
       );
       return {
         adapterId: "sts2companion",
-        scaleType: "letter_6",
-        detectedCharacter,
-        cards,
-        warnings,
+        sections: [
+          {
+            detectedCharacter,
+            scaleType: "letter_6",
+            cards,
+            warnings,
+          },
+        ],
+        warnings: [],
       };
     }
 
@@ -104,10 +109,15 @@ export const sts2companionAdapter: TierListSourceAdapter = {
 
     return {
       adapterId: "sts2companion",
-      scaleType: "letter_6",
-      detectedCharacter,
-      cards,
-      warnings,
+      sections: [
+        {
+          detectedCharacter,
+          scaleType: "letter_6",
+          cards,
+          warnings,
+        },
+      ],
+      warnings: [],
     };
   },
 };

--- a/packages/shared/tier-sources/tiermaker.test.ts
+++ b/packages/shared/tier-sources/tiermaker.test.ts
@@ -36,13 +36,18 @@ describe("resolveAdapter", () => {
 describe("tiermakerAdapter.parse", () => {
   const result = tiermakerAdapter.parse(FIXTURE_HTML, FIXTURE_URL);
 
+  it("returns single section", () => {
+    expect(result.sections).toHaveLength(1);
+    expect(result.sections[0].cards.length).toBeGreaterThan(0);
+  });
+
   it("extracts tier rows in top-to-bottom order", () => {
-    const tierOrder = [...new Set(result.cards.map((c) => c.tier))];
+    const tierOrder = [...new Set(result.sections[0].cards.map((c) => c.tier))];
     expect(tierOrder).toEqual(["S", "A", "B", "C"]);
   });
 
   it("extracts every card's imageUrl and externalId", () => {
-    const sCards = result.cards.filter((c) => c.tier === "S");
+    const sCards = result.sections[0].cards.filter((c) => c.tier === "S");
     expect(sCards).toHaveLength(6);
     expect(sCards[0]).toEqual({
       tier: "S",
@@ -53,15 +58,15 @@ describe("tiermakerAdapter.parse", () => {
   });
 
   it("decodes HTML entities in src attributes", () => {
-    for (const card of result.cards) {
+    for (const card of result.sections[0].cards) {
       expect(card.imageUrl).not.toContain("&quot;");
       expect(card.imageUrl).toMatch(/^https:\/\//);
     }
   });
 
   it("returns letter_6 scale with no 7-letter override for this fixture", () => {
-    expect(result.scaleType).toBe("letter_6");
-    expect(result.scaleConfig).toBeUndefined();
+    expect(result.sections[0].scaleType).toBe("letter_6");
+    expect(result.sections[0].scaleConfig).toBeUndefined();
   });
 
   it("applies 7-letter override when E and F are both present", () => {
@@ -71,18 +76,18 @@ describe("tiermakerAdapter.parse", () => {
        <div class="tier-row"><div class="label-holder"><span class="label">F</span></div><div class="tier sort"><div class="character" id="3"><img src="/c.png"></div></div></div>`,
       FIXTURE_URL,
     );
-    expect(sevenLetter.scaleConfig?.map.S).toBe(6);
-    expect(sevenLetter.scaleConfig?.map.E).toBeGreaterThan(1);
-    expect(sevenLetter.scaleConfig?.map.F).toBe(1);
+    expect(sevenLetter.sections[0].scaleConfig?.map.S).toBe(6);
+    expect(sevenLetter.sections[0].scaleConfig?.map.E).toBeGreaterThan(1);
+    expect(sevenLetter.sections[0].scaleConfig?.map.F).toBe(1);
   });
 
   it("warns when no tier rows are found", () => {
     const empty = tiermakerAdapter.parse("<p>not a tier list</p>", FIXTURE_URL);
-    expect(empty.cards).toHaveLength(0);
-    expect(empty.warnings.length).toBeGreaterThan(0);
+    expect(empty.sections[0].cards).toHaveLength(0);
+    expect(empty.sections[0].warnings.length).toBeGreaterThan(0);
   });
 
   it("always returns null detectedCharacter (admin sets via form)", () => {
-    expect(result.detectedCharacter).toBeNull();
+    expect(result.sections[0].detectedCharacter).toBeNull();
   });
 });

--- a/packages/shared/tier-sources/tiermaker.ts
+++ b/packages/shared/tier-sources/tiermaker.ts
@@ -66,11 +66,16 @@ export const tiermakerAdapter: TierListSourceAdapter = {
 
     return {
       adapterId: "tiermaker",
-      scaleType: "letter_6",
-      scaleConfig,
-      detectedCharacter: null,
-      cards,
-      warnings,
+      sections: [
+        {
+          detectedCharacter: null,
+          scaleType: "letter_6",
+          ...(scaleConfig ? { scaleConfig } : {}),
+          cards,
+          warnings,
+        },
+      ],
+      warnings: [],
     };
   },
 };

--- a/packages/shared/tier-sources/types.ts
+++ b/packages/shared/tier-sources/types.ts
@@ -13,12 +13,19 @@ export interface ScrapedCard {
   name?: string;
 }
 
-export interface ScrapedTierList {
-  adapterId: string;
+export interface ScrapedSection {
+  /** "ironclad" | "silent" | "regent" | "necrobinder" | "defect" | null */
+  detectedCharacter: string | null;
   scaleType: ScaleType;
   scaleConfig?: { map: Record<string, number> };
-  detectedCharacter?: string | null;
   cards: ScrapedCard[];
+  warnings: string[];
+}
+
+export interface ScrapedTierList {
+  adapterId: string;
+  sections: ScrapedSection[];
+  /** Adapter-level warnings (vs section-level). */
   warnings: string[];
 }
 


### PR DESCRIPTION
## Summary
- Adds Refresh action on each admin tier-lists row that opens the existing ingestion wizard pre-filled with source metadata and locks the source-meta inputs.
- Mobalytics adapter splits multi-character pages into per-character sections via h2 detection + section-ancestor walk. Other adapters keep returning a single-section array.
- Scrape route returns `sections[]`; confirm route accepts `sections[]` with backwards-compat for the legacy single-shape payload.
- Admin preview UI renders a tab bar with per-section include checkboxes when >1 section is returned.
- Staleness thresholds tightened from 180/365 to 28/84 days. Admin table shows a fresh/aging/excluded chip per row and sorts by staleness rank by default.

Closes #145

## Test plan
- [x] `pnpm test` green (all packages)
- [x] `pnpm lint` clean
- [x] `pnpm typecheck` clean
- [ ] Manual: Edit modal still works (metadata-only edits)
- [ ] Manual: upload flow still works (vision LLM + scrape paths)
- [ ] Manual: Refresh on a website-source row pre-fills source-meta with the row's values, locks them visually, and accepts a re-paste
- [ ] Manual: Mobalytics all-characters paste produces 5 preview tabs; confirming inserts 5 active rows; prior 5 active rows for that source go inactive
- [ ] Manual: Mobalytics single-section paste (one character's HTML only) produces 1 preview, 1 insert
- [ ] Manual: staleness chips render correctly across the row population; default sort is excluded → aging → fresh

## Specs
- [docs/superpowers/specs/2026-05-28-tier-list-refresh-and-staleness-design.md](docs/superpowers/specs/2026-05-28-tier-list-refresh-and-staleness-design.md)
- Plan: [docs/superpowers/plans/2026-05-28-tier-list-refresh-and-staleness.md](docs/superpowers/plans/2026-05-28-tier-list-refresh-and-staleness.md)

## Follow-ups not in this PR
- Per-section `tierMapping` for mixed-scale lists (TODO comments inline; current implementation uses the first section's scale)
- Auto-refresh system per [docs/superpowers/specs/2026-05-28-tier-list-auto-refresh-design.md](docs/superpowers/specs/2026-05-28-tier-list-auto-refresh-design.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)