### PR TITLE
fix(map-coach): sync act when eval starts to stop start-of-act re-eval storm

### DIFF
--- a/apps/desktop/src/__tests__/integration/map-eval-flow.test.tsx
+++ b/apps/desktop/src/__tests__/integration/map-eval-flow.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import React from "react";
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { configureStore, combineSlices, createListenerMiddleware } from "@reduxjs/toolkit";
 import { Provider } from "react-redux";
 import { render, screen, waitFor } from "@testing-library/react";
@@ -33,7 +33,11 @@ import type { MapState, MultiplayerFields } from "@sts2/shared/types/game-state"
 // We capture calls and return a canned `mapCoachOutputSchema`-shaped payload
 // for `/api/evaluate`; everything else returns a benign empty 200 so
 // non-target endpoints (logChoice, etc.) don't blow up on `res.json()`.
-const { apiFetchMock } = vi.hoisted(() => {
+const { apiFetchMock, evalGate } = vi.hoisted(() => {
+  // When `evalGate.promise` is set, /api/evaluate awaits it before resolving.
+  // Lets a test hold an eval "in flight" to exercise mid-flight poll behavior
+  // (#149). Default null = resolve immediately (existing tests unaffected).
+  const evalGate: { promise: Promise<void> | null } = { promise: null };
   const mapEvaluatePayload = {
     reasoning: {
       risk_capacity: "Moderate HP buffer; can take one elite this floor.",
@@ -55,6 +59,7 @@ const { apiFetchMock } = vi.hoisted(() => {
 
   const apiFetchMock = vi.fn(async (path: string) => {
     if (path === "/api/evaluate") {
+      if (evalGate.promise) await evalGate.promise;
       return {
         ok: true,
         status: 200,
@@ -67,7 +72,7 @@ const { apiFetchMock } = vi.hoisted(() => {
       json: async () => ({}),
     } as unknown as Response;
   });
-  return { apiFetchMock };
+  return { apiFetchMock, evalGate };
 });
 
 vi.mock("@sts2/shared/lib/api-client", () => ({
@@ -132,6 +137,7 @@ import {
 } from "../../features/evaluation/evaluationSlice";
 import { evaluationApi } from "../../services/evaluationApi";
 import { gameStateApi } from "../../services/gameStateApi";
+import { selectMapEvalContext, selectRecommendedPath } from "../../features/run/runSelectors";
 import { connectionSlice } from "../../features/connection/connectionSlice";
 import { clearEvaluationRegistry } from "@sts2/shared/evaluation/last-evaluation-registry";
 import { MapView } from "../../views/map/map-view";
@@ -435,6 +441,98 @@ describe("map-eval flow — listener → /api/evaluate → adapter → slice →
           apiFetchMock.mock.calls.filter(([p]) => p === "/api/evaluate"),
         ).toHaveLength(2);
       });
+    });
+  });
+
+  describe("act sync on eval start — no start-of-act re-eval storm (#149)", () => {
+    const settle = () => new Promise<void>((r) => setTimeout(r, 50));
+
+    afterEach(() => {
+      evalGate.promise = null;
+    });
+
+    it("records the current act when the eval STARTS, not only on success", async () => {
+      // Hold the coach call in flight so the post-eval (which also syncs the
+      // act) cannot run. Only the pre-eval has executed.
+      let release!: () => void;
+      evalGate.promise = new Promise<void>((r) => (release = r));
+
+      const store = createIntegrationStore();
+      setupMapEvalListener();
+      seedRun(store);
+
+      // run.act === 1 (buildHappyPathMapState). This is the initial eval.
+      store.dispatch(gameStateReceived(buildHappyPathMapState()));
+      await settle();
+
+      // Eval is in flight (one call, gate not released).
+      expect(
+        apiFetchMock.mock.calls.filter(([p]) => p === "/api/evaluate"),
+      ).toHaveLength(1);
+
+      // The bug (#149): the pre-eval wrote a STALE act (prevContext.act ?? 0),
+      // so a mid-flight poll saw isStartOfAct=true forever and re-evaluated on
+      // every poll/move, starving the coach call. The fix records the current
+      // act on start, so isStartOfAct clears once an eval is underway.
+      expect(selectMapEvalContext(store.getState())?.act).toBe(1);
+
+      release();
+      await settle();
+    });
+
+    it("does not re-eval on an on-path move while the coach call is still in flight", async () => {
+      let release!: () => void;
+      evalGate.promise = new Promise<void>((r) => (release = r));
+
+      const store = createIntegrationStore();
+      setupMapEvalListener();
+      seedRun(store);
+
+      store.dispatch(gameStateReceived(buildHappyPathMapState()));
+      await settle();
+      expect(
+        apiFetchMock.mock.calls.filter(([p]) => p === "/api/evaluate"),
+      ).toHaveLength(1);
+
+      // Follow the recommendation: move to the first node the (eager) path
+      // points at, giving it a single forced next option so the only thing
+      // that could trigger a re-eval is the start-of-act bug.
+      const path = selectRecommendedPath(store.getState());
+      const step = path[1] ?? { col: 0, row: 1 };
+      const onPathMove: MapState & MultiplayerFields = {
+        state_type: "map",
+        player: { character: "Ironclad", hp: 70, max_hp: 80, gold: 99 },
+        map: {
+          current_position: { col: step.col, row: step.row, type: "Monster" },
+          visited: [
+            { col: 1, row: 0, type: "Monster" },
+            { col: step.col, row: step.row, type: "Monster" },
+          ],
+          next_options: [
+            {
+              index: 0,
+              col: step.col,
+              row: step.row + 1,
+              type: "Monster",
+              leads_to: [{ col: 1, row: 3, type: "Boss" }],
+            },
+          ],
+          nodes: TEST_NODES,
+          boss: TEST_BOSS,
+        },
+        run: { act: 1, floor: step.row + 1, ascension: 0 },
+      };
+      store.dispatch(gameStateReceived(onPathMove));
+      await settle();
+
+      // With the fix the in-flight eval is NOT cancelled/restarted: still one
+      // call. Before the fix the move re-evaluated (startAct=true), making two.
+      expect(
+        apiFetchMock.mock.calls.filter(([p]) => p === "/api/evaluate"),
+      ).toHaveLength(1);
+
+      release();
+      await settle();
     });
   });
 });

--- a/apps/desktop/src/features/map/mapListeners.ts
+++ b/apps/desktop/src/features/map/mapListeners.ts
@@ -415,10 +415,22 @@ export function setupMapEvalListener() {
             }
           : null,
       });
-      // Preserve the PREVIOUS act in the pre-eval context so that if the
-      // API call fails, shouldEvaluateMap still detects the act change and
-      // retries. The post-API dispatch sets the correct act on success.
-      preEval.lastEvalContext.act = prevContext?.act ?? 0;
+      // Sync `act` to the CURRENT act as soon as the eval STARTS (not just on
+      // success). buildPreEvalPayload already set it to the current act; we no
+      // longer overwrite it with the previous act.
+      //
+      // Why: `isStartOfAct` is derived from `prevContext.act !== run.act`. The
+      // old code kept the previous act here so a failed API call would re-arm
+      // the start-of-act trigger and retry. But the post-eval (which synced the
+      // act on success) is frequently starved: at ~3s poll cadence the next
+      // poll sees the stale act, re-fires `shouldEvaluateMap` via the
+      // start-of-act branch, and cancelActiveListeners() kills the in-flight
+      // LLM call before it can complete. The act then never syncs and EVERY
+      // poll/move at the start of an act re-evaluates — bypassing the on-path
+      // guards in shouldEvaluateMap (#149). Syncing on start lets standing-still
+      // / on-path polls suppress, so the in-flight eval runs to completion.
+      // On failure the eager (local-scorer) recommendation persists; natural
+      // triggers (off-path, meaningful fork) re-evaluate later.
 
       // Pre-eval: dispatch the deterministic winner's path immediately so
       // the UI can highlight the recommended route while the LLM narrator


### PR DESCRIPTION
Closes #149

## The bug

The map coach re-evaluated on **every poll and every move** for the entire start of an act, repeatedly swapping the recommendation for a different path — even when standing still or following the recommendation. This is what #143/#144 tried to fix; those guards live *below* the `isStartOfAct` branch in `shouldEvaluateMap` and were never reached.

## Root cause (confirmed from a dev-session capture)

`map_should_eval` showed `startAct=true` on **every** poll across an entire act (rows 4→16), never clearing, and a `map_coach_path` (completed coach eval) **never** appeared.

The pre-eval dispatch wrote a **stale** act: `preEval.lastEvalContext.act = prevContext?.act ?? 0`. Since `isStartOfAct = prevContext.act !== run.act`, it stayed true until a *completed* coach eval synced the act — but that post-eval is starved: each ~3s poll sees the stale act, re-fires via the start-of-act branch, and `cancelActiveListeners()` kills the in-flight LLM call. The act never syncs → perpetual re-eval, and the UI only ever shows the eager local-scorer path.

## Fix

Record the current act as soon as the eval **starts** (drop the stale override — `buildPreEvalPayload` already sets the current act). Once an eval is underway `isStartOfAct` clears, so standing-still / on-path polls suppress via the existing #144 guards and the in-flight eval completes. On failure the eager recommendation persists; off-path / meaningful-fork triggers re-evaluate later.

One-line behavioral change; the rest is comments + tests.

## Tests

`map-eval-flow.test.tsx` gains a deferred-API harness that holds the coach call in flight to reproduce the starvation:
- asserts the act is synced **on start** (not just on success)
- asserts an on-path move mid-flight does **not** re-evaluate

Both fail with the stale override restored (verified), pass with the fix. Full desktop suite green (818), lint clean.

## Test plan
- [x] `pnpm --filter @sts2/desktop test` — 818 pass
- [x] `pnpm --filter @sts2/desktop lint` — 0 errors
- [x] Regression tests fail without the fix, pass with it
- [ ] Live: dev build → land on map → `map_should_eval` shows `startAct` clearing after the first eval, `map_coach_path` appears, no re-eval storm when following the path